### PR TITLE
feat(CLI): Add node version check and allow user to change API environment

### DIFF
--- a/apps/cli/.gitignore
+++ b/apps/cli/.gitignore
@@ -81,7 +81,7 @@ web_modules/
 .env.development.local
 .env.test.local
 .env.production.local
-.env.local
+.env
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -1,18 +1,30 @@
-import 'dotenv/config'
+import './utils/node19OrFail'
+import './utils/setupVerbose'
 import {Command} from 'commander'
 import {addContactCommands} from './contact/cli'
 import {pipe} from 'fp-ts/function'
-import {setLogLevel} from './utils/logging'
 import {addAuthsCommands} from './auth/cli'
 import {addOfferCommands} from './offer/cli'
 import {addChatCommands} from './chat/cli'
 
 const program = new Command()
 
+program.description(
+  `Welcome to Vexl CLI tool. 
+See subcommands for more info.
+This tool connects to staging environment by default. 
+To change environments, use the API_ENV_PRESET_KEY=(prodEnv|stageEnv) environment variable. Or setup your own by setting API_ENV to a json: with following structure: 
+{
+"userMs": "ServiceUrl",
+"contactMs": "ServiceUrl",
+"chatMs": "ServiceUrl",
+"offerMs": "ServiceUrl"
+}
+Example usage: "API_ENV_PRESET_KEY=prodEnv node cli.js auth login +420123456789"
+`
+)
+
 program.option('-v, --verbose', 'Enable verbose logging')
-program.on('option:verbose', () => {
-  setLogLevel(true)
-})
 
 pipe(
   program,

--- a/apps/cli/src/utils/logging.ts
+++ b/apps/cli/src/utils/logging.ts
@@ -13,7 +13,6 @@ function checkIfFd3IsOpen() {
 export const fd3isOpen = checkIfFd3IsOpen()
 
 export function setLogLevel(verbose: boolean): void {
-  console.log('Setting verbose', {verbose})
   logVerbose = verbose
 }
 

--- a/apps/cli/src/utils/node19OrFail.ts
+++ b/apps/cli/src/utils/node19OrFail.ts
@@ -1,0 +1,11 @@
+const REQUIRED_VERSION = 19
+
+const currentNodeVersion = Number(process.version.match(/^v(\d+)/)?.[1])
+
+if (currentNodeVersion < REQUIRED_VERSION) {
+  console.error(`You are running Node ${process.version}.`)
+  console.error(
+    `Vexl cli requires Node ${REQUIRED_VERSION} or higher. \nPlease update your version of Node. \nYou can use nvm to manage multiple versions of NodeJS on your environment.`
+  )
+  process.exit(1)
+}

--- a/apps/cli/src/utils/setupVerbose.ts
+++ b/apps/cli/src/utils/setupVerbose.ts
@@ -1,0 +1,6 @@
+import {setLogLevel} from './logging'
+
+const args = process.argv.slice(2)
+if (args.includes('-v')) {
+  setLogLevel(true)
+}

--- a/packages/rest-api/src/index.ts
+++ b/packages/rest-api/src/index.ts
@@ -1,3 +1,4 @@
+import {z} from 'zod'
 import {ServiceUrl} from './ServiceUrl.brand'
 import * as user from './services/user'
 import * as contact from './services/contact'
@@ -7,6 +8,14 @@ import * as chat from './services/chat'
 import {PlatformName} from './PlatformName'
 import * as UserSessionCredentials from './UserSessionCredentials.brand'
 
+export const EnvPreset = z.object({
+  userMs: ServiceUrl,
+  contactMs: ServiceUrl,
+  chatMs: ServiceUrl,
+  offerMs: ServiceUrl,
+})
+export type EnvPreset = z.TypeOf<typeof EnvPreset>
+
 export interface CredentialHeaders {
   publicKey: string
   hash: string
@@ -15,7 +24,7 @@ export interface CredentialHeaders {
 
 export {user, contact, offer, chat}
 
-export const ENV_PRESETS = {
+export const ENV_PRESETS: {stageEnv: EnvPreset; prodEnv: EnvPreset} = {
   stageEnv: {
     userMs: ServiceUrl.parse('https://stage-user.vexl.it'),
     contactMs: ServiceUrl.parse('https://stage-contact.vexl.it'),
@@ -24,9 +33,9 @@ export const ENV_PRESETS = {
   },
   prodEnv: {
     userMs: ServiceUrl.parse('https://user.vexl.it'),
-    contactMs: ServiceUrl.parse('https://offer.vexl.it'),
+    contactMs: ServiceUrl.parse('https://contact.vexl.it'),
     chatMs: ServiceUrl.parse('https://chat.vexl.it'),
-    offerMs: ServiceUrl.parse('https://contact.vexl.it'),
+    offerMs: ServiceUrl.parse('https://offer2.vexl.it'),
   },
 }
 


### PR DESCRIPTION
- Cli now checks if node version and informs user if run with node version lower than desired.
- User can now specify API keys, to run the CLI against different environment.
- Fix prod env preset
- Setup verbose logging sooner, so the CLI can log before loading commander