### PR TITLE
fix: 1st level offer should not encrypt to 2nd lvl connections

### DIFF
--- a/apps/mobile/src/state/connections/atom/offerToConnectionsAtom.ts
+++ b/apps/mobile/src/state/connections/atom/offerToConnectionsAtom.ts
@@ -187,7 +187,7 @@ export const updateAllOffersConnectionsActionAtom = atom(
                         ...val.connections.secondLevel,
                         ...(newConnections.secondLevel ?? []),
                       ]
-                    : [],
+                    : undefined,
                 },
               }))
               return {

--- a/packages/resources-utils/src/offers/updatePrivateParts.ts
+++ b/packages/resources-utils/src/offers/updatePrivateParts.ts
@@ -54,6 +54,7 @@ export default function updatePrivateParts({
   {
     encryptionErrors: PrivatePartEncryptionError[]
     timeLimitReachedErrors: TimeLimitReachedError[]
+    removedConnections: PublicKeyPemBase64[]
     newConnections: {
       firstLevel: PublicKeyPemBase64[]
       secondLevel?: PublicKeyPemBase64[]
@@ -158,6 +159,7 @@ export default function updatePrivateParts({
       return {
         encryptionErrors,
         timeLimitReachedErrors,
+        removedConnections: deduplicate(removedConnections),
         newConnections: {
           firstLevel: subtractArrays(
             newFirstLevelConnections,


### PR DESCRIPTION
How to test: 

1. Create new 1st lvl offer with code from main branch
2. while still in the main branch, put app on background and open it again
3. Offer is now encrypted for 2nd lvl friends although it was intended for 1st lvl only
4. Checkout this branch
5. run `yarn turbo:build` - to build all changes
6. Rerun the app on the same device with the same state from steps 1-3
7. Offer should now be encrypted only for 1st lvl friends 2nd lvl private parts should be removed from the server