### PR TITLE
securityFix: Remove authToken from sentry configuration in app.config.ts

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -176,7 +176,6 @@ export default {
       '@sentry/react-native/expo',
       {
         'url': 'https://sentry.io/',
-        'authToken': process.env.SENTRY_AUTH_TOKEN,
         'project': 'vexl-app',
         'organization': 'vexl',
       },


### PR DESCRIPTION
Removed sentry auth token to mitigate security risk according to this: https://blog.expo.dev/security-notice-incorrect-plugin-configuration-guidance-in-sdk-50-migration-documentation-may-6464aab65704 blogpost. 
