### PR TITLE
feature: #48 - handle chat notifications properly

### DIFF
--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -8,7 +8,6 @@ import {
 } from '@vexl-next/cryptography/dist/implementations/ecdhComputeSecret'
 import {Platform} from 'react-native'
 import {computeSharedSecret} from '@vexl-next/react-native-ecdh-platform-native-utils/src'
-import {showUINotification} from './src/utils/notifications'
 
 // polyfill Array.at() function
 if (![].at) {

--- a/apps/mobile/src/components/RootNavigation/index.tsx
+++ b/apps/mobile/src/components/RootNavigation/index.tsx
@@ -25,12 +25,14 @@ import {useSyncConnections} from '../../state/connections'
 import EditOfferScreen from '../ModifyOffer/components/EditOfferScreen'
 import FilterOffersScreen from '../FilterOffersScreen'
 import CommonFriendsScreen from '../CommonFriendsScreen'
+import useHandleNotificationOpen from '../../state/useHandleNotificationOpen'
 
 const Stack = createNativeStackNavigator<RootStackParamsList>()
 
 function LoggedInHookGroup(): null {
   useRefreshNotificationTokenOnResumeAssumeLoggedIn()
   useHandleReceivedNotifications()
+  useHandleNotificationOpen()
 
   useHandleNotificationsPermissionsRedirect()
   useHandlePostLoginFlowRedirect()

--- a/apps/mobile/src/state/chat/atoms/selectChatByInboxKeyAndSenderKey.ts
+++ b/apps/mobile/src/state/chat/atoms/selectChatByInboxKeyAndSenderKey.ts
@@ -1,0 +1,21 @@
+import {type Atom} from 'jotai'
+import {selectAtom} from 'jotai/utils'
+import {type PublicKeyPemBase64} from '@vexl-next/cryptography/dist/KeyHolder'
+import messagingStateAtom from './messagingStateAtom'
+import {type ChatWithMessages} from '../domain'
+
+function selectChatByInboxKeyAndSenderKey({
+  inboxKey,
+  senderKey,
+}: {
+  inboxKey: PublicKeyPemBase64
+  senderKey: PublicKeyPemBase64
+}): Atom<ChatWithMessages | undefined> {
+  return selectAtom(messagingStateAtom, (messagingState) =>
+    messagingState
+      .find((one) => one.inbox.privateKey.publicKeyPemBase64 === inboxKey)
+      ?.chats.find((one) => one.chat.otherSide.publicKey === senderKey)
+  )
+}
+
+export default selectChatByInboxKeyAndSenderKey

--- a/apps/mobile/src/state/useHandleNotificationOpen.ts
+++ b/apps/mobile/src/state/useHandleNotificationOpen.ts
@@ -1,0 +1,128 @@
+import {useCallback, useEffect} from 'react'
+import notifee, {EventType, type Notification} from '@notifee/react-native'
+import {useAppState} from '../utils/useAppState'
+import {atom, useStore} from 'jotai'
+import {useNavigation} from '@react-navigation/native'
+import {pipe} from 'fp-ts/function'
+import {z} from 'zod'
+import * as E from 'fp-ts/Either'
+import {PublicKeyPemBase64} from '@vexl-next/cryptography/dist/KeyHolder'
+import {safeParse} from '../utils/fpUtils'
+import selectChatByInboxKeyAndSenderKey from './chat/atoms/selectChatByInboxKeyAndSenderKey'
+import reportError from '../utils/reportError'
+import {type NavigationState} from 'react-native-tab-view'
+import {type ChatId} from '@vexl-next/domain/dist/general/messaging'
+
+const lastNotificationIdHandledAtom = atom<string | undefined>(undefined)
+
+const MessageNotificationPayload = z.object({
+  inbox: PublicKeyPemBase64,
+  sender: PublicKeyPemBase64,
+})
+
+// TODO how to type this properly?
+function getActiveRoute(route: NavigationState<any>): any {
+  if (
+    !route.routes ||
+    route.routes.length === 0 ||
+    route.index >= route.routes.length
+  ) {
+    return route
+  }
+
+  const childActiveRoute = route.routes[route.index] as NavigationState<any>
+  return getActiveRoute(childActiveRoute)
+}
+
+function isOnSpecificChat(
+  state: NavigationState<any>,
+  chatId: ChatId
+): boolean {
+  const activeRoute = getActiveRoute(state)
+  return (
+    activeRoute.name === 'ChatDetail' && activeRoute.params?.chatId === chatId
+  )
+}
+
+function isOnMessagesList(state: NavigationState<any>): boolean {
+  const activeRoute = getActiveRoute(state)
+  return activeRoute.name === 'Messages'
+}
+
+function useReactOnNotificationOpen(): (notification: Notification) => void {
+  const store = useStore()
+  const navigation = useNavigation()
+
+  return useCallback(
+    (notification) => {
+      if (store.get(lastNotificationIdHandledAtom) === notification.id) return
+      store.set(lastNotificationIdHandledAtom, notification.id)
+
+      if (notification.data?.inbox && notification.data?.sender) {
+        pipe(
+          notification.data,
+          safeParse(MessageNotificationPayload),
+          E.chainNullableK({_tag: 'chatNotFound'})((payload) =>
+            store.get(
+              selectChatByInboxKeyAndSenderKey({
+                inboxKey: payload.inbox,
+                senderKey: payload.sender,
+              })
+            )
+          ),
+          E.match(
+            (l) => {
+              if (l._tag !== 'chatNotFound')
+                // This is to be expected
+                reportError(
+                  'error',
+                  'Error while opening chat from notification',
+                  l
+                )
+
+              // as fallback navigate to messages list.
+              if (!isOnMessagesList(navigation.getState())) {
+                navigation.navigate('InsideTabs', {screen: 'Messages'})
+              }
+            },
+            (payload) => {
+              if (isOnSpecificChat(navigation.getState(), payload.chat.id))
+                return 'ok'
+              navigation.navigate('ChatDetail', {
+                inboxKey: payload.chat.inbox.privateKey.publicKeyPemBase64,
+                chatId: payload.chat.id,
+              })
+
+              return 'ok'
+            }
+          )
+        )
+      }
+    },
+    [navigation, store]
+  )
+}
+
+export default function useHandleNotificationOpen(): void {
+  const reactOnNotificationOpen = useReactOnNotificationOpen()
+
+  useAppState(
+    useCallback(
+      (appState) => {
+        if (appState !== 'active') return
+        void (async () => {
+          const initialNotification = await notifee.getInitialNotification()
+          if (initialNotification)
+            reactOnNotificationOpen(initialNotification.notification)
+        })()
+      },
+      [reactOnNotificationOpen]
+    )
+  )
+  useEffect(() => {
+    return notifee.onForegroundEvent(({type, detail}) => {
+      if (type === EventType.PRESS && detail.notification)
+        reactOnNotificationOpen(detail.notification)
+    })
+  }, [reactOnNotificationOpen])
+}

--- a/apps/mobile/src/state/useHandleNotificationOpen.ts
+++ b/apps/mobile/src/state/useHandleNotificationOpen.ts
@@ -10,8 +10,7 @@ import {PublicKeyPemBase64} from '@vexl-next/cryptography/dist/KeyHolder'
 import {safeParse} from '../utils/fpUtils'
 import selectChatByInboxKeyAndSenderKey from './chat/atoms/selectChatByInboxKeyAndSenderKey'
 import reportError from '../utils/reportError'
-import {type NavigationState} from 'react-native-tab-view'
-import {type ChatId} from '@vexl-next/domain/dist/general/messaging'
+import {isOnMessagesList, isOnSpecificChat} from '../utils/navigation'
 
 const lastNotificationIdHandledAtom = atom<string | undefined>(undefined)
 
@@ -19,35 +18,6 @@ const MessageNotificationPayload = z.object({
   inbox: PublicKeyPemBase64,
   sender: PublicKeyPemBase64,
 })
-
-// TODO how to type this properly?
-function getActiveRoute(route: NavigationState<any>): any {
-  if (
-    !route.routes ||
-    route.routes.length === 0 ||
-    route.index >= route.routes.length
-  ) {
-    return route
-  }
-
-  const childActiveRoute = route.routes[route.index] as NavigationState<any>
-  return getActiveRoute(childActiveRoute)
-}
-
-function isOnSpecificChat(
-  state: NavigationState<any>,
-  chatId: ChatId
-): boolean {
-  const activeRoute = getActiveRoute(state)
-  return (
-    activeRoute.name === 'ChatDetail' && activeRoute.params?.chatId === chatId
-  )
-}
-
-function isOnMessagesList(state: NavigationState<any>): boolean {
-  const activeRoute = getActiveRoute(state)
-  return activeRoute.name === 'Messages'
-}
 
 function useReactOnNotificationOpen(): (notification: Notification) => void {
   const store = useStore()

--- a/apps/mobile/src/utils/navigation.ts
+++ b/apps/mobile/src/utils/navigation.ts
@@ -1,0 +1,44 @@
+// TODO how to type this properly?
+import {type NavigationState} from 'react-native-tab-view'
+import {ChatId} from '@vexl-next/domain/dist/general/messaging'
+import {pipe} from 'fp-ts/function'
+import {safeParse} from './fpUtils'
+import * as O from 'fp-ts/Option'
+
+function getActiveRoute(route: NavigationState<any>): any {
+  if (
+    !route.routes ||
+    route.routes.length === 0 ||
+    route.index >= route.routes.length
+  ) {
+    return route
+  }
+
+  const childActiveRoute = route.routes[route.index] as NavigationState<any>
+  return getActiveRoute(childActiveRoute)
+}
+
+export function isOnSpecificChat(
+  state: NavigationState<any>,
+  chatId: ChatId
+): boolean {
+  const activeRoute = getActiveRoute(state)
+  return (
+    activeRoute.name === 'ChatDetail' && activeRoute.params?.chatId === chatId
+  )
+}
+
+export function getChatIdOfChatOnCurrentScreenIfAny(
+  state: NavigationState<any>
+): O.Option<ChatId> {
+  return pipe(
+    getActiveRoute(state).params?.chatId,
+    safeParse(ChatId),
+    O.fromEither
+  )
+}
+
+export function isOnMessagesList(state: NavigationState<any>): boolean {
+  const activeRoute = getActiveRoute(state)
+  return activeRoute.name === 'Messages'
+}

--- a/apps/mobile/src/utils/notifications/index.ts
+++ b/apps/mobile/src/utils/notifications/index.ts
@@ -117,7 +117,7 @@ export async function showUINotificationFromRemoteMessage(
       title,
       body,
       data: remoteMessage.data,
-      android: {channelId},
+      android: {channelId, pressAction: {id: 'default'}},
     })
 }
 


### PR DESCRIPTION
How to test: 

- Notification about new chat should lead to chat detail
- If notification is about new message request it will lead to chat detail or to chat list (if not yet downloaded)
- Notification should open proper location when app is in foreground, in background, and killed