### PR TITLE
Add lint action

### DIFF
--- a/.github/workflows/test-lint.yaml
+++ b/.github/workflows/test-lint.yaml
@@ -1,0 +1,32 @@
+name: "[Test] lint code"
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Lint code
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 19
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build
+        run: yarn turbo:build
+
+      - name: Test
+        run: yarn turbo:lint

--- a/apps/mobile/src/components/Image.tsx
+++ b/apps/mobile/src/components/Image.tsx
@@ -24,7 +24,7 @@ export default function Image({source, ...props}: Props): JSX.Element {
     return <SvgXml {...xmlProps} xml={source.xml} />
   }
   const imageProps = props as RNImageProps
-  return <RNImage source={source} {...imageProps} />
+  return <RNImage {...imageProps} source={source} />
 }
 
 export type ImageProps = Props


### PR DESCRIPTION
Add lint job to check code for lint errors. 

Especially useful before merging PR.