### PR TITLE
Simplify currency handling

### DIFF
--- a/apps/mobile/src/components/FilterOffersScreen/components/AmountOfTransaction/components/LimitInput.tsx
+++ b/apps/mobile/src/components/FilterOffersScreen/components/AmountOfTransaction/components/LimitInput.tsx
@@ -1,6 +1,4 @@
 import Input from '../../../../Input'
-import {useMemo} from 'react'
-import {useTranslation} from '../../../../../utils/localization/I18nProvider'
 import {type PrimitiveAtom, useAtomValue} from 'jotai'
 import {type TextInputProps} from 'react-native'
 import {type Currency} from '@vexl-next/domain/dist/general/offers'
@@ -9,22 +7,12 @@ interface Props extends Omit<TextInputProps, 'style'> {
 }
 
 function LimitInput({currencyAtom, ...props}: Props): JSX.Element {
-  const {t} = useTranslation()
   const currency = useAtomValue(currencyAtom)
-  const currencySymbol = useMemo(
-    () =>
-      currency === 'USD'
-        ? t('common.dollarSymbol')
-        : currency === 'EUR'
-        ? t('common.eurSymbol')
-        : t('common.czkSymbol'),
-    [currency, t]
-  )
   return (
     <Input
       keyboardType="numeric"
-      leftText={currency === 'USD' ? currencySymbol : undefined}
-      rightText={currency !== 'USD' ? currencySymbol : undefined}
+      leftText={undefined}
+      rightText={currency}
       variant="greyOnBlack"
       leftTextColor={'$main'}
       rightTextColor={'$main'}

--- a/apps/mobile/src/components/FilterOffersScreen/components/Currency/useContent.tsx
+++ b/apps/mobile/src/components/FilterOffersScreen/components/Currency/useContent.tsx
@@ -1,26 +1,23 @@
 import {type Currency} from '@vexl-next/domain/dist/general/offers'
-import {useTranslation} from '../../../../utils/localization/I18nProvider'
 import {type TabProps} from '../../../Tabs'
 import {useMemo} from 'react'
 
 export default function useContent(): Array<TabProps<Currency>> {
-  const {t} = useTranslation()
-
   return useMemo(
     () => [
       {
-        title: t('common.czk'),
+        title: 'CZK',
         type: 'CZK',
       },
       {
-        title: t('common.eur'),
+        title: 'EUR',
         type: 'EUR',
       },
       {
-        title: t('common.usd'),
+        title: 'USD',
         type: 'USD',
       },
     ],
-    [t]
+    []
   )
 }

--- a/apps/mobile/src/components/FilterOffersScreen/useContent.tsx
+++ b/apps/mobile/src/components/FilterOffersScreen/useContent.tsx
@@ -43,7 +43,7 @@ export default function useContent(): SectionProps[] {
         children: <Sorting sortingAtom={sortingAtom} />,
       },
       {
-        title: t('offerForm.currency'),
+        title: t('common.currency'),
         image: coinsSvg,
         children: (
           <Currency

--- a/apps/mobile/src/components/InsideRouter/components/BitcoinPriceChart.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/BitcoinPriceChart.tsx
@@ -1,6 +1,5 @@
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {Stack, Text, XStack} from 'tamagui'
-import {useTranslation} from '../../../utils/localization/I18nProvider'
 import {TouchableOpacity} from 'react-native'
 import {useAtomValue, useSetAtom} from 'jotai'
 import {btcPriceAtom, refreshBtcPriceActionAtom} from '../atoms'
@@ -12,7 +11,6 @@ import {selectedCurrencyAtom} from '../../../state/selectedCurrency'
 export const CHART_HEIGHT_PX = 100
 
 function BitcoinPriceChart(): JSX.Element {
-  const {t} = useTranslation()
   const insets = useSafeAreaInsets()
   const refreshBtcPrice = useSetAtom(refreshBtcPriceActionAtom)
   const btcPrice = useAtomValue(btcPriceAtom)
@@ -55,11 +53,7 @@ function BitcoinPriceChart(): JSX.Element {
               {btcPriceValue ?? '- '}
             </Text>
             <Text fos={12} ff={'$body700'} color={'$yellowAccent1'}>
-              {selectedCurrency === 'USD'
-                ? t('common.usd')
-                : selectedCurrency === 'EUR'
-                ? t('common.eur')
-                : t('common.czk')}
+              {selectedCurrency}
             </Text>
           </XStack>
         </TouchableOpacity>

--- a/apps/mobile/src/components/InsideRouter/components/SettingsScreen/components/ButtonsSection.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/SettingsScreen/components/ButtonsSection.tsx
@@ -171,7 +171,7 @@ function ButtonsSection(): JSX.Element {
               }
             : null,
           {
-            text: t('settings.items.czechCrown'),
+            text: 'CZK',
             icon: coinsIconSvg,
             onPress: () => {
               setChangeCurrencyDialogVisible(true)

--- a/apps/mobile/src/components/InsideRouter/components/SettingsScreen/components/ChangeCurrency/index.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/SettingsScreen/components/ChangeCurrency/index.tsx
@@ -68,7 +68,7 @@ function ChangeCurrency(): JSX.Element {
       onClose={() => {
         setChangeCurrencyDialogVisible(false)
       }}
-      title={t('currency.currency')}
+      title={t('common.currency')}
       visible={changeCurrencyDialogVisible}
     >
       <YStack space={'$6'}>

--- a/apps/mobile/src/components/InsideRouter/components/SettingsScreen/components/ChangeCurrency/useContent.ts
+++ b/apps/mobile/src/components/InsideRouter/components/SettingsScreen/components/ChangeCurrency/useContent.ts
@@ -1,29 +1,26 @@
 import {type Currency} from '@vexl-next/domain/dist/general/offers'
 
 import {useMemo} from 'react'
-import {useTranslation} from '../../../../../../utils/localization/I18nProvider'
 
 export default function useContent(): Array<{
   title: string
   currency: Currency
 }> {
-  const {t} = useTranslation()
-
   return useMemo(
     () => [
       {
-        title: t('currency.czechCrown'),
+        title: 'CZK',
         currency: 'CZK',
       },
       {
-        title: t('currency.euro'),
+        title: 'EUR',
         currency: 'EUR',
       },
       {
-        title: t('currency.unitedStatesDollar'),
+        title: 'USD',
         currency: 'USD',
       },
     ],
-    [t]
+    []
   )
 }

--- a/apps/mobile/src/components/InsideRouter/components/SettingsScreen/components/SelectedCurrencyTitle.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/SettingsScreen/components/SelectedCurrencyTitle.tsx
@@ -1,4 +1,3 @@
-import {useTranslation} from '../../../../../utils/localization/I18nProvider'
 import {useAtomValue} from 'jotai'
 import {selectedCurrencyAtom} from '../../../../../state/selectedCurrency'
 import {styled, Text} from 'tamagui'
@@ -8,15 +7,10 @@ export const ItemText = styled(Text, {
 })
 
 function SelectedCurrencyTitle(): JSX.Element {
-  const {t} = useTranslation()
   const selectedCurrency = useAtomValue(selectedCurrencyAtom)
   return (
     <ItemText ff="$body500" col="$white">
-      {selectedCurrency === 'USD'
-        ? t('currency.unitedStatesDollar')
-        : selectedCurrency === 'EUR'
-        ? t('currency.euro')
-        : t('currency.czechCrown')}
+      {selectedCurrency}
     </ItemText>
   )
 }

--- a/apps/mobile/src/components/ModifyOffer/useContent.tsx
+++ b/apps/mobile/src/components/ModifyOffer/useContent.tsx
@@ -51,7 +51,7 @@ export default function useContent(): SectionProps[] {
         children: <OfferType offerTypeAtom={offerTypeAtom} />,
       },
       {
-        title: t('offerForm.currency'),
+        title: t('common.currency'),
         image: coinsSvg,
         children: (
           <Currency

--- a/apps/mobile/src/components/OfferForm/components/AmountOfTransaction/components/LimitInput.tsx
+++ b/apps/mobile/src/components/OfferForm/components/AmountOfTransaction/components/LimitInput.tsx
@@ -1,6 +1,5 @@
 import Input from '../../../../Input'
-import {type SetStateAction, useMemo} from 'react'
-import {useTranslation} from '../../../../../utils/localization/I18nProvider'
+import {type SetStateAction} from 'react'
 import {useAtomValue, type WritableAtom} from 'jotai'
 import {type TextInputProps} from 'react-native'
 import {type Currency} from '@vexl-next/domain/dist/general/offers'
@@ -13,22 +12,12 @@ interface Props extends Omit<TextInputProps, 'style'> {
 }
 
 function LimitInput({currencyAtom, ...props}: Props): JSX.Element {
-  const {t} = useTranslation()
   const currency = useAtomValue(currencyAtom)
-  const currencySymbol = useMemo(
-    () =>
-      currency === 'USD'
-        ? t('common.dollarSymbol')
-        : currency === 'EUR'
-        ? t('common.eurSymbol')
-        : t('common.czkSymbol'),
-    [currency, t]
-  )
   return (
     <Input
       keyboardType="numeric"
-      leftText={currency === 'USD' ? currencySymbol : undefined}
-      rightText={currency !== 'USD' ? currencySymbol : undefined}
+      leftText={undefined}
+      rightText={currency}
       variant="greyOnBlack"
       leftTextColor={'$main'}
       rightTextColor={'$main'}

--- a/apps/mobile/src/components/OfferForm/components/Currency/useContent.tsx
+++ b/apps/mobile/src/components/OfferForm/components/Currency/useContent.tsx
@@ -1,26 +1,23 @@
 import {type Currency} from '@vexl-next/domain/dist/general/offers'
-import {useTranslation} from '../../../../utils/localization/I18nProvider'
 import {type TabProps} from '../../../Tabs'
 import {useMemo} from 'react'
 
 export default function useContent(): Array<TabProps<Currency>> {
-  const {t} = useTranslation()
-
   return useMemo(
     () => [
       {
-        title: t('common.czk'),
+        title: 'CZK',
         type: 'CZK',
       },
       {
-        title: t('common.eur'),
+        title: 'EUR',
         type: 'EUR',
       },
       {
-        title: t('common.usd'),
+        title: 'USD',
         type: 'USD',
       },
     ],
-    [t]
+    []
   )
 }

--- a/apps/mobile/src/components/OfferInfoPreview.tsx
+++ b/apps/mobile/src/components/OfferInfoPreview.tsx
@@ -52,19 +52,8 @@ function OfferInfoPreview({
   )
 
   const offerAmount = useMemo(() => {
-    if (offer.publicPart.currency === 'CZK')
-      return `${bigNumberToString(offer.publicPart.amountTopLimit)} ${t(
-        'common.czkSymbol'
-      )}`
-    if (offer.publicPart.currency === 'EUR')
-      return `${t('common.eurSymbol')}${bigNumberToString(
-        offer.publicPart.amountTopLimit
-      )}`
-    if (offer.publicPart.currency === 'USD')
-      return `${t('common.dollarSymbol')}${bigNumberToString(
-        offer.publicPart.amountTopLimit
-      )}`
-  }, [offer.publicPart.amountTopLimit, offer.publicPart.currency, t])
+    return `${bigNumberToString(offer.publicPart.amountTopLimit)} ${offer.publicPart.currency}`
+  }, [offer.publicPart.amountTopLimit, offer.publicPart.currency])
 
   return (
     <>

--- a/packages/localizations/src/chunks/other.cs.ts
+++ b/packages/localizations/src/chunks/other.cs.ts
@@ -41,13 +41,7 @@ const otherCs: typeof en =
       "more": "Více na",
       "yes": "Ano",
       "no": "Ne",
-      "czk": "CZK",
-      "usd": "USD",
-      "eur": "EUR",
       "myOffers": "Moje nabídky",
-      "eurSymbol": "€",
-      "dollarSymbol": "$",
-      "czkSymbol": "Kč",
       "errorOpeningLink": {
         "message": "Chyba při otvírání linku.",
         "text": "Zkopírovat do schránky?",
@@ -60,7 +54,8 @@ const otherCs: typeof en =
       "declined": "Zamítnuto",
       "reset": "Reset",
       "you": "Vy",
-      "allow": "Povolit"
+      "allow": "Povolit",
+      "currency": "Měna"
     },
     "loginFlow": {
       "anonymityNotice": "Bez tvého svolení jej nikdo neuvidí. Ani my.",
@@ -189,7 +184,6 @@ const otherCs: typeof en =
         "xFriends": "{{number}} přátel",
         "setPin": "Nastavit PIN",
         "faceId": "Face ID",
-        "czechCrown": "Česká koruna",
         "allowScreenshots": "Povolit screenshoty",
         "allowScreenshotsDescription":
           "Zakázat uživatelům pořizovat snímky chatu",
@@ -315,7 +309,6 @@ const otherCs: typeof en =
       "iWantTo": "Chci",
       "sellBitcoin": "Prodat bitcoin",
       "buyBitcoin": "Koupit Bitcoin",
-      "currency": "Měna",
       "amountOfTransaction": {
         "amountOfTransaction": "Částka",
         "pleaseSelectCurrencyFirst": "Nejdřív si vyber měnu",
@@ -610,12 +603,6 @@ const otherCs: typeof en =
     },
     "btcPriceChart": {
       "requestCouldNotBeProcessed": ":D"
-    },
-    "currency": {
-      "currency": "Měna",
-      "czechCrown": "Česká koruna",
-      "euro": "Euro",
-      "unitedStatesDollar": "USD"
     },
     "deepLinks": {
       "importContacts": {

--- a/packages/localizations/src/chunks/other.en.ts
+++ b/packages/localizations/src/chunks/other.en.ts
@@ -40,13 +40,7 @@ const otherEn =
       "more": "More",
       "yes": "Yes",
       "no": "No",
-      "czk": "CZK",
-      "usd": "USD",
-      "eur": "EUR",
       "myOffers": "My offers",
-      "eurSymbol": "€",
-      "dollarSymbol": "$",
-      "czkSymbol": "Kč",
       "errorOpeningLink": {
         "message": "Error opening link",
         "text": "Copy to clipboard instead?",
@@ -59,7 +53,8 @@ const otherEn =
       "declined": "Declined",
       "reset": "Reset",
       "you": "You",
-      "allow": "Allow"
+      "allow": "Allow",
+      "currency": "Currency"
     },
     "loginFlow": {
       "anonymityNotice":
@@ -186,7 +181,6 @@ const otherEn =
         "xFriends": "{{number}} friends",
         "setPin": "Set PIN",
         "faceId": "Face ID",
-        "czechCrown": "Czech crown",
         "allowScreenshots": "Allow Screenshots",
         "allowScreenshotsDescription":
           "Prevent users from taking screenshots of the chat",
@@ -314,7 +308,6 @@ const otherEn =
       "iWantTo": "I want to",
       "sellBitcoin": "Sell Bitcoin",
       "buyBitcoin": "Buy Bitcoin",
-      "currency": "Currency",
       "amountOfTransaction": {
         "amountOfTransaction": "Amount",
         "pleaseSelectCurrencyFirst": "Please select currency first",
@@ -609,12 +602,6 @@ const otherEn =
     "btcPriceChart": {
       "requestCouldNotBeProcessed":
         "Request to obtain current BTC price failed"
-    },
-    "currency": {
-      "currency": "Currency",
-      "czechCrown": "Czech crown",
-      "euro": "Euro",
-      "unitedStatesDollar": "USD"
     },
     "deepLinks": {
       "importContacts": {

--- a/packages/localizations/src/chunks/other.sk.ts
+++ b/packages/localizations/src/chunks/other.sk.ts
@@ -41,13 +41,7 @@ const otherSk: typeof en =
       "more": "Viac na",
       "yes": "Áno",
       "no": "Nie",
-      "czk": "CZK",
-      "usd": "USD",
-      "eur": "EUR",
       "myOffers": "Moje ponuky",
-      "eurSymbol": "€",
-      "dollarSymbol": "$",
-      "czkSymbol": "Kč",
       "errorOpeningLink": {
         "message": "Chyba pri otváraní linku.",
         "text": "Skopírovať do schránky?",
@@ -60,7 +54,8 @@ const otherSk: typeof en =
       "declined": "Zamietnuté",
       "reset": "Reset",
       "you": "Vy",
-      "allow": "Povoliť"
+      "allow": "Povoliť",
+      "currency": "Mena"
     },
     "loginFlow": {
       "anonymityNotice": "Kým to nepovolíte, nikto to neuvidí. Dokonca ani my.",
@@ -189,7 +184,6 @@ const otherSk: typeof en =
         "xFriends": "{{number}} priateľov",
         "setPin": "Nastaviť PIN",
         "faceId": "Face ID",
-        "czechCrown": "Česká koruna",
         "allowScreenshots": "Povoliť screenshoty",
         "allowScreenshotsDescription": "Zákazať užívateľom screenshoty chatu",
         "termsAndPrivacy": "Podmienky a ochrana osobných údajov",
@@ -314,7 +308,6 @@ const otherSk: typeof en =
       "iWantTo": "Chcem",
       "sellBitcoin": "Predať Bitcoin",
       "buyBitcoin": "Kúpiť Bitcoin",
-      "currency": "Mena",
       "amountOfTransaction": {
         "amountOfTransaction": "Čiastka",
         "pleaseSelectCurrencyFirst": "Najskôr si vyber menu",
@@ -611,12 +604,6 @@ const otherSk: typeof en =
     "btcPriceChart": {
       "requestCouldNotBeProcessed":
         "Request to obtain current BTC price failed"
-    },
-    "currency": {
-      "currency": "Mena",
-      "czechCrown": "Česká koruna",
-      "euro": "Euro",
-      "unitedStatesDollar": "USD"
     },
     "deepLinks": {
       "importContacts": {


### PR DESCRIPTION
Please review carefully since:
1. this is my first bigger PR to this repo
2. this code is completely untested

This PR:
- simplifies currency handling - i.e. removes unnecessary translations and transformations of used currency = just use CZK/USD/EUR everywhere
- simplifies implementing https://github.com/vexl-it/vexl/issues/234 for the time being
- fixes https://github.com/vexl-it/vexl/issues/335

We can later reintroduce something like the mapping:

```
USD => $
CZK => Kč
EUR => €
```

but not via translations, but rather via a fixed map (dict) in the code.

This creates a new problem, though, where for example both CNY and JPY use the same symbol ￥ and THB uses the symbol ฿. So we might never introduce this.