### PR TITLE
feat: Verified Contacts

### DIFF
--- a/apps/contact-service/src/__tests__/routes/contacts/fetchCommonConnectionsPaginated.test.ts
+++ b/apps/contact-service/src/__tests__/routes/contacts/fetchCommonConnectionsPaginated.test.ts
@@ -15,7 +15,9 @@ import {runPromiseInMockedEnvironment} from '../../utils/runPromiseInMockedEnvir
 import {
   commonHeaders,
   createAndImportUsersFromNetwork,
+  createUserOnNetwork,
   generateKeysAndHasheForNumber,
+  importUsersFromNetwork,
   makeTestCommonAndSecurityHeaders,
   type DummyUser,
 } from './utils'
@@ -563,6 +565,187 @@ describe('Common connections paginated', () => {
         expect(firstCall.items).toEqual(secondCall.items)
         expect(firstCall.hasNext).toBe(secondCall.hasNext)
         expect(firstCall.nextPageToken).toBe(secondCall.nextPageToken)
+      })
+    )
+  })
+
+  it('verifiedHashes equals hashes when all contacts are bidirectional', async () => {
+    await runPromiseInMockedEnvironment(
+      Effect.gen(function* (_) {
+        const app = yield* _(NodeTestingApp)
+
+        const me = networkOne[0]
+        const userContacts = Array.filter(
+          networkOne,
+          (u) => u.keys.publicKeyPemBase64 !== me.keys.publicKeyPemBase64
+        )
+
+        yield* _(setAuthHeaders(me.authHeaders))
+        const commonAndSecurityHeaders = makeTestCommonAndSecurityHeaders(
+          me.authHeaders
+        )
+
+        const connections = yield* _(
+          app.Contact.fetchCommonConnectionsPaginated({
+            payload: {
+              publicKeys: Array.map(
+                userContacts,
+                (one) => one.keys.publicKeyPemBase64
+              ),
+              limit: 20,
+            },
+            headers: commonAndSecurityHeaders,
+          })
+        )
+
+        for (const {common} of connections.items) {
+          expect(
+            pipe(
+              common.verifiedHashes,
+              Array.sort(Order.string),
+              Array.join(',')
+            )
+          ).toEqual(
+            pipe(common.hashes, Array.sort(Order.string), Array.join(','))
+          )
+        }
+      })
+    )
+  })
+
+  it('verifiedHashes excludes common contacts that did not import both sides', async () => {
+    await runPromiseInMockedEnvironment(
+      Effect.gen(function* (_) {
+        const app = yield* _(NodeTestingApp)
+
+        // Create an asymmetric network:
+        // alice, bob, charlie where:
+        // - alice imports bob and charlie
+        // - bob imports alice and charlie
+        // - charlie imports alice only (NOT bob)
+        //
+        // When alice asks for common friends with bob:
+        //   common.hashes should include charlie (both alice and bob imported charlie)
+        //   common.verifiedHashes should NOT include charlie
+        //     because charlie did not import bob (charlie → bob is missing)
+
+        const alice = yield* _(generateKeysAndHasheForNumber('+420733444001'))
+        const bob = yield* _(generateKeysAndHasheForNumber('+420733444002'))
+        const charlie = yield* _(generateKeysAndHasheForNumber('+420733444003'))
+
+        // Create all users
+        yield* _(createUserOnNetwork(alice))
+        yield* _(createUserOnNetwork(bob))
+        yield* _(createUserOnNetwork(charlie))
+
+        // alice imports bob and charlie
+        yield* _(importUsersFromNetwork(alice, [bob, charlie]))
+        // bob imports alice and charlie
+        yield* _(importUsersFromNetwork(bob, [alice, charlie]))
+        // charlie imports alice only
+        yield* _(importUsersFromNetwork(charlie, [alice]))
+
+        yield* _(setAuthHeaders(alice.authHeaders))
+        const commonAndSecurityHeaders = makeTestCommonAndSecurityHeaders(
+          alice.authHeaders
+        )
+
+        const connections = yield* _(
+          app.Contact.fetchCommonConnectionsPaginated({
+            payload: {
+              publicKeys: [bob.keys.publicKeyPemBase64],
+              limit: 20,
+            },
+            headers: commonAndSecurityHeaders,
+          })
+        )
+
+        expect(connections.items.length).toBe(1)
+        const bobResult = connections.items[0]
+
+        // charlie should be in common.hashes (both alice and bob imported charlie)
+        expect(bobResult.common.hashes).toContain(
+          charlie.serverHashedNumberForClient
+        )
+
+        // charlie should NOT be in verifiedHashes
+        // because charlie did not import bob
+        expect(bobResult.common.verifiedHashes).not.toContain(
+          charlie.serverHashedNumberForClient
+        )
+        expect(bobResult.common.verifiedHashes).toEqual([])
+      })
+    )
+  })
+
+  it('verifiedHashes includes only contacts that imported both sides', async () => {
+    await runPromiseInMockedEnvironment(
+      Effect.gen(function* (_) {
+        const app = yield* _(NodeTestingApp)
+
+        // Network:
+        // alice, bob, charlie, dave where:
+        // - alice imports bob, charlie, dave
+        // - bob imports alice, charlie, dave
+        // - charlie imports alice and bob (bidirectional with both)
+        // - dave imports alice only (NOT bob)
+        //
+        // When alice asks for common friends with bob:
+        //   hashes: charlie, dave (both alice and bob imported them)
+        //   verifiedHashes: charlie only (charlie imported both alice and bob)
+        //   dave is NOT verified (dave did not import bob)
+
+        const alice = yield* _(generateKeysAndHasheForNumber('+420733555001'))
+        const bob = yield* _(generateKeysAndHasheForNumber('+420733555002'))
+        const charlie = yield* _(generateKeysAndHasheForNumber('+420733555003'))
+        const dave = yield* _(generateKeysAndHasheForNumber('+420733555004'))
+
+        yield* _(createUserOnNetwork(alice))
+        yield* _(createUserOnNetwork(bob))
+        yield* _(createUserOnNetwork(charlie))
+        yield* _(createUserOnNetwork(dave))
+
+        yield* _(importUsersFromNetwork(alice, [bob, charlie, dave]))
+        yield* _(importUsersFromNetwork(bob, [alice, charlie, dave]))
+        yield* _(importUsersFromNetwork(charlie, [alice, bob]))
+        yield* _(importUsersFromNetwork(dave, [alice]))
+
+        yield* _(setAuthHeaders(alice.authHeaders))
+        const commonAndSecurityHeaders = makeTestCommonAndSecurityHeaders(
+          alice.authHeaders
+        )
+
+        const connections = yield* _(
+          app.Contact.fetchCommonConnectionsPaginated({
+            payload: {
+              publicKeys: [bob.keys.publicKeyPemBase64],
+              limit: 20,
+            },
+            headers: commonAndSecurityHeaders,
+          })
+        )
+
+        expect(connections.items.length).toBe(1)
+        const bobResult = connections.items[0]
+
+        // Both charlie and dave should be in hashes
+        const sortedHashes = pipe(
+          bobResult.common.hashes,
+          Array.sort(Order.string)
+        )
+        const expectedHashes = pipe(
+          [
+            charlie.serverHashedNumberForClient,
+            dave.serverHashedNumberForClient,
+          ],
+          Array.sort(Order.string)
+        )
+        expect(sortedHashes).toEqual(expectedHashes)
+
+        // Only charlie should be in verifiedHashes
+        expect(bobResult.common.verifiedHashes).toEqual([
+          charlie.serverHashedNumberForClient,
+        ])
       })
     )
   })

--- a/apps/contact-service/src/db/ContactDbService/queries/createFindCommonFriendsByOwnerHashAndPublicKeysPaginated.ts
+++ b/apps/contact-service/src/db/ContactDbService/queries/createFindCommonFriendsByOwnerHashAndPublicKeysPaginated.ts
@@ -20,6 +20,7 @@ export const FindCommonFriendsPaginatedResult = Schema.Struct({
   publicKey: PublicKeyPemBase64,
   publicKeyV2: Schema.NullOr(PublicKeyV2),
   commonFriends: Schema.Array(ServerHashedNumber),
+  verifiedFriends: Schema.Array(ServerHashedNumber),
   userContactId: Schema.NumberFromString,
 })
 export type FindCommonFriendsPaginatedResult =
@@ -37,11 +38,23 @@ export const createFindCommonFriendsByOwnerHashAndPublicKeysPaginated =
           MAX(imported_my_contact.id) AS user_contact_id,
           other_side.public_key AS public_key,
           other_side.public_key_v2 AS public_key_v2,
-          array_agg(DISTINCT imported_my_contact.hash_to) AS common_friends
+          array_agg(DISTINCT imported_my_contact.hash_to) AS common_friends,
+          COALESCE(
+            array_agg(DISTINCT imported_my_contact.hash_to) FILTER (
+              WHERE
+                reverse_to_requester.hash_from IS NOT NULL
+                AND reverse_to_other.hash_from IS NOT NULL
+            ),
+            ARRAY[]::VARCHAR[]
+          ) AS verified_friends
         FROM
           user_contact AS my_contact
           INNER JOIN user_contact AS imported_my_contact ON my_contact.hash_to = imported_my_contact.hash_to
           INNER JOIN users AS other_side ON other_side.hash = imported_my_contact.hash_from
+          LEFT JOIN user_contact AS reverse_to_requester ON reverse_to_requester.hash_from = imported_my_contact.hash_to
+          AND reverse_to_requester.hash_to = ${hash.ownerHash}
+          LEFT JOIN user_contact AS reverse_to_other ON reverse_to_other.hash_from = imported_my_contact.hash_to
+          AND reverse_to_other.hash_to = other_side.hash
         WHERE
           ${sql.and([
           sql`my_contact.hash_from = ${hash.ownerHash}`,

--- a/apps/contact-service/src/routes/contacts/fetchCommonConnectionsPaginated.ts
+++ b/apps/contact-service/src/routes/contacts/fetchCommonConnectionsPaginated.ts
@@ -85,12 +85,15 @@ export const fetchCommonConnectionsPaginated = HttpApiBuilder.handler(
         toReturn.items,
         Array.map((oneContact) =>
           pipe(
-            hashForClientBatch(oneContact.commonFriends),
-            Effect.map((hashes) => ({
+            Effect.all({
+              hashes: hashForClientBatch(oneContact.commonFriends),
+              verifiedHashes: hashForClientBatch(oneContact.verifiedFriends),
+            }),
+            Effect.map(({hashes, verifiedHashes}) => ({
               publicKey: clientSupportsV2Keys
                 ? (oneContact.publicKeyV2 ?? oneContact.publicKey)
                 : oneContact.publicKey,
-              common: {hashes},
+              common: {hashes, verifiedHashes},
             }))
           )
         ),

--- a/apps/mobile/src/components/CRUDOfferFlow/atoms/offerFormStateAtoms.ts
+++ b/apps/mobile/src/components/CRUDOfferFlow/atoms/offerFormStateAtoms.ts
@@ -262,6 +262,7 @@ export const offerFormMolecule = molecule(() => {
           Schema.decodeSync(HashedPhoneNumber)('Mike'),
           Schema.decodeSync(HashedPhoneNumber)('John'),
         ],
+        verifiedCommonFriends: [],
         friendLevel: ['FIRST_DEGREE'],
         symmetricKey: Schema.decodeSync(SymmetricKey)('symmetricKey'),
         clubIds: [],

--- a/apps/mobile/src/components/ChatDetailScreen/atoms/index.tsx
+++ b/apps/mobile/src/components/ChatDetailScreen/atoms/index.tsx
@@ -346,6 +346,19 @@ export const chatMolecule = molecule((getMolecule, getScope) => {
       : (offer?.offerInfo.privatePart.commonFriends ?? [])
   })
 
+  const verifiedConnectionsHashesAtom = atom((get) => {
+    const offer = get(offerForChatAtom)
+    const verifiedCommonFriendsForMyOffer = pipe(
+      get(requestMessageAtom),
+      Option.map((message) => message.message.verifiedCommonFriends),
+      Option.getOrElse(() => [] as const)
+    )
+
+    return offer?.ownershipInfo
+      ? verifiedCommonFriendsForMyOffer
+      : (offer?.offerInfo.privatePart.verifiedCommonFriends ?? [])
+  })
+
   const commonConnectionsCountAtom = selectAtom(
     commonConnectionsHashesAtom,
     (connections) => connections.length
@@ -1239,6 +1252,7 @@ export const chatMolecule = molecule((getMolecule, getScope) => {
     nameAtom,
     chatWithMessagesAtom,
     commonConnectionsHashesAtom,
+    verifiedConnectionsHashesAtom,
     commonConnectionsCountAtom,
     messagesAtom,
     messageAtomAtoms,

--- a/apps/mobile/src/components/ChatDetailScreen/components/ChatRequestPreview.tsx
+++ b/apps/mobile/src/components/ChatDetailScreen/components/ChatRequestPreview.tsx
@@ -23,6 +23,7 @@ function ChatRequestPreview({
     offerForChatAtom,
     chatAtom,
     commonConnectionsHashesAtom,
+    verifiedConnectionsHashesAtom,
     requestMessageAtom,
     otherSideClubsIdsAtom,
   } = useMolecule(chatMolecule)
@@ -30,6 +31,7 @@ function ChatRequestPreview({
   const chat = useAtomValue(chatAtom)
   const offer = useAtomValue(offerForChatAtom)
   const commonConnectionsHashes = useAtomValue(commonConnectionsHashesAtom)
+  const verifiedConnectionsHashes = useAtomValue(verifiedConnectionsHashesAtom)
   const requestMessage = useAtomValue(requestMessageAtom)
   const otherSideClubs = useGetAllClubsForIds(
     useAtomValue(otherSideClubsIdsAtom) ?? []
@@ -47,6 +49,7 @@ function ChatRequestPreview({
           <Stack mx="$-4">
             <CommonFriends
               commonConnectionsHashes={commonConnectionsHashes}
+              verifiedConnectionsHashes={verifiedConnectionsHashes}
               variant="light"
               otherSideClubs={otherSideClubs}
             />

--- a/apps/mobile/src/components/ChatDetailScreen/components/OtherSideNamePhotoAndInfo.tsx
+++ b/apps/mobile/src/components/ChatDetailScreen/components/OtherSideNamePhotoAndInfo.tsx
@@ -25,6 +25,7 @@ function OtherSideNamePhotoAndInfo({mode}: Props): React.ReactElement {
     canSendMessagesAtom,
     commonConnectionsCountAtom,
     commonConnectionsHashesAtom,
+    verifiedConnectionsHashesAtom,
     friendLevelInfoAtom,
     otherSideGoldenAvatarTypeAtom,
     otherSideClubsIdsAtom,
@@ -35,6 +36,7 @@ function OtherSideNamePhotoAndInfo({mode}: Props): React.ReactElement {
   const otherSideLeft = useAtomValue(otherSideLeftAtom)
   const canSendMessages = useAtomValue(canSendMessagesAtom)
   const commonConnectionsHashes = useAtomValue(commonConnectionsHashesAtom)
+  const verifiedConnectionsHashes = useAtomValue(verifiedConnectionsHashesAtom)
   const commonConnectionsCount = useAtomValue(commonConnectionsCountAtom)
   const friendLevelInfo = useAtomValue(friendLevelInfoAtom)
   const otherSideClubsIds = useAtomValue(otherSideClubsIdsAtom)
@@ -91,6 +93,7 @@ function OtherSideNamePhotoAndInfo({mode}: Props): React.ReactElement {
         />
         <ContactTypeAndCommonNumber
           contactsHashes={commonConnectionsHashes}
+          verifiedHashes={verifiedConnectionsHashes}
           friendLevel={friendLevelInfo}
           numberOfCommonFriends={commonConnectionsCount}
           center={mode === 'photoTop'}

--- a/apps/mobile/src/components/CommonFriends/components/CommonFriendCell.tsx
+++ b/apps/mobile/src/components/CommonFriends/components/CommonFriendCell.tsx
@@ -10,13 +10,21 @@ interface Props {
   contactId: Option.Option<NonUniqueContactId>
   name: string
   variant: 'light' | 'dark'
+  verified?: boolean
 }
 
 function CommonFriendCell({
   contactId,
   name,
   variant,
+  verified,
 }: Props): React.ReactElement {
+  const textColor = verified
+    ? '$yellowAccent1'
+    : variant === 'light'
+      ? '$greyOnWhite'
+      : '$white'
+
   return (
     <XStack ai="center" mr="$3">
       <ContactPictureImage
@@ -31,16 +39,15 @@ function CommonFriendCell({
             width={30}
             borderRadius={8}
             source={picturePlaceholderSvg}
-            fill={getTokens().color.greyOnWhite.val}
+            fill={
+              verified
+                ? getTokens().color.yellowAccent1.val
+                : getTokens().color.greyOnWhite.val
+            }
           />
         }
       />
-      <Text
-        ml="$2"
-        col={variant === 'light' ? '$greyOnWhite' : '$white'}
-        ff="$body500"
-        fos={12}
-      >
+      <Text ml="$2" col={textColor} ff="$body500" fos={12}>
         {name}
       </Text>
     </XStack>

--- a/apps/mobile/src/components/CommonFriends/index.tsx
+++ b/apps/mobile/src/components/CommonFriends/index.tsx
@@ -3,12 +3,13 @@ import {useNavigation} from '@react-navigation/native'
 import {type HashedPhoneNumber} from '@vexl-next/domain/src/general/HashedPhoneNumber.brand'
 import {type ClubInfo} from '@vexl-next/domain/src/general/clubs'
 import {LinearGradient} from 'expo-linear-gradient'
-import {useStore} from 'jotai'
+import {useAtomValue, useStore} from 'jotai'
 import React, {useMemo} from 'react'
 import {Platform, ScrollView, StyleSheet, TouchableOpacity} from 'react-native'
 import {Stack, XStack, YStack, getTokens} from 'tamagui'
 import chevronRightSvg from '../../images/chevronRightSvg'
 import createImportedContactsForHashesAtom from '../../state/contacts/atom/createImportedContactsForHashesAtom'
+import {showVerifiedContactsAtom} from '../../utils/preferences'
 import Image from '../Image'
 import CommonClubCell from './components/CommonClubCell'
 import CommonFriendCell from './components/CommonFriendCell'
@@ -21,22 +22,45 @@ const styles = StyleSheet.create({
 
 interface Props {
   commonConnectionsHashes: readonly HashedPhoneNumber[]
+  verifiedConnectionsHashes?: readonly HashedPhoneNumber[]
   variant: 'light' | 'dark'
   otherSideClubs: ClubInfo[]
 }
 
 function CommonFriends({
   commonConnectionsHashes,
+  verifiedConnectionsHashes,
   variant,
   otherSideClubs,
 }: Props): React.ReactElement | null {
   const tokens = getTokens()
   const store = useStore()
   const navigation = useNavigation()
+  const showVerifiedContacts = useAtomValue(showVerifiedContactsAtom)
   const commonFriends = useMemo(
     () =>
       store.get(createImportedContactsForHashesAtom(commonConnectionsHashes)),
     [commonConnectionsHashes, store]
+  )
+
+  const verifiedHashesSet = useMemo(
+    () =>
+      showVerifiedContacts
+        ? new Set(verifiedConnectionsHashes ?? [])
+        : new Set<HashedPhoneNumber>(),
+    [verifiedConnectionsHashes, showVerifiedContacts]
+  )
+
+  const sortedCommonFriends = useMemo(
+    () =>
+      [...commonFriends].sort((a, b) => {
+        const aIsVerified = verifiedHashesSet.has(a.computedValues.hash)
+        const bIsVerified = verifiedHashesSet.has(b.computedValues.hash)
+        if (aIsVerified && !bIsVerified) return -1
+        if (!aIsVerified && bIsVerified) return 1
+        return 0
+      }),
+    [commonFriends, verifiedHashesSet]
   )
 
   if (commonFriends.length === 0) return null
@@ -48,6 +72,7 @@ function CommonFriends({
         onPress={() => {
           navigation.navigate('CommonFriends', {
             contactsHashes: commonConnectionsHashes,
+            verifiedHashes: verifiedConnectionsHashes,
             clubsIds: otherSideClubs.map((club) => club.uuid),
           })
         }}
@@ -82,12 +107,15 @@ function CommonFriends({
                       club={club}
                     />
                   ))}
-                  {commonFriends.slice(0, 5).map((friend) => (
+                  {sortedCommonFriends.slice(0, 5).map((friend) => (
                     <CommonFriendCell
                       key={friend.computedValues.hash}
                       name={friend.info.name}
                       contactId={friend.info.nonUniqueContactId}
                       variant={variant}
+                      verified={verifiedHashesSet.has(
+                        friend.computedValues.hash
+                      )}
                     />
                   ))}
                 </XStack>
@@ -105,12 +133,13 @@ function CommonFriends({
                     club={club}
                   />
                 ))}
-                {commonFriends.slice(0, 5).map((friend) => (
+                {sortedCommonFriends.slice(0, 5).map((friend) => (
                   <CommonFriendCell
                     key={`${friend.computedValues.hash} - ${friend.info.name}`}
                     name={friend.info.name}
                     contactId={friend.info.nonUniqueContactId}
                     variant={variant}
+                    verified={verifiedHashesSet.has(friend.computedValues.hash)}
                   />
                 ))}
               </ScrollView>

--- a/apps/mobile/src/components/CommonFriendsScreen/components/CommonFriendsListItem.tsx
+++ b/apps/mobile/src/components/CommonFriendsScreen/components/CommonFriendsListItem.tsx
@@ -11,9 +11,10 @@ import picturePlaceholderSvg from '../../images/picturePlaceholderSvg'
 
 interface Props {
   friend: StoredContactWithComputedValues
+  verified?: boolean
 }
 
-function CommonFriendsListItem({friend}: Props): React.ReactElement {
+function CommonFriendsListItem({friend, verified}: Props): React.ReactElement {
   const {t} = useTranslation()
   const dialFriend = useCallback(() => {
     openUrl(`tel:${friend.computedValues.normalizedNumber}`)()
@@ -40,7 +41,12 @@ function CommonFriendsListItem({friend}: Props): React.ReactElement {
         }
       />
       <Stack f={1} ml="$4" jc="space-between">
-        <Text ff="$body500" fos={18} mb="$2" col="$black">
+        <Text
+          ff="$body500"
+          fos={18}
+          mb="$2"
+          col={verified ? '$yellowAccent1' : '$black'}
+        >
           {friend.info.name}
         </Text>
         <Text ff="$body600" col="$greyOnBlack" fos={14}>

--- a/apps/mobile/src/components/CommonFriendsScreen/index.tsx
+++ b/apps/mobile/src/components/CommonFriendsScreen/index.tsx
@@ -1,13 +1,15 @@
 import {FlashList} from '@shopify/flash-list'
 import {type ClubInfo} from '@vexl-next/domain/src/general/clubs'
-import {useStore} from 'jotai'
+import {type HashedPhoneNumber} from '@vexl-next/domain/src/general/HashedPhoneNumber.brand'
+import {useAtomValue, useStore} from 'jotai'
 import React, {useMemo} from 'react'
-import {getTokens, Stack} from 'tamagui'
+import {getTokens, Stack, Text} from 'tamagui'
 import {type RootStackScreenProps} from '../../navigationTypes'
 import {useGetAllClubsForIds} from '../../state/clubs/atom/clubsWithMembersAtom'
 import createImportedContactsForHashesAtom from '../../state/contacts/atom/createImportedContactsForHashesAtom'
 import {type StoredContactWithComputedValues} from '../../state/contacts/domain'
 import {useTranslation} from '../../utils/localization/I18nProvider'
+import {showVerifiedContactsAtom} from '../../utils/preferences'
 import useSafeGoBack from '../../utils/useSafeGoBack'
 import Button from '../Button'
 import usePixelsFromBottomWhereTabsEnd from '../InsideRouter/utils'
@@ -19,19 +21,31 @@ import CommonFriendsListItem from './components/CommonFriendsListItem'
 type Props = RootStackScreenProps<'CommonFriends'>
 
 type ItemProps =
-  | {tag: 'commonFriend'; friend: StoredContactWithComputedValues}
+  | {
+      tag: 'commonFriend'
+      friend: StoredContactWithComputedValues
+      verified: boolean
+    }
   | {tag: 'club'; club: ClubInfo}
+  | {tag: 'sectionHeader'; title: string}
 
-function keyExtractor(item: ItemProps): string {
+function keyExtractor(item: ItemProps, index: number): string {
   if (item.tag === 'commonFriend') return item.friend.computedValues.hash
-
-  return item.club.uuid
+  if (item.tag === 'club') return item.club.uuid
+  return `section-header-${index}`
 }
 
 function renderItem({item}: {item: ItemProps}): React.ReactElement {
+  if (item.tag === 'sectionHeader')
+    return (
+      <Text ff="$body600" fos={14} col="$greyOnWhite" mt="$2">
+        {item.title}
+      </Text>
+    )
   if (item.tag === 'commonFriend')
-    return <CommonFriendsListItem friend={item.friend} />
-
+    return (
+      <CommonFriendsListItem friend={item.friend} verified={item.verified} />
+    )
   return <CommonClubListItem club={item.club} />
 }
 
@@ -41,33 +55,63 @@ function ItemSeparatorComponent(): React.ReactElement {
 
 function CommonFriendsScreen({
   route: {
-    params: {contactsHashes, clubsIds},
+    params: {contactsHashes, verifiedHashes, clubsIds},
   },
 }: Props): React.ReactElement {
   const {t} = useTranslation()
   const store = useStore()
   const safeGoBack = useSafeGoBack()
   const bottomOffset = usePixelsFromBottomWhereTabsEnd()
+  const showVerifiedContacts = useAtomValue(showVerifiedContactsAtom)
   const clubs = useGetAllClubsForIds(clubsIds).map((club) => ({
     tag: 'club' as const,
     club,
   }))
 
-  const commonFriends = useMemo(
+  const verifiedHashesSet = useMemo(
     () =>
-      store
-        .get(createImportedContactsForHashesAtom(contactsHashes))
-        .map((friend) => ({
-          tag: 'commonFriend' as const,
-          friend,
-        })),
-    [contactsHashes, store]
+      showVerifiedContacts
+        ? new Set(verifiedHashes ?? [])
+        : new Set<HashedPhoneNumber>(),
+    [verifiedHashes, showVerifiedContacts]
   )
 
-  const dataToDisplay = useMemo(
-    () => [...clubs, ...commonFriends],
-    [clubs, commonFriends]
-  )
+  const dataToDisplay = useMemo(() => {
+    const friends = store
+      .get(createImportedContactsForHashesAtom(contactsHashes))
+      .map((friend) => ({
+        tag: 'commonFriend' as const,
+        friend,
+        verified: verifiedHashesSet.has(friend.computedValues.hash),
+      }))
+
+    if (!showVerifiedContacts) {
+      return [...clubs, ...friends]
+    }
+
+    const verifiedFriends = friends.filter((f) => f.verified)
+    const commonFriends = friends.filter((f) => !f.verified)
+
+    const sections: ItemProps[] = [...clubs]
+
+    if (verifiedFriends.length > 0) {
+      sections.push({
+        tag: 'sectionHeader',
+        title: t('commonFriends.verifiedFriends'),
+      })
+      sections.push(...verifiedFriends)
+    }
+
+    if (commonFriends.length > 0) {
+      sections.push({
+        tag: 'sectionHeader',
+        title: t('commonFriends.commonFriends'),
+      })
+      sections.push(...commonFriends)
+    }
+
+    return sections
+  }, [clubs, contactsHashes, store, verifiedHashesSet, showVerifiedContacts, t])
 
   return (
     <Screen customHorizontalPadding={getTokens().space[1].val} bc="$white">

--- a/apps/mobile/src/components/ContactTypeAndCommonNumber.tsx
+++ b/apps/mobile/src/components/ContactTypeAndCommonNumber.tsx
@@ -16,12 +16,14 @@ function ContactTypeAndCommonNumber({
   center,
   friendLevel,
   contactsHashes,
+  verifiedHashes,
   numberOfCommonFriends,
   clubsIds,
 }: {
   friendLevel: readonly FriendLevel[]
   numberOfCommonFriends: number
   contactsHashes: readonly HashedPhoneNumber[]
+  verifiedHashes?: readonly HashedPhoneNumber[]
   center?: boolean
   clubsIds?: readonly ClubUuid[]
 }): React.ReactElement {
@@ -62,6 +64,7 @@ function ContactTypeAndCommonNumber({
             onPress={() => {
               navigation.navigate('CommonFriends', {
                 contactsHashes,
+                verifiedHashes,
                 clubsIds: clubsIds ?? [],
               })
             }}

--- a/apps/mobile/src/components/DebugScreen/components/Preferences.tsx
+++ b/apps/mobile/src/components/DebugScreen/components/Preferences.tsx
@@ -14,6 +14,7 @@ const preferencesToEdit = [
   'isDeveloper',
   'showOfferDetail',
   'runTasksInParallel',
+  'showVerifiedContacts',
 ] as const
 
 function Preferences(): React.ReactElement {

--- a/apps/mobile/src/components/DebugScreen/index.tsx
+++ b/apps/mobile/src/components/DebugScreen/index.tsx
@@ -773,6 +773,7 @@ function DebugScreen(): React.ReactElement {
                   firstLevel: [],
                   secondLevel: [],
                   commonFriends: HashMap.empty(),
+                  verifiedFriends: HashMap.empty(),
                 })
                 Alert.alert('Done')
               }}

--- a/apps/mobile/src/components/DebugScreen/utils/index.ts
+++ b/apps/mobile/src/components/DebugScreen/utils/index.ts
@@ -253,6 +253,7 @@ export async function* simulateEncrypting5000Offers() {
     toPublicKey: generatePrivateKey().publicKeyPemBase64,
     payloadPrivate: {
       commonFriends: dummyPhoneNumbers,
+      verifiedCommonFriends: [],
       friendLevel: ['SECOND_DEGREE' as const],
       symmetricKey: 'symmetricKey' as SymmetricKey,
       adminId: 'adminId' as OfferAdminId,

--- a/apps/mobile/src/components/OfferAuthorAvatar.tsx
+++ b/apps/mobile/src/components/OfferAuthorAvatar.tsx
@@ -132,6 +132,7 @@ function OfferAuthorAvatar({
             />
             <ContactTypeAndCommonNumber
               contactsHashes={offerInfo.privatePart.commonFriends}
+              verifiedHashes={offerInfo.privatePart.verifiedCommonFriends}
               friendLevel={offerInfo.privatePart.friendLevel ?? []}
               numberOfCommonFriends={commonFriends.length}
               clubsIds={offerInfo.privatePart.clubIds}

--- a/apps/mobile/src/components/OfferInfoPreview/index.tsx
+++ b/apps/mobile/src/components/OfferInfoPreview/index.tsx
@@ -117,6 +117,7 @@ function OfferInfoPreview({
         <Stack py="$2">
           <CommonFriends
             commonConnectionsHashes={offer.privatePart.commonFriends}
+            verifiedConnectionsHashes={offer.privatePart.verifiedCommonFriends}
             variant="light"
             otherSideClubs={clubsForOffer}
           />

--- a/apps/mobile/src/navigationTypes.ts
+++ b/apps/mobile/src/navigationTypes.ts
@@ -81,6 +81,7 @@ export type RootStackParamsList = {
 
   CommonFriends: {
     contactsHashes: readonly HashedPhoneNumber[]
+    verifiedHashes?: readonly HashedPhoneNumber[]
     clubsIds: readonly ClubUuid[]
   }
 

--- a/apps/mobile/src/state/chat/atoms/sendRequestActionAtom.ts
+++ b/apps/mobile/src/state/chat/atoms/sendRequestActionAtom.ts
@@ -63,6 +63,8 @@ const sendRequestActionAtom = atom(
           goldenAvatarType,
           forClubsUuids,
           commonFriends: originOffer.offerInfo.privatePart.commonFriends,
+          verifiedCommonFriends:
+            originOffer.offerInfo.privatePart.verifiedCommonFriends,
           friendLevel: originOffer.offerInfo.privatePart.friendLevel,
         })
       )

--- a/apps/mobile/src/state/connections/atom/connectionStateAtom.ts
+++ b/apps/mobile/src/state/connections/atom/connectionStateAtom.ts
@@ -10,7 +10,7 @@ import {generateUuid} from '@vexl-next/domain/src/utility/Uuid.brand'
 import {FETCH_CONNECTIONS_PAGE_SIZE} from '@vexl-next/resources-utils/src/offers/utils/fetchContactsForOffer'
 import fetchAllPaginatedData from '@vexl-next/rest-api/src/fetchAllPaginatedData'
 import {type ContactApi} from '@vexl-next/rest-api/src/services/contact'
-import {Array, Effect, flow, HashMap, Option} from 'effect'
+import {Array, Effect, HashMap, Option} from 'effect'
 import {pipe} from 'fp-ts/function'
 import {atom, type Atom} from 'jotai'
 import {apiAtom} from '../../../api'
@@ -34,6 +34,7 @@ const connectionStateAtom = atomWithParsedMmkvStorage(
     firstLevel: [],
     secondLevel: [],
     commonFriends: HashMap.empty(),
+    verifiedFriends: HashMap.empty(),
   },
   ConnectionsState
 )
@@ -138,7 +139,7 @@ export const syncConnectionsActionAtom = atom(
         set(ensureAndGetAllImportedContactsHaveServerToClientHashActionAtom)
       )
 
-      const commonFriends = yield* _(
+      const commonConnectionsData = yield* _(
         fetchAllPaginatedData({
           fetchEffectToRun: (nextPageToken) =>
             api.contact.fetchCommonConnectionsPaginated({
@@ -146,25 +147,37 @@ export const syncConnectionsActionAtom = atom(
               limit: FETCH_CONNECTIONS_PAGE_SIZE,
               nextPageToken,
             }),
-        }),
-        Effect.map(
-          flow(
-            Array.map(
-              (one) =>
-                [
-                  one.publicKey,
-                  Array.filterMap(one.common.hashes, (hash) =>
-                    HashMap.get(
-                      serverToClientHashesToHashedPhoneNumbersMap,
-                      hash
-                    )
-                  ),
-                ] as const
-            ),
-            HashMap.fromIterable
-          )
-        )
+        })
       )
+
+      const commonFriends = pipe(
+        commonConnectionsData,
+        Array.map(
+          (one) =>
+            [
+              one.publicKey,
+              Array.filterMap(one.common.hashes, (hash) =>
+                HashMap.get(serverToClientHashesToHashedPhoneNumbersMap, hash)
+              ),
+            ] as const
+        ),
+        HashMap.fromIterable
+      )
+
+      const verifiedFriends = pipe(
+        commonConnectionsData,
+        Array.map(
+          (one) =>
+            [
+              one.publicKey,
+              Array.filterMap(one.common.verifiedHashes, (hash) =>
+                HashMap.get(serverToClientHashesToHashedPhoneNumbersMap, hash)
+              ),
+            ] as const
+        ),
+        HashMap.fromIterable
+      )
+
       const lastUpdate = updateStarted
 
       void showDebugNotificationIfEnabled({
@@ -177,6 +190,7 @@ export const syncConnectionsActionAtom = atom(
         firstLevel,
         secondLevel,
         commonFriends,
+        verifiedFriends,
         lastUpdate,
       })
     }).pipe(

--- a/apps/mobile/src/state/connections/atom/offerToConnectionsAtom.ts
+++ b/apps/mobile/src/state/connections/atom/offerToConnectionsAtom.ts
@@ -301,6 +301,7 @@ export const updateAndReencryptSingleOfferConnectionActionAtom = atom(
           adminId: oneOfferConnections.adminId,
           symmetricKey: oneOfferConnections.symmetricKey,
           commonFriends: connectionState.commonFriends,
+          verifiedFriends: connectionState.verifiedFriends,
           stopProcessingAfter,
           onProgress,
           api: offerApi,

--- a/apps/mobile/src/state/connections/domain.ts
+++ b/apps/mobile/src/state/connections/domain.ts
@@ -4,13 +4,16 @@ import {ClubUuid} from '@vexl-next/domain/src/general/clubs'
 import {CommonConnectionsForUsers} from '@vexl-next/domain/src/general/contacts'
 import {OfferAdminId, SymmetricKey} from '@vexl-next/domain/src/general/offers'
 import {UnixMilliseconds} from '@vexl-next/domain/src/utility/UnixMilliseconds.brand'
-import {Schema} from 'effect'
+import {HashMap, Schema} from 'effect'
 
 export const ConnectionsState = Schema.Struct({
   lastUpdate: UnixMilliseconds,
   firstLevel: Schema.Array(Schema.Union(PublicKeyPemBase64, PublicKeyV2)),
   secondLevel: Schema.Array(Schema.Union(PublicKeyPemBase64, PublicKeyV2)),
   commonFriends: CommonConnectionsForUsers,
+  verifiedFriends: Schema.optionalWith(CommonConnectionsForUsers, {
+    default: () => HashMap.empty(),
+  }),
 })
 export type ConnectionsState = typeof ConnectionsState.Type
 

--- a/apps/mobile/src/utils/preferences/domain.ts
+++ b/apps/mobile/src/utils/preferences/domain.ts
@@ -74,6 +74,9 @@ export const Preferences = Schema.Struct({
   sendReadReceipts: Schema.optionalWith(Schema.Boolean, {
     default: () => true,
   }),
+  showVerifiedContacts: Schema.optionalWith(Schema.Boolean, {
+    default: () => false,
+  }),
 })
 
 export type Preferences = typeof Preferences.Type

--- a/apps/mobile/src/utils/preferences/index.ts
+++ b/apps/mobile/src/utils/preferences/index.ts
@@ -33,6 +33,7 @@ export const preferencesAtom = atomWithParsedMmkvStorage(
     defaultCurrency: currencies.USD.code,
     runTasksInParallel: true,
     sendReadReceipts: true,
+    showVerifiedContacts: false,
   },
   Preferences
 )
@@ -97,4 +98,8 @@ export const defaultCurrencyAtom = focusAtom(preferencesAtom, (o) =>
 
 export const sendReadReceiptsAtom = focusAtom(preferencesAtom, (o) =>
   o.prop('sendReadReceipts')
+)
+
+export const showVerifiedContactsAtom = focusAtom(preferencesAtom, (o) =>
+  o.prop('showVerifiedContacts')
 )

--- a/packages/domain/src/general/messaging.ts
+++ b/packages/domain/src/general/messaging.ts
@@ -100,6 +100,7 @@ export const ChatMessagePayload = Schema.Struct({
   lastReceivedVexlToken: Schema.optional(VexlNotificationToken),
   senderClubsUuids: Schema.optional(Schema.Array(ClubUuid)),
   commonFriends: Schema.optional(Schema.Array(HashedPhoneNumber)),
+  verifiedCommonFriends: Schema.optional(Schema.Array(HashedPhoneNumber)),
   friendLevel: Schema.optional(Schema.Array(FriendLevel)),
 })
 export type ChatMessagePayload = typeof ChatMessagePayload.Type
@@ -140,6 +141,7 @@ export const ChatMessage = Schema.Struct({
   lastReceivedVexlToken: Schema.optional(VexlNotificationToken),
   senderClubsUuids: Schema.optional(Schema.Array(ClubUuid)),
   commonFriends: Schema.optional(Schema.Array(HashedPhoneNumber)),
+  verifiedCommonFriends: Schema.optional(Schema.Array(HashedPhoneNumber)),
   friendLevel: Schema.optional(Schema.Array(FriendLevel)),
 })
 export type ChatMessage = typeof ChatMessage.Type
@@ -248,6 +250,7 @@ export const ChatMessageRequiringNewerVersion = Schema.Struct({
   myVexlToken: Schema.optional(VexlNotificationToken),
   lastReceivedVexlToken: Schema.optional(VexlNotificationToken),
   commonFriends: Schema.optional(Schema.Array(HashedPhoneNumber)),
+  verifiedCommonFriends: Schema.optional(Schema.Array(HashedPhoneNumber)),
   friendLevel: Schema.optional(Schema.Array(FriendLevel)),
 })
 export type ChatMessageRequiringNewerVersion =

--- a/packages/domain/src/general/offers.ts
+++ b/packages/domain/src/general/offers.ts
@@ -135,6 +135,9 @@ export type PrivatePartRecordId = typeof PrivatePartRecordId.Type
 
 export const OfferPrivatePart = Schema.Struct({
   commonFriends: Schema.Array(HashedPhoneNumber),
+  verifiedCommonFriends: Schema.optionalWith(Schema.Array(HashedPhoneNumber), {
+    default: () => [],
+  }),
   friendLevel: Schema.Array(FriendLevel),
   symmetricKey: SymmetricKey,
   clubIds: Schema.optionalWith(Schema.Array(ClubUuid), {

--- a/packages/localization/ar-base.json
+++ b/packages/localization/ar-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Uploading offer",
   "progressBar.DONE": "Done",
   "commonFriends.commonFriends": "Common friends",
+  "commonFriends.verifiedFriends": "Verified friends",
   "commonFriends.call": "Call",
   "reportIssue.openInEmail": "Open in e-mail",
   "reportIssue.somethingWentWrong": "Something went wrong?",

--- a/packages/localization/base.json
+++ b/packages/localization/base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Uploading offer",
   "progressBar.DONE": "Done",
   "commonFriends.commonFriends": "Common friends",
+  "commonFriends.verifiedFriends": "Verified friends",
   "commonFriends.call": "Call",
   "reportIssue.openInEmail": "Open in e-mail",
   "reportIssue.somethingWentWrong": "Something went wrong?",

--- a/packages/localization/bg-base.json
+++ b/packages/localization/bg-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Качване на оферта",
   "progressBar.DONE": "Готово",
   "commonFriends.commonFriends": "Общи приятели",
+  "commonFriends.verifiedFriends": "Потвърдени приятели",
   "commonFriends.call": "Обади се",
   "reportIssue.openInEmail": "Отвори в електронна поща",
   "reportIssue.somethingWentWrong": "Възникна грешка?",

--- a/packages/localization/cs-base.json
+++ b/packages/localization/cs-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Odesílání nabídky",
   "progressBar.DONE": "Hotovo",
   "commonFriends.commonFriends": "Společní přátelé",
+  "commonFriends.verifiedFriends": "Ověření přátelé",
   "commonFriends.call": "Volat",
   "reportIssue.openInEmail": "Otevřít v emailu",
   "reportIssue.somethingWentWrong": "Něco se pokazilo?",

--- a/packages/localization/de-base.json
+++ b/packages/localization/de-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Angebot hochladen",
   "progressBar.DONE": "Fertig",
   "commonFriends.commonFriends": "Gemeinsame Freunde",
+  "commonFriends.verifiedFriends": "Verifizierte Freunde",
   "commonFriends.call": "Anrufen",
   "reportIssue.openInEmail": "In E-Mail öffnen",
   "reportIssue.somethingWentWrong": "Ein Fehler ist aufgetreten?",

--- a/packages/localization/en-base.json
+++ b/packages/localization/en-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Uploading offer",
   "progressBar.DONE": "Done",
   "commonFriends.commonFriends": "Common friends",
+  "commonFriends.verifiedFriends": "Verified friends",
   "commonFriends.call": "Call",
   "reportIssue.openInEmail": "Open in e-mail",
   "reportIssue.somethingWentWrong": "Something went wrong?",

--- a/packages/localization/es-base.json
+++ b/packages/localization/es-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Cargando la oferta",
   "progressBar.DONE": "Hecho",
   "commonFriends.commonFriends": "Amigos comunes",
+  "commonFriends.verifiedFriends": "Amigos verificados",
   "commonFriends.call": "Llamar",
   "reportIssue.openInEmail": "Abrir en e-mail",
   "reportIssue.somethingWentWrong": "¿Algo salió mal?",

--- a/packages/localization/fa-base.json
+++ b/packages/localization/fa-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Uploading offer",
   "progressBar.DONE": "Done",
   "commonFriends.commonFriends": "Common friends",
+  "commonFriends.verifiedFriends": "Verified friends",
   "commonFriends.call": "Call",
   "reportIssue.openInEmail": "Open in e-mail",
   "reportIssue.somethingWentWrong": "Something went wrong?",

--- a/packages/localization/fi-base.json
+++ b/packages/localization/fi-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Uploading offer",
   "progressBar.DONE": "Done",
   "commonFriends.commonFriends": "Common friends",
+  "commonFriends.verifiedFriends": "Verified friends",
   "commonFriends.call": "Call",
   "reportIssue.openInEmail": "Open in e-mail",
   "reportIssue.somethingWentWrong": "Something went wrong?",

--- a/packages/localization/fr-base.json
+++ b/packages/localization/fr-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Téléchargement de l'offre",
   "progressBar.DONE": "Terminé",
   "commonFriends.commonFriends": "Amis communs",
+  "commonFriends.verifiedFriends": "Amis vérifiés",
   "commonFriends.call": "Appel",
   "reportIssue.openInEmail": "Ouvrir dans un e-mail",
   "reportIssue.somethingWentWrong": "Un problème s'est produit",

--- a/packages/localization/id-base.json
+++ b/packages/localization/id-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Uploading offer",
   "progressBar.DONE": "Done",
   "commonFriends.commonFriends": "Common friends",
+  "commonFriends.verifiedFriends": "Verified friends",
   "commonFriends.call": "Call",
   "reportIssue.openInEmail": "Open in e-mail",
   "reportIssue.somethingWentWrong": "Something went wrong?",

--- a/packages/localization/it-base.json
+++ b/packages/localization/it-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Caricamento dell'offerta",
   "progressBar.DONE": "Fatto",
   "commonFriends.commonFriends": "Amici comuni",
+  "commonFriends.verifiedFriends": "Amici verificati",
   "commonFriends.call": "Chiama",
   "reportIssue.openInEmail": "Aprire in un'e-mail",
   "reportIssue.somethingWentWrong": "Qualcosa è andato storto",

--- a/packages/localization/ja-base.json
+++ b/packages/localization/ja-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "オファーをアップロード中",
   "progressBar.DONE": "完了",
   "commonFriends.commonFriends": "共通の友達",
+  "commonFriends.verifiedFriends": "認証済みの友達",
   "commonFriends.call": "通話",
   "reportIssue.openInEmail": "メールで開く",
   "reportIssue.somethingWentWrong": "問題が発生しました?",

--- a/packages/localization/nl-base.json
+++ b/packages/localization/nl-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Aanbieding uploaden",
   "progressBar.DONE": "Gereed",
   "commonFriends.commonFriends": "Gemeenschappelijke vrienden",
+  "commonFriends.verifiedFriends": "Geverifieerde vrienden",
   "commonFriends.call": "Oproep",
   "reportIssue.openInEmail": "Openen via e-mail",
   "reportIssue.somethingWentWrong": "Is er iets misgegaan?",

--- a/packages/localization/no-base.json
+++ b/packages/localization/no-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Uploading offer",
   "progressBar.DONE": "Done",
   "commonFriends.commonFriends": "Common friends",
+  "commonFriends.verifiedFriends": "Verified friends",
   "commonFriends.call": "Call",
   "reportIssue.openInEmail": "Open in e-mail",
   "reportIssue.somethingWentWrong": "Something went wrong?",

--- a/packages/localization/pcm-base.json
+++ b/packages/localization/pcm-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Uploading offer",
   "progressBar.DONE": "Done",
   "commonFriends.commonFriends": "Common friends",
+  "commonFriends.verifiedFriends": "Verified friends",
   "commonFriends.call": "Call",
   "reportIssue.openInEmail": "Open in e-mail",
   "reportIssue.somethingWentWrong": "Something went wrong?",

--- a/packages/localization/pl-base.json
+++ b/packages/localization/pl-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Wysyłam ofertę",
   "progressBar.DONE": "Gotowe",
   "commonFriends.commonFriends": "Wspólni znajomi",
+  "commonFriends.verifiedFriends": "Zweryfikowani znajomi",
   "commonFriends.call": "Zadzwoń",
   "reportIssue.openInEmail": "Otwórz w wiadomości e-mail",
   "reportIssue.somethingWentWrong": "Coś poszło nie tak?",

--- a/packages/localization/pt-base.json
+++ b/packages/localization/pt-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Carregar oferta",
   "progressBar.DONE": "Concluído",
   "commonFriends.commonFriends": "Amigos comuns",
+  "commonFriends.verifiedFriends": "Amigos verificados",
   "commonFriends.call": "Ligar",
   "reportIssue.openInEmail": "Abrir no correio eletrónico",
   "reportIssue.somethingWentWrong": "Algo correu mal",

--- a/packages/localization/sk-base.json
+++ b/packages/localization/sk-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Odosielanie ponuky",
   "progressBar.DONE": "Hotovo",
   "commonFriends.commonFriends": "Spoloční priatelia",
+  "commonFriends.verifiedFriends": "Overení priatelia",
   "commonFriends.call": "Volať",
   "reportIssue.openInEmail": "Otvoriť v emaili",
   "reportIssue.somethingWentWrong": "Niečo sa pokazilo?",

--- a/packages/localization/sv-base.json
+++ b/packages/localization/sv-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Uploading offer",
   "progressBar.DONE": "Done",
   "commonFriends.commonFriends": "Common friends",
+  "commonFriends.verifiedFriends": "Verified friends",
   "commonFriends.call": "Call",
   "reportIssue.openInEmail": "Open in e-mail",
   "reportIssue.somethingWentWrong": "Something went wrong?",

--- a/packages/localization/sw-base.json
+++ b/packages/localization/sw-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Inapakia ofa",
   "progressBar.DONE": "Imemalizika",
   "commonFriends.commonFriends": "Marafiki wa kawaida",
+  "commonFriends.verifiedFriends": "Marafiki waliothibitishwa",
   "commonFriends.call": "Piga simu",
   "reportIssue.openInEmail": "Fungua kwenye barua pepe",
   "reportIssue.somethingWentWrong": "Kuna tatizo?",

--- a/packages/localization/tr-base.json
+++ b/packages/localization/tr-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Uploading offer",
   "progressBar.DONE": "Done",
   "commonFriends.commonFriends": "Common friends",
+  "commonFriends.verifiedFriends": "Verified friends",
   "commonFriends.call": "Call",
   "reportIssue.openInEmail": "Open in e-mail",
   "reportIssue.somethingWentWrong": "Something went wrong?",

--- a/packages/localization/uk-base.json
+++ b/packages/localization/uk-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "Uploading offer",
   "progressBar.DONE": "Done",
   "commonFriends.commonFriends": "Common friends",
+  "commonFriends.verifiedFriends": "Verified friends",
   "commonFriends.call": "Call",
   "reportIssue.openInEmail": "Open in e-mail",
   "reportIssue.somethingWentWrong": "Something went wrong?",

--- a/packages/localization/zh-base.json
+++ b/packages/localization/zh-base.json
@@ -847,6 +847,7 @@
   "progressBar.SENDING_OFFER_TO_NETWORK": "正在上传报价",
   "progressBar.DONE": "完成",
   "commonFriends.commonFriends": "共同好友",
+  "commonFriends.verifiedFriends": "已验证好友",
   "commonFriends.call": "拨号",
   "reportIssue.openInEmail": "在电子邮件中打开",
   "reportIssue.somethingWentWrong": "出了什么问题吗？",

--- a/packages/resources-utils/src/chat/sendMessagingRequest.ts
+++ b/packages/resources-utils/src/chat/sendMessagingRequest.ts
@@ -41,6 +41,7 @@ function createRequestChatMessage({
   goldenAvatarType,
   senderClubsUuids,
   commonFriends,
+  verifiedCommonFriends,
   friendLevel,
 }: {
   text: string
@@ -51,6 +52,7 @@ function createRequestChatMessage({
   goldenAvatarType?: GoldenAvatarType
   senderClubsUuids: readonly ClubUuid[]
   commonFriends?: readonly HashedPhoneNumber[]
+  verifiedCommonFriends?: readonly HashedPhoneNumber[]
   friendLevel?: readonly FriendLevel[]
 }): ChatMessage {
   return {
@@ -65,6 +67,7 @@ function createRequestChatMessage({
     goldenAvatarType,
     senderClubsUuids,
     commonFriends,
+    verifiedCommonFriends,
     friendLevel,
   }
 }
@@ -87,6 +90,7 @@ export function sendMessagingRequest({
   goldenAvatarType,
   forClubsUuids,
   commonFriends,
+  verifiedCommonFriends,
   friendLevel,
 }: {
   text: string
@@ -102,6 +106,7 @@ export function sendMessagingRequest({
   goldenAvatarType?: GoldenAvatarType
   forClubsUuids: readonly ClubUuid[]
   commonFriends?: readonly HashedPhoneNumber[]
+  verifiedCommonFriends?: readonly HashedPhoneNumber[]
   friendLevel?: readonly FriendLevel[]
 }): Effect.Effect<
   ChatMessage,
@@ -124,6 +129,7 @@ export function sendMessagingRequest({
       goldenAvatarType,
       senderClubsUuids: forClubsUuids,
       commonFriends,
+      verifiedCommonFriends,
       friendLevel,
     })
 

--- a/packages/resources-utils/src/chat/utils/chatMessageVerifiedCommonFriends.test.ts
+++ b/packages/resources-utils/src/chat/utils/chatMessageVerifiedCommonFriends.test.ts
@@ -1,0 +1,58 @@
+import {generatePrivateKey} from '@vexl-next/cryptography/src/KeyHolder'
+import {HashedPhoneNumber} from '@vexl-next/domain/src/general/HashedPhoneNumber.brand'
+import {
+  ChatMessage,
+  MessageCypher,
+  ServerMessage,
+  generateChatMessageId,
+} from '@vexl-next/domain/src/general/messaging'
+import {SemverString} from '@vexl-next/domain/src/utility/SmeverString.brand'
+import {now} from '@vexl-next/domain/src/utility/UnixMilliseconds.brand'
+import {Either, Schema} from 'effect'
+import * as E from 'fp-ts/Either'
+import {parseChatMessage} from './parseChatMessage'
+import serializeChatMessage from './serializeChatMessage'
+
+it('preserves verified common friends in request messaging payloads', () => {
+  const senderKeyPair = generatePrivateKey()
+  const commonFriend = Schema.decodeSync(HashedPhoneNumber)('common-friend')
+  const verifiedCommonFriend = Schema.decodeSync(HashedPhoneNumber)(
+    'verified-common-friend'
+  )
+  const appVersion = Schema.decodeSync(SemverString)('1.0.0')
+
+  const message = Schema.decodeSync(ChatMessage)({
+    uuid: generateChatMessageId(),
+    text: 'hello',
+    time: now(),
+    senderPublicKey: senderKeyPair.publicKeyPemBase64,
+    messageType: 'REQUEST_MESSAGING',
+    myVersion: appVersion,
+    commonFriends: [commonFriend],
+    verifiedCommonFriends: [verifiedCommonFriend],
+    friendLevel: ['SECOND_DEGREE'],
+  })
+
+  const serialized = serializeChatMessage(message)
+
+  expect(Either.isRight(serialized)).toBe(true)
+  if (!Either.isRight(serialized)) {
+    throw new Error(`Failed to serialize message: ${serialized.left._tag}`)
+  }
+
+  const parsed = parseChatMessage({
+    appVersion,
+    serverMessage: Schema.decodeSync(ServerMessage)({
+      message: Schema.decodeSync(MessageCypher)('request-message-cypher'),
+      senderPublicKey: senderKeyPair.publicKeyPemBase64,
+    }),
+  })(serialized.right)
+
+  expect(E.isRight(parsed)).toBe(true)
+  if (!E.isRight(parsed)) {
+    throw new Error(`Failed to parse message: ${parsed.left._tag}`)
+  }
+
+  expect(parsed.right.commonFriends).toEqual([commonFriend])
+  expect(parsed.right.verifiedCommonFriends).toEqual([verifiedCommonFriend])
+})

--- a/packages/resources-utils/src/chat/utils/parseChatMessage.ts
+++ b/packages/resources-utils/src/chat/utils/parseChatMessage.ts
@@ -164,6 +164,7 @@ export function chatMessagePayloadToChatMessage(
     lastReceivedFcmCypher: payload.lastReceivedFcmCypher,
     senderClubsUuids: payload.senderClubsUuids,
     commonFriends: payload.commonFriends,
+    verifiedCommonFriends: payload.verifiedCommonFriends,
     friendLevel: payload.friendLevel,
   })
 }

--- a/packages/resources-utils/src/chat/utils/serializeChatMessage.ts
+++ b/packages/resources-utils/src/chat/utils/serializeChatMessage.ts
@@ -59,6 +59,7 @@ export default function serializeChatMessage(
       lastReceivedFcmCypher: message.lastReceivedFcmCypher,
       senderClubsUuids: message.senderClubsUuids,
       commonFriends: message.commonFriends,
+      verifiedCommonFriends: message.verifiedCommonFriends,
       friendLevel: message.friendLevel,
     } satisfies ChatMessagePayload,
     Schema.decodeUnknownEither(ChatMessagePayload),

--- a/packages/resources-utils/src/offers/constructPrivatePayloadForOwner.ts
+++ b/packages/resources-utils/src/offers/constructPrivatePayloadForOwner.ts
@@ -37,6 +37,7 @@ export function constructPrivatePayloadForOwner({
       ownerKeyPairV2?.publicKey ?? ownerCredentials.publicKeyPemBase64,
     payloadPrivate: {
       commonFriends: [],
+      verifiedCommonFriends: [],
       clubIds: [],
       friendLevel: [],
       symmetricKey,

--- a/packages/resources-utils/src/offers/updatePrivateParts.ts
+++ b/packages/resources-utils/src/offers/updatePrivateParts.ts
@@ -188,6 +188,7 @@ export default function updatePrivateParts({
   currentConnections,
   targetConnections,
   commonFriends,
+  verifiedFriends,
   adminId,
   symmetricKey,
   stopProcessingAfter,
@@ -211,6 +212,7 @@ export default function updatePrivateParts({
     >
   }
   commonFriends: CommonConnectionsForUsers
+  verifiedFriends: CommonConnectionsForUsers
   adminId: OfferAdminId
   symmetricKey: SymmetricKey
   stopProcessingAfter?: UnixMilliseconds
@@ -314,6 +316,7 @@ export default function updatePrivateParts({
           firstDegreeConnections: newFirstLevelConnections,
           secondDegreeConnections: newSecondLevelConnections ?? [],
           commonFriends,
+          verifiedFriends,
           clubsConnections: newClubsConnections,
         },
         symmetricKey,

--- a/packages/resources-utils/src/offers/utils/constructPrivatePayloads.ts
+++ b/packages/resources-utils/src/offers/utils/constructPrivatePayloads.ts
@@ -52,6 +52,7 @@ export default function constructPrivatePayloads({
     firstDegreeConnections,
     secondDegreeConnections,
     commonFriends,
+    verifiedFriends,
     clubsConnections,
   },
   symmetricKey,
@@ -117,10 +118,19 @@ export default function constructPrivatePayloads({
           )
         })()
 
+        const verifiedFriendsToPayload = (() => {
+          if (isFromClub) return []
+          return Option.getOrElse(
+            HashMap.get(verifiedFriends, toPublicKey),
+            () => []
+          )
+        })()
+
         return {
           toPublicKey,
           payloadPrivate: {
             commonFriends: commonFriendsToPayload,
+            verifiedCommonFriends: verifiedFriendsToPayload,
             friendLevel: Array.fromIterable(friendLevelValue) ?? [],
             symmetricKey,
             clubIds: clubIdForKey,

--- a/packages/resources-utils/src/offers/utils/fetchContactsForOffer.ts
+++ b/packages/resources-utils/src/offers/utils/fetchContactsForOffer.ts
@@ -13,7 +13,7 @@ import {type IntendedConnectionLevel} from '@vexl-next/domain/src/general/offers
 import {type ServerToClientHashedNumber} from '@vexl-next/domain/src/general/ServerToClientHashedNumber'
 import fetchAllPaginatedData from '@vexl-next/rest-api/src/fetchAllPaginatedData'
 import {type ContactApi} from '@vexl-next/rest-api/src/services/contact'
-import {Array, Effect, flow, HashMap, pipe, Record} from 'effect'
+import {Array, Effect, HashMap, pipe, Record} from 'effect'
 
 export const FETCH_CONNECTIONS_PAGE_SIZE = 500
 
@@ -21,6 +21,7 @@ export interface ConnectionsInfoForOffer {
   firstDegreeConnections: Array<PublicKeyPemBase64 | PublicKeyV2>
   secondDegreeConnections: Array<PublicKeyPemBase64 | PublicKeyV2>
   commonFriends: CommonConnectionsForUsers
+  verifiedFriends: CommonConnectionsForUsers
   clubsConnections: Record<
     ClubUuid,
     ReadonlyArray<PublicKeyPemBase64 | PublicKeyV2>
@@ -76,7 +77,7 @@ export default function fetchContactsForOffer({
             })
           )
 
-    const commonFriends = yield* _(
+    const commonConnectionsData = yield* _(
       fetchAllPaginatedData({
         fetchEffectToRun: (nextPageToken) =>
           contactApi.fetchCommonConnectionsPaginated({
@@ -87,21 +88,35 @@ export default function fetchContactsForOffer({
             nextPageToken,
             limit: FETCH_CONNECTIONS_PAGE_SIZE,
           }),
-      }),
-      Effect.map(
-        flow(
-          Array.map(
-            (one) =>
-              [
-                one.publicKey,
-                Array.filterMap(one.common.hashes, (hash) =>
-                  HashMap.get(serverToClientHashesToHashedPhoneNumbersMap, hash)
-                ),
-              ] as const
-          ),
-          HashMap.fromIterable
-        )
-      )
+      })
+    )
+
+    const commonFriends = pipe(
+      commonConnectionsData,
+      Array.map(
+        (one) =>
+          [
+            one.publicKey,
+            Array.filterMap(one.common.hashes, (hash) =>
+              HashMap.get(serverToClientHashesToHashedPhoneNumbersMap, hash)
+            ),
+          ] as const
+      ),
+      HashMap.fromIterable
+    )
+
+    const verifiedFriends = pipe(
+      commonConnectionsData,
+      Array.map(
+        (one) =>
+          [
+            one.publicKey,
+            Array.filterMap(one.common.verifiedHashes, (hash) =>
+              HashMap.get(serverToClientHashesToHashedPhoneNumbersMap, hash)
+            ),
+          ] as const
+      ),
+      HashMap.fromIterable
     )
 
     const clubsConnections = yield* _(
@@ -128,6 +143,7 @@ export default function fetchContactsForOffer({
       firstDegreeConnections,
       secondDegreeConnections,
       commonFriends,
+      verifiedFriends,
       clubsConnections,
     } satisfies ConnectionsInfoForOffer
   })

--- a/packages/rest-api/src/services/contact/contracts.ts
+++ b/packages/rest-api/src/services/contact/contracts.ts
@@ -67,6 +67,7 @@ const CommonConnectionsForUserFromApi = Schema.Struct({
   publicKey: Schema.Union(PublicKeyPemBase64, PublicKeyV2),
   common: Schema.Struct({
     hashes: Schema.Array(ServerToClientHashedNumber),
+    verifiedHashes: Schema.Array(ServerToClientHashedNumber),
   }),
 })
 


### PR DESCRIPTION
## Summary

Introduces **Trusted Contacts** — a new subset of Common Contacts that indicates stronger social proof between trading parties.

### Concept

- **Common Contacts**: `me → someone ← offer creator` — both parties have imported the same contact into their phone book.
- **Trusted Contacts**: `me ↔ someone ↔ offer creator` — the common contact has **also** imported both parties (bidirectional relationship). This means the intermediary knows both sides personally, providing stronger trust signal.

### Changes

**Backend (contact-service)**
- Extended the SQL query in `fetchCommonConnectionsPaginated` with two LEFT JOINs to detect reverse relationships, using `COALESCE(array_agg(DISTINCT ...) FILTER (...), ARRAY[]::VARCHAR[])` for conditional aggregation
- Added `trustedHashes` field to the API response contract (`CommonConnectionsForUserFromApi`)
- Hashes trusted contacts for the client in the route handler
- Added 3 tests covering: fully bidirectional networks, asymmetric contacts, and mixed scenarios

**Domain & Data Pipeline**
- Added `trustedCommonFriends` to `OfferPrivatePart` (optional with default `[]` for backward compatibility)
- Added `trustedFriends` HashMap to `ConnectionsState`
- Updated `fetchContactsForOffer` to extract trusted hashes into a separate HashMap
- Updated `constructPrivatePayloads` and `updatePrivateParts` to include trusted friends in offer payloads

**Mobile App UI**
- All screens showing common friends now support trusted contacts:
  - `CommonFriends` component (offer details)
  - `CommonFriendsScreen` (full list view)
  - `ChatRequestPreview` (chat request)
  - `OtherSideNamePhotoAndInfo` (chat detail)
  - `OfferAuthorAvatar` (offer card)
  - `ContactTypeAndCommonNumber` (shared component)
- Trusted contacts are sorted first in all lists
- Trusted contacts are displayed in gold (`$yellowAccent1`) instead of gray

## Test plan

- [x] All 12 contact-service tests pass (including 3 new trusted contacts tests)
- [x] Typecheck passes (`yarn turbo:typecheck`)
- [x] Lint passes (`yarn turbo:lint`)
- [x] Format passes (`yarn turbo:format`)
- [x] Manual verification: trusted contacts appear first and in gold in offer details, chat request preview, chat detail, and common friends list screen