### PR TITLE
Feature: Filter flaggs (#47) and don't show offers when < 1 common co…

### DIFF
--- a/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/OffersListButtons.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/OffersListButtons.tsx
@@ -35,7 +35,7 @@ function OffersListButtons({
           onPress={onMyOffersPress}
           variant={'primary'}
           size={'small'}
-          text={t('offer.myOffers')}
+          text={t('common.myOffers')}
         />
         <Stack w="$2" />
         <Button

--- a/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/OffersListStateDisplayerContent.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/OffersListStateDisplayerContent.tsx
@@ -9,13 +9,14 @@ import EmptyListPlaceholder from './EmptyListPlaceholder'
 import OffersList from '../../../../OffersList'
 import {
   useAreOffersLoading,
-  useFilteredOffers,
   useOffersLoadingError,
   useTriggerOffersRefresh,
 } from '../../../../../state/marketplace'
 import {useMolecule} from 'jotai-molecules'
 import {filterOffersMolecule} from '../../../../FilterOffersScreen/atom'
 import {useAtomValue} from 'jotai'
+import {offersAtomWithFilter} from '../../../../../state/marketplace/atom'
+import {splitAtom} from 'jotai/utils'
 
 interface Props {
   type: 'BUY' | 'SELL'
@@ -43,7 +44,12 @@ function OffersListStateDisplayerContent({
     [type]
   )
 
-  const offers = useFilteredOffers(filter ?? basicFilter)
+  const offersAtoms = useAtomValue(
+    useMemo(
+      () => splitAtom(offersAtomWithFilter(filter ?? basicFilter)),
+      [filter, basicFilter]
+    )
+  )
 
   const renderListHeader = useMemo(() => {
     if (isNone(error)) return null
@@ -51,7 +57,7 @@ function OffersListStateDisplayerContent({
     return <ErrorListHeader mt={'$6'} error={error.value} />
   }, [error])
 
-  if (offers.length === 0 && loading) {
+  if (offersAtoms.length === 0 && loading) {
     return (
       <Stack f={1} ai="center" pt="$5">
         <ActivityIndicator color={tokens.color.main.val} size="large" />
@@ -66,12 +72,12 @@ function OffersListStateDisplayerContent({
         onFilterOffersPress={navigateToFilterOffers}
         onMyOffersPress={navigateToMyOffers}
       />
-      {offers.length === 0 ? (
+      {offersAtoms.length === 0 ? (
         <EmptyListPlaceholder />
       ) : (
         <OffersList
           ListHeaderComponent={renderListHeader}
-          offers={offers}
+          offersAtoms={offersAtoms}
           // eslint-disable-next-line @typescript-eslint/no-misused-promises
           onRefresh={refreshOffers}
           refreshing={loading}

--- a/apps/mobile/src/components/InsideRouter/components/SettingsScreen/components/ButtonsSection.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/SettingsScreen/components/ButtonsSection.tsx
@@ -107,7 +107,7 @@ function ButtonsSection(): JSX.Element {
         enableHiddenFeatures
           ? [
               {
-                text: t('settings.items.myOffers'),
+                text: t('common.myOffers'),
                 icon: profileIconSvg,
                 onPress: todo,
               },

--- a/apps/mobile/src/components/MyOffersScreen/components/MyOffersSortingDropdown.tsx
+++ b/apps/mobile/src/components/MyOffersScreen/components/MyOffersSortingDropdown.tsx
@@ -1,0 +1,39 @@
+import Dropdown, {type RowProps} from '../../Dropdown'
+import React from 'react'
+import {atom, useAtom, useAtomValue} from 'jotai'
+import {selectedMyOffersSortingOptionAtom} from '../../../state/marketplace/atom'
+import {type Sort} from '@vexl-next/domain/dist/general/offers'
+import {translationAtom} from '../../../utils/localization/I18nProvider'
+
+const myOffersSortingOptionsAtom = atom<Array<RowProps<Sort>>>((get) => {
+  const {t} = get(translationAtom)
+
+  return [
+    {
+      title: t('myOffers.sortedByNewest'),
+      type: 'NEWEST_OFFER',
+    },
+    {
+      title: t('myOffers.sortedByOldest'),
+      type: 'OLDEST_OFFER',
+    },
+  ]
+})
+
+function MyOffersSortingDropdown(): JSX.Element {
+  const [myOffersSortingOption, setMyOffersSortingOption] = useAtom(
+    selectedMyOffersSortingOptionAtom
+  )
+  const myOffersSortingOptions = useAtomValue(myOffersSortingOptionsAtom)
+
+  return (
+    <Dropdown
+      size={'small'}
+      activeRowType={myOffersSortingOption}
+      setActiveRowType={setMyOffersSortingOption}
+      rows={myOffersSortingOptions}
+    />
+  )
+}
+
+export default MyOffersSortingDropdown

--- a/apps/mobile/src/components/MyOffersScreen/index.tsx
+++ b/apps/mobile/src/components/MyOffersScreen/index.tsx
@@ -1,67 +1,35 @@
 import Screen from '../Screen'
 import ScreenTitle from '../ScreenTitle'
 import {type RootStackScreenProps} from '../../navigationTypes'
-import {
-  translationAtom,
-  useTranslation,
-} from '../../utils/localization/I18nProvider'
+import {useTranslation} from '../../utils/localization/I18nProvider'
 import Button from '../Button'
 import plusSvg from './images/plusSvg'
 import {Text, XStack} from 'tamagui'
-import {useAtomValue, atom, useAtom} from 'jotai'
+import {useAtomValue} from 'jotai'
 import OffersList from '../OffersList'
 import IconButton from '../IconButton'
 import closeSvg from '../images/closeSvg'
 import {
   myActiveOffersAtom,
-  myOffersAtom,
-  myOffersSortingOptionAtom,
-  sortOffers,
+  myOffersSortedAtomsAtom,
 } from '../../state/marketplace/atom'
 import {selectAtom} from 'jotai/utils'
-import Dropdown, {type RowProps} from '../Dropdown'
-import {type Sort} from '@vexl-next/domain/dist/general/offers'
-import React, {useMemo} from 'react'
+import React from 'react'
+import MyOffersSortingDropdown from './components/MyOffersSortingDropdown'
 
 type Props = RootStackScreenProps<'MyOffers'>
 
 const myActiveOffers = selectAtom(myActiveOffersAtom, (offers) => offers.length)
 
-const myOffersSortingOptionsAtom = atom<Array<RowProps<Sort>>>((get) => {
-  const {t} = get(translationAtom)
-
-  return [
-    {
-      title: t('myOffers.sortedByNewest'),
-      type: 'NEWEST_OFFER',
-    },
-    {
-      title: t('myOffers.sortedByOldest'),
-      type: 'OLDEST_OFFER',
-    },
-  ]
-})
-
 function MyOffersScreen({navigation}: Props): JSX.Element {
   const {t} = useTranslation()
 
-  const [myOffersSortingOption, setMyOffersSortingOption] = useAtom(
-    myOffersSortingOptionAtom
-  )
-  const mySortedOffers = [
-    ...useAtomValue(
-      useMemo(
-        () => sortOffers(myOffersAtom, myOffersSortingOption),
-        [myOffersSortingOption]
-      )
-    ),
-  ]
-  const myOffersSortingOptions = useAtomValue(myOffersSortingOptionsAtom)
+  const myOffersSortedAtoms = useAtomValue(myOffersSortedAtomsAtom)
   const activeOffersCount = useAtomValue(myActiveOffers)
 
   return (
     <Screen>
-      <ScreenTitle text={t('myOffers.myOffers')} withBottomBorder>
+      <ScreenTitle text={t('common.myOffers')} withBottomBorder>
         <IconButton
           variant="dark"
           icon={closeSvg}
@@ -80,12 +48,7 @@ function MyOffersScreen({navigation}: Props): JSX.Element {
         <Text ff={'$body600'} fos={18} col={'$white'}>
           {t('myOffers.activeOffers', {count: activeOffersCount})}
         </Text>
-        <Dropdown
-          size={'small'}
-          activeRowType={myOffersSortingOption}
-          setActiveRowType={setMyOffersSortingOption}
-          rows={myOffersSortingOptions}
-        />
+        <MyOffersSortingDropdown />
       </XStack>
       <Button
         beforeIcon={plusSvg}
@@ -96,7 +59,7 @@ function MyOffersScreen({navigation}: Props): JSX.Element {
         text={t('myOffers.addNewOffer')}
         variant={'secondary'}
       />
-      <OffersList offers={mySortedOffers} />
+      <OffersList offersAtoms={myOffersSortedAtoms} />
     </Screen>
   )
 }

--- a/apps/mobile/src/components/OfferDetailScreen/api.ts
+++ b/apps/mobile/src/components/OfferDetailScreen/api.ts
@@ -15,6 +15,7 @@ import {toCommonErrorMessage} from '../../utils/useCommonErrorMessages'
 import useSafeGoBack from '../../utils/useSafeGoBack'
 import {useRequestOffer} from '../../state/marketplace'
 import {useShowLoadingOverlay} from '../LoadingOverlayProvider'
+import {createSingleOfferReportedFlagAtom} from '../../state/marketplace/atom'
 
 export function useSubmitRequestHandleUI(): (
   text: string,
@@ -57,8 +58,9 @@ export function useReportOfferHandleUI(): (
   const loadingOverlay = useShowLoadingOverlay()
 
   return useCallback(
-    /// todo set reported flag
     (offerId: OfferId) => {
+      const reportedFlagAtom = createSingleOfferReportedFlagAtom(offerId)
+
       return pipe(
         store.set(askAreYouSureActionAtom, {
           variant: 'danger',
@@ -89,6 +91,7 @@ export function useReportOfferHandleUI(): (
             return false
           },
           () => {
+            store.set(reportedFlagAtom, true)
             safeGoBack()
             loadingOverlay.hide()
             return true

--- a/apps/mobile/src/components/OfferDetailScreen/index.tsx
+++ b/apps/mobile/src/components/OfferDetailScreen/index.tsx
@@ -14,7 +14,6 @@ function OfferDetailScreen({
   route: {
     params: {offerId},
   },
-  navigation,
 }: Props): JSX.Element {
   const safeGoBack = useSafeGoBack()
   const {t} = useTranslation()

--- a/apps/mobile/src/components/OffersList/OffersListItem.tsx
+++ b/apps/mobile/src/components/OffersList/OffersListItem.tsx
@@ -5,14 +5,16 @@ import {type OneOfferInState} from '../../state/marketplace/domain'
 import {Stack} from 'tamagui'
 import OfferWithBubbleTip from '../OfferWithBubbleTip'
 import {useMemo} from 'react'
+import {type Atom, useAtomValue} from 'jotai'
 
 interface Props {
-  readonly offer: OneOfferInState
+  readonly offerAtom: Atom<OneOfferInState>
 }
 
-function OffersListItem({offer}: Props): JSX.Element {
+function OffersListItem({offerAtom}: Props): JSX.Element {
   const {t} = useTranslation()
   const navigation = useNavigation()
+  const offer = useAtomValue(offerAtom)
 
   const isMine = useMemo(
     () => !!offer.ownershipInfo?.adminId,

--- a/apps/mobile/src/components/OffersList/index.tsx
+++ b/apps/mobile/src/components/OffersList/index.tsx
@@ -5,26 +5,24 @@ import {getTokens} from 'tamagui'
 import React, {type ComponentProps, useMemo} from 'react'
 import usePixelsFromBottomWhereTabsEnd from '../InsideRouter/utils'
 import {FlashList} from '@shopify/flash-list'
+import {type Atom} from 'jotai'
+import atomKeyExtractor from '../../utils/atomUtils/atomKeyExtractor'
 
 export interface Props {
-  readonly offers: OneOfferInState[]
+  readonly offersAtoms: Array<Atom<OneOfferInState>>
   onRefresh?: () => void
   refreshing?: boolean
   ListHeaderComponent?: ComponentProps<typeof FlatList>['ListHeaderComponent']
 }
 
-function keyExtractor(offer: OneOfferInState): string {
-  return offer.offerInfo.offerId
-}
-
-function renderItem({item}: {item: OneOfferInState}): JSX.Element {
-  return <OffersListItem offer={item} />
+function renderItem({item}: {item: Atom<OneOfferInState>}): JSX.Element {
+  return <OffersListItem offerAtom={item} />
 }
 
 function OffersList({
   onRefresh,
   refreshing,
-  offers,
+  offersAtoms,
   ListHeaderComponent,
 }: Props): JSX.Element {
   const bottomOffset = usePixelsFromBottomWhereTabsEnd()
@@ -40,11 +38,11 @@ function OffersList({
         }),
         [bottomOffset]
       )}
-      data={offers}
+      data={offersAtoms}
       onRefresh={onRefresh}
       refreshing={refreshing}
       renderItem={renderItem}
-      keyExtractor={keyExtractor}
+      keyExtractor={atomKeyExtractor}
     />
   )
 }

--- a/apps/mobile/src/localization/en.ts
+++ b/apps/mobile/src/localization/en.ts
@@ -40,6 +40,7 @@ export default {
     'more': 'More',
     'yes': 'Yes',
     'no': 'No',
+    'myOffers': 'My offers',
   },
   'loginFlow': {
     'anonymityNotice': 'Nobody will see this until you allow it. Even us.',
@@ -156,7 +157,6 @@ export default {
   'settings': {
     'yourReach': 'Your reach: {{number}} vexlers',
     'items': {
-      'myOffers': 'My offers',
       'changeProfilePicture': 'Change profile picture',
       'editName': 'Edit name',
       'contactsImported': 'Contacts imported',
@@ -210,7 +210,6 @@ export default {
     'buy': 'Buy',
     'sell': 'Sell',
     'filterOffers': 'Filter offers',
-    'myOffers': 'My offers',
     'numberOfCommon': '{{number}} common',
     'offerNotFound':
       'Offer not found. It might have been deleted by the author',
@@ -395,7 +394,6 @@ export default {
     },
   },
   'myOffers': {
-    'myOffers': 'My offers',
     'addNewOffer': 'Add new offer',
     'activeOffers': '{{count}} active offers',
     'filterOffers': 'Filter offers',

--- a/apps/mobile/src/state/contacts/index.ts
+++ b/apps/mobile/src/state/contacts/index.ts
@@ -15,6 +15,11 @@ export const importedContactsAtom = focusAtom(
   (o) => o.prop('importedContacts')
 )
 
+export const importedContactsHashesAtom = selectAtom(
+  importedContactsAtom,
+  (o) => o.map((one) => one.hash)
+)
+
 export function createHashesToImportedContactsAtom(
   hashes: readonly string[]
 ): Atom<ContactNormalizedWithHash[]> {

--- a/apps/mobile/src/state/marketplace/index.ts
+++ b/apps/mobile/src/state/marketplace/index.ts
@@ -13,19 +13,14 @@ import {
   offerFlagsAtom,
   offerForChatOriginAtom,
   offersAtom,
-  offersAtomWithFilter,
   offersIdsAtom,
   offersStateAtom,
-  offersToSee,
+  offersToSeeInMarketplace,
   singleOfferAtom,
   singleOfferByAdminIdAtom,
 } from './atom'
 import * as Option from 'fp-ts/Option'
-import {
-  type ApiErrorDeletingOffer,
-  type OffersFilter,
-  type OneOfferInState,
-} from './domain'
+import {type ApiErrorDeletingOffer, type OneOfferInState} from './domain'
 import {privateApiAtom, usePrivateApiAssumeLoggedIn} from '../../api'
 import {pipe} from 'fp-ts/function'
 import {dummySession, sessionAtom, useSessionAssumeLoggedIn} from '../session'
@@ -202,7 +197,7 @@ export function useOffersLoadingError(): Option.Option<ApiErrorFetchingOffers> {
 }
 
 export function useOffers(): OneOfferInState[] {
-  return useAtomValue(offersToSee)
+  return useAtomValue(offersToSeeInMarketplace)
 }
 
 export function useMyOffers(): OneOfferInState[] {
@@ -216,10 +211,6 @@ export function useSingleOffer(
     useMemo(() => singleOfferAtom(offerId), [offerId])
   )
   return Option.fromNullable(foundOffer)
-}
-
-export function useFilteredOffers(filter: OffersFilter): OneOfferInState[] {
-  return useAtomValue(useMemo(() => offersAtomWithFilter(filter), [filter]))
 }
 
 export const createOfferAtom = atom<

--- a/apps/mobile/src/state/marketplace/utils.ts
+++ b/apps/mobile/src/state/marketplace/utils.ts
@@ -1,3 +1,0 @@
-export function areIncluded<T>(elementsToLookFor: T[], arrayToLookIn: T[]): boolean {
-  return elementsToLookFor.every((element) => arrayToLookIn.includes(element))
-}

--- a/apps/mobile/src/state/marketplace/utils/areIncluded.ts
+++ b/apps/mobile/src/state/marketplace/utils/areIncluded.ts
@@ -1,0 +1,6 @@
+export default function areIncluded<T>(
+  elementsToLookFor: T[],
+  arrayToLookIn: T[]
+): boolean {
+  return elementsToLookFor.every((element) => arrayToLookIn.includes(element))
+}

--- a/apps/mobile/src/state/marketplace/utils/sortOffers.ts
+++ b/apps/mobile/src/state/marketplace/utils/sortOffers.ts
@@ -1,0 +1,41 @@
+import {type OneOfferInState} from '../domain'
+import {type Sort} from '@vexl-next/domain/dist/general/offers'
+
+export default function sortOffers(
+  offers: OneOfferInState[],
+  sort: Sort
+): OneOfferInState[] {
+  const toReturn = [...offers]
+
+  if (sort === 'LOWEST_FEE_FIRST')
+    return toReturn.sort(function (a: OneOfferInState, b: OneOfferInState) {
+      return a.offerInfo.publicPart.feeAmount - b.offerInfo.publicPart.feeAmount
+    })
+  if (sort === 'HIGHEST_FEE')
+    return toReturn.sort(function (a: OneOfferInState, b: OneOfferInState) {
+      return b.offerInfo.publicPart.feeAmount - a.offerInfo.publicPart.feeAmount
+    })
+  if (sort === 'NEWEST_OFFER')
+    return toReturn.sort(function (a: OneOfferInState, b: OneOfferInState) {
+      return b.offerInfo.id - a.offerInfo.id
+    })
+  if (sort === 'OLDEST_OFFER')
+    return toReturn.sort(function (a: OneOfferInState, b: OneOfferInState) {
+      return a.offerInfo.id - b.offerInfo.id
+    })
+  if (sort === 'LOWEST_AMOUNT')
+    return toReturn.sort(function (a: OneOfferInState, b: OneOfferInState) {
+      return (
+        a.offerInfo.publicPart.amountTopLimit -
+        b.offerInfo.publicPart.amountTopLimit
+      )
+    })
+  if (sort === 'HIGHEST_AMOUNT')
+    return toReturn.sort(function (a: OneOfferInState, b: OneOfferInState) {
+      return (
+        b.offerInfo.publicPart.amountTopLimit -
+        a.offerInfo.publicPart.amountTopLimit
+      )
+    })
+  return toReturn // fallback. Let's return original array in case of invalid sort
+}


### PR DESCRIPTION
Feature: Filter flaggs (#47) and don't show offers when < 1 common connection (#123). 

Smaller refinements :
- Remove `My offers` duplicates from translation file
- Offers list displays list of atoms (instead of offers directly)
- Dropdown for filtering of my offers moved to a separate component to prevent unnecessary rerenders 
- Sorting atom replaced with function
- Simplified sorting login on MyOffersScreen
- Renamed offersToSee atom to offersToSeeInMarketplace to be more descriptive
- Renamed myOffersSortingOptionAtom to selectedMyOffersSortingOptionAtom to be more descriptive