### PR TITLE
Remove COP and TZS as they are not supported by CoinGecko

### DIFF
--- a/apps/mobile/src/utils/localization/currency.ts
+++ b/apps/mobile/src/utils/localization/currency.ts
@@ -323,24 +323,24 @@ export const currencies = {
     maxAmount: 200000,
     countryCode: [27],
   }),
-  'COP': CurrencyInfo.parse({
-    code: 'COP',
-    flag: '🇨🇴',
-    name: 'Colombian Peso',
-    symbol: 'Col$',
-    position: 'before',
-    maxAmount: 40_000_000,
-    countryCode: [57],
-  }),
-  'TZS': CurrencyInfo.parse({
-    code: 'TZS',
-    flag: '🇹🇿',
-    name: 'Tanzanian Shilling',
-    symbol: 'TZS',
-    position: 'after',
-    maxAmount: 2_000_000,
-    countryCode: [255],
-  }),
+  // 'COP': CurrencyInfo.parse({
+  //   code: 'COP',
+  //   flag: '🇨🇴',
+  //   name: 'Colombian Peso',
+  //   symbol: 'Col$',
+  //   position: 'before',
+  //   maxAmount: 40_000_000,
+  //   countryCode: [57],
+  // }),
+  // 'TZS': CurrencyInfo.parse({
+  //   code: 'TZS',
+  //   flag: '🇹🇿',
+  //   name: 'Tanzanian Shilling',
+  //   symbol: 'TZS',
+  //   position: 'after',
+  //   maxAmount: 2_000_000,
+  //   countryCode: [255],
+  // }),
 } as const
 
 export function getCurrencyLeftText(

--- a/packages/domain/src/general/currency.brand.ts
+++ b/packages/domain/src/general/currency.brand.ts
@@ -35,8 +35,8 @@ export const CurrencyCode = z.enum([
   'UAH',
   'USD',
   'ZAR',
-  'COP',
-  'TZS',
+  // 'COP',
+  // 'TZS',
 ])
 
 export const CurrencyInfo = z.object({


### PR DESCRIPTION
@kaladivo as we cannot fetch price from CoinGecko, product offers will not be able to calculate SATS price.