### PR TITLE
[codex] Fix high-risk security scan findings

### DIFF
--- a/apps/backoffice-app/app/api/proxy/[...path]/route.ts
+++ b/apps/backoffice-app/app/api/proxy/[...path]/route.ts
@@ -30,6 +30,27 @@ const truncateForLog = (value: string): string =>
     ? `${value.slice(0, MAX_ERROR_BODY_LOG_LENGTH)}...[truncated]`
     : value
 
+const ABSOLUTE_URL_SCHEME_REGEX = /^[a-z][a-z0-9+.-]*:/i
+
+const buildBackendUrl = (path: string): URL | undefined => {
+  if (
+    !path ||
+    path.startsWith('/') ||
+    path.startsWith('//') ||
+    ABSOLUTE_URL_SCHEME_REGEX.test(path)
+  ) {
+    return undefined
+  }
+
+  const backendUrl = new URL(getBackendUrl(path))
+  const backendBasePath = backendUrl.pathname.endsWith('/')
+    ? backendUrl.pathname.slice(0, -1)
+    : backendUrl.pathname
+
+  backendUrl.pathname = `${backendBasePath}/${path}`
+  return backendUrl
+}
+
 async function proxyRequest(request: NextRequest, method: string) {
   const startedAt = Date.now()
   const requestId = getRequestId(request)
@@ -40,7 +61,11 @@ async function proxyRequest(request: NextRequest, method: string) {
     const backendBaseUrl = getBackendUrl(path)
 
     // Build the backend URL
-    const backendUrl = new URL(`${path}`, backendBaseUrl)
+    const backendUrl = buildBackendUrl(path)
+
+    if (!backendUrl) {
+      return NextResponse.json({error: 'Invalid proxy path'}, {status: 400})
+    }
 
     // Copy non-admin query params from the original request.
     request.nextUrl.searchParams.forEach((value, key) => {

--- a/apps/backoffice-app/app/api/proxy/[...path]/route.ts
+++ b/apps/backoffice-app/app/api/proxy/[...path]/route.ts
@@ -33,12 +33,7 @@ const truncateForLog = (value: string): string =>
 const ABSOLUTE_URL_SCHEME_REGEX = /^[a-z][a-z0-9+.-]*:/i
 
 const buildBackendUrl = (path: string): URL | undefined => {
-  if (
-    !path ||
-    path.startsWith('/') ||
-    path.startsWith('//') ||
-    ABSOLUTE_URL_SCHEME_REGEX.test(path)
-  ) {
+  if (!path || path.startsWith('/') || ABSOLUTE_URL_SCHEME_REGEX.test(path)) {
     return undefined
   }
 

--- a/apps/backoffice-app/app/api/upload-to-s3/route.ts
+++ b/apps/backoffice-app/app/api/upload-to-s3/route.ts
@@ -11,7 +11,26 @@ export const runtime = 'nodejs'
 const CLUB_IMAGE_PATH_REGEX =
   /(^|\/)clubs\/[0-9a-f-]+\.jpe?g$|(^|\/)clubs\/[0-9a-f-]+\.png$/i
 
-const isAllowedS3Host = (hostname: string): boolean => {
+const SLIDESHOW_ASSET_PATH_REGEX =
+  /(^|\/)backoffice\/slideshows\/[0-9a-f-]+\/[0-9a-f-]+\.(jpe?g|png|webp|mp4|webm)$/i
+
+const getConfiguredS3Endpoint = (): URL | undefined => {
+  const configuredEndpoint = process.env.S3_ENDPOINT
+
+  if (!configuredEndpoint) return undefined
+
+  try {
+    return new URL(configuredEndpoint)
+  } catch {
+    return undefined
+  }
+}
+
+const isAllowedS3Host = (
+  url: URL,
+  configuredEndpoint: URL | undefined
+): boolean => {
+  const hostname = url.hostname
   const host = hostname.toLowerCase()
 
   return (
@@ -19,18 +38,38 @@ const isAllowedS3Host = (hostname: string): boolean => {
     (host.endsWith('.amazonaws.com') &&
       (host.startsWith('s3.') ||
         host.includes('.s3.') ||
-        host.includes('.s3-')))
+        host.includes('.s3-'))) ||
+    (configuredEndpoint !== undefined &&
+      url.protocol === configuredEndpoint.protocol &&
+      host === configuredEndpoint.hostname.toLowerCase())
   )
 }
+
+const isAllowedS3Path = (pathname: string): boolean => {
+  return (
+    CLUB_IMAGE_PATH_REGEX.test(pathname) ||
+    SLIDESHOW_ASSET_PATH_REGEX.test(pathname)
+  )
+}
+
+const isAllowedS3Protocol = (
+  url: URL,
+  configuredEndpoint: URL | undefined
+): boolean =>
+  url.protocol === 'https:' ||
+  (configuredEndpoint !== undefined &&
+    url.protocol === configuredEndpoint.protocol &&
+    url.hostname.toLowerCase() === configuredEndpoint.hostname.toLowerCase())
 
 const parsePresignedS3Url = (presignedUrl: string): URL | undefined => {
   try {
     const url = new URL(presignedUrl)
+    const configuredEndpoint = getConfiguredS3Endpoint()
 
     if (
-      url.protocol !== 'https:' ||
-      !isAllowedS3Host(url.hostname) ||
-      !CLUB_IMAGE_PATH_REGEX.test(url.pathname) ||
+      !isAllowedS3Protocol(url, configuredEndpoint) ||
+      !isAllowedS3Host(url, configuredEndpoint) ||
+      !isAllowedS3Path(url.pathname) ||
       !url.searchParams.has('X-Amz-Credential') ||
       !url.searchParams.has('X-Amz-Signature')
     ) {

--- a/apps/backoffice-app/app/api/upload-to-s3/route.ts
+++ b/apps/backoffice-app/app/api/upload-to-s3/route.ts
@@ -8,6 +8,41 @@ import {type NextRequest, NextResponse} from 'next/server'
 
 export const runtime = 'nodejs'
 
+const CLUB_IMAGE_PATH_REGEX =
+  /(^|\/)clubs\/[0-9a-f-]+\.jpe?g$|(^|\/)clubs\/[0-9a-f-]+\.png$/i
+
+const isAllowedS3Host = (hostname: string): boolean => {
+  const host = hostname.toLowerCase()
+
+  return (
+    host === 's3.amazonaws.com' ||
+    (host.endsWith('.amazonaws.com') &&
+      (host.startsWith('s3.') ||
+        host.includes('.s3.') ||
+        host.includes('.s3-')))
+  )
+}
+
+const parsePresignedS3Url = (presignedUrl: string): URL | undefined => {
+  try {
+    const url = new URL(presignedUrl)
+
+    if (
+      url.protocol !== 'https:' ||
+      !isAllowedS3Host(url.hostname) ||
+      !CLUB_IMAGE_PATH_REGEX.test(url.pathname) ||
+      !url.searchParams.has('X-Amz-Credential') ||
+      !url.searchParams.has('X-Amz-Signature')
+    ) {
+      return undefined
+    }
+
+    return url
+  } catch {
+    return undefined
+  }
+}
+
 export async function PUT(request: NextRequest) {
   try {
     const authError = await requireAdmin(request)
@@ -20,11 +55,17 @@ export async function PUT(request: NextRequest) {
       return badRequest('Missing presigned URL')
     }
 
+    const s3Url = parsePresignedS3Url(presignedUrl)
+
+    if (!s3Url) {
+      return NextResponse.json({error: 'Invalid presigned URL'}, {status: 400})
+    }
+
     // Get the file data from the request
     const fileData = await request.arrayBuffer()
 
     // Upload to S3 using the presigned URL
-    const uploadResponse = await fetch(presignedUrl, {
+    const uploadResponse = await fetch(s3Url.toString(), {
       method: 'PUT',
       body: fileData,
       headers: {

--- a/apps/mobile/src/state/session/index.ts
+++ b/apps/mobile/src/state/session/index.ts
@@ -13,6 +13,10 @@ import {
 import {focusAtom} from 'jotai-optics'
 import {type SessionV2} from '../../brands/Session.brand'
 import getValueFromSetStateActionOfAtom from '../../utils/atomUtils/getValueFromSetStateActionOfAtom'
+import {
+  makeErrorJsonWithRemovedSensitiveData,
+  makeErrorWithRemovedSensitiveData,
+} from '../../utils/errorSanitization'
 import {replaceAll} from '../../utils/replaceAll'
 import {dummySession} from './dummySesssion'
 import writeSessionToStorage, {
@@ -50,33 +54,11 @@ function toJsonWithRemovedSensitiveData(object: any): string {
   }
 }
 
-const errorToPlainObject = (
-  error: Error,
-  depth: number = 0
-): Record<string, unknown> => {
-  if (depth > 4) return {message: '[[truncated]]'}
+const toErrorWithRemovedSensitiveData =
+  makeErrorWithRemovedSensitiveData(removeSensitiveData)
 
-  return {
-    name: error.name,
-    message: error.message,
-    stack: error.stack,
-    cause:
-      error.cause instanceof Error
-        ? errorToPlainObject(error.cause, depth + 1)
-        : error.cause,
-  }
-}
-
-function toErrorWithRemovedSensitiveData(error: Error): Error {
-  const strippedError = new Error(removeSensitiveData(error.message))
-  strippedError.name = error.name
-  if (error.stack) strippedError.stack = removeSensitiveData(error.stack)
-  return strippedError
-}
-
-function toErrorJsonWithRemovedSensitiveData(error: Error): string {
-  return toJsonWithRemovedSensitiveData(errorToPlainObject(error))
-}
+const toErrorJsonWithRemovedSensitiveData =
+  makeErrorJsonWithRemovedSensitiveData(toJsonWithRemovedSensitiveData)
 
 export function toExtraWithRemovedSensitiveData(
   extra: Record<string, unknown>

--- a/apps/mobile/src/state/session/index.ts
+++ b/apps/mobile/src/state/session/index.ts
@@ -50,6 +50,34 @@ function toJsonWithRemovedSensitiveData(object: any): string {
   }
 }
 
+const errorToPlainObject = (
+  error: Error,
+  depth: number = 0
+): Record<string, unknown> => {
+  if (depth > 4) return {message: '[[truncated]]'}
+
+  return {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+    cause:
+      error.cause instanceof Error
+        ? errorToPlainObject(error.cause, depth + 1)
+        : error.cause,
+  }
+}
+
+function toErrorWithRemovedSensitiveData(error: Error): Error {
+  const strippedError = new Error(removeSensitiveData(error.message))
+  strippedError.name = error.name
+  if (error.stack) strippedError.stack = removeSensitiveData(error.stack)
+  return strippedError
+}
+
+function toErrorJsonWithRemovedSensitiveData(error: Error): string {
+  return toJsonWithRemovedSensitiveData(errorToPlainObject(error))
+}
+
 export function toExtraWithRemovedSensitiveData(
   extra: Record<string, unknown>
 ): Record<string, string> {
@@ -57,21 +85,25 @@ export function toExtraWithRemovedSensitiveData(
     return {
       ...acc,
       [key]:
-        // Keep errors to get stacktrace
-        value instanceof Error ? value : toJsonWithRemovedSensitiveData(value),
+        value instanceof Error
+          ? toErrorJsonWithRemovedSensitiveData(value)
+          : toJsonWithRemovedSensitiveData(value),
     }
   }, {})
 }
 
 function reportError(error: Error, extra: Record<string, unknown>): void {
+  const strippedError = toErrorWithRemovedSensitiveData(error)
+  const strippedExtra = toExtraWithRemovedSensitiveData(extra)
+
   // We can not use reportError method because of circular require
   if (!__DEV__) {
-    captureException(error, {
+    captureException(strippedError, {
       level: 'error',
-      extra: extra ? toExtraWithRemovedSensitiveData(extra) : undefined,
+      extra: strippedExtra,
     })
   }
-  console.error(error, extra)
+  console.error(toErrorJsonWithRemovedSensitiveData(error), strippedExtra)
 }
 
 // -------------- end of duplicated code

--- a/apps/mobile/src/state/session/loadSession.ts
+++ b/apps/mobile/src/state/session/loadSession.ts
@@ -35,7 +35,7 @@ import writeSessionToStorage, {
 
 export class SessionSanityCheckFailed extends Data.TaggedError(
   'SessionSanityCheckFailed'
-)<{cause: unknown; message: string; session: SessionV2}> {}
+)<{cause: unknown; message: string}> {}
 
 function logLoadSessionProgress(text: string): void {
   console.log('🔑 loading session', text)
@@ -288,7 +288,6 @@ export function loadSession(
           new SessionSanityCheckFailed({
             message: 'Session sanity check failed',
             cause: 'Session data is invalid or corrupted',
-            session,
           })
         )
       )

--- a/apps/mobile/src/utils/errorSanitization.ts
+++ b/apps/mobile/src/utils/errorSanitization.ts
@@ -1,0 +1,30 @@
+export const errorToPlainObject = (
+  error: Error,
+  depth: number = 0
+): Record<string, unknown> => {
+  if (depth > 4) return {message: '[[truncated]]'}
+
+  return {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+    cause:
+      error.cause instanceof Error
+        ? errorToPlainObject(error.cause, depth + 1)
+        : error.cause,
+  }
+}
+
+export const makeErrorWithRemovedSensitiveData =
+  (removeSensitiveData: (string: string) => string) =>
+  (error: Error): Error => {
+    const strippedError = new Error(removeSensitiveData(error.message))
+    strippedError.name = error.name
+    if (error.stack) strippedError.stack = removeSensitiveData(error.stack)
+    return strippedError
+  }
+
+export const makeErrorJsonWithRemovedSensitiveData =
+  (toJsonWithRemovedSensitiveData: (object: unknown) => string) =>
+  (error: Error): string =>
+    toJsonWithRemovedSensitiveData(errorToPlainObject(error))

--- a/apps/mobile/src/utils/removeSensitiveData.ts
+++ b/apps/mobile/src/utils/removeSensitiveData.ts
@@ -34,6 +34,34 @@ export function toJsonWithRemovedSensitiveData(object: any): string {
   }
 }
 
+const errorToPlainObject = (
+  error: Error,
+  depth: number = 0
+): Record<string, unknown> => {
+  if (depth > 4) return {message: '[[truncated]]'}
+
+  return {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+    cause:
+      error.cause instanceof Error
+        ? errorToPlainObject(error.cause, depth + 1)
+        : error.cause,
+  }
+}
+
+export function toErrorWithRemovedSensitiveData(error: Error): Error {
+  const strippedError = new Error(removeSensitiveData(error.message))
+  strippedError.name = error.name
+  if (error.stack) strippedError.stack = removeSensitiveData(error.stack)
+  return strippedError
+}
+
+export function toErrorJsonWithRemovedSensitiveData(error: Error): string {
+  return toJsonWithRemovedSensitiveData(errorToPlainObject(error))
+}
+
 export function toExtraWithRemovedSensitiveData(
   extra: Record<string, unknown>
 ): Record<string, string> {
@@ -41,8 +69,9 @@ export function toExtraWithRemovedSensitiveData(
     return {
       ...acc,
       [key]:
-        // Keep errors to get stacktrace
-        value instanceof Error ? value : toJsonWithRemovedSensitiveData(value),
+        value instanceof Error
+          ? toErrorJsonWithRemovedSensitiveData(value)
+          : toJsonWithRemovedSensitiveData(value),
     }
   }, {})
 }

--- a/apps/mobile/src/utils/removeSensitiveData.ts
+++ b/apps/mobile/src/utils/removeSensitiveData.ts
@@ -1,6 +1,10 @@
 import {captureException} from '@sentry/react-native'
 import {getDefaultStore} from 'jotai'
 import {sessionDataOrDummyAtom} from '../state/session'
+import {
+  makeErrorJsonWithRemovedSensitiveData,
+  makeErrorWithRemovedSensitiveData,
+} from './errorSanitization'
 import {replaceAll} from './replaceAll'
 
 export default function removeSensitiveData(string: string): string {
@@ -34,33 +38,11 @@ export function toJsonWithRemovedSensitiveData(object: any): string {
   }
 }
 
-const errorToPlainObject = (
-  error: Error,
-  depth: number = 0
-): Record<string, unknown> => {
-  if (depth > 4) return {message: '[[truncated]]'}
+export const toErrorWithRemovedSensitiveData =
+  makeErrorWithRemovedSensitiveData(removeSensitiveData)
 
-  return {
-    name: error.name,
-    message: error.message,
-    stack: error.stack,
-    cause:
-      error.cause instanceof Error
-        ? errorToPlainObject(error.cause, depth + 1)
-        : error.cause,
-  }
-}
-
-export function toErrorWithRemovedSensitiveData(error: Error): Error {
-  const strippedError = new Error(removeSensitiveData(error.message))
-  strippedError.name = error.name
-  if (error.stack) strippedError.stack = removeSensitiveData(error.stack)
-  return strippedError
-}
-
-export function toErrorJsonWithRemovedSensitiveData(error: Error): string {
-  return toJsonWithRemovedSensitiveData(errorToPlainObject(error))
-}
+export const toErrorJsonWithRemovedSensitiveData =
+  makeErrorJsonWithRemovedSensitiveData(toJsonWithRemovedSensitiveData)
 
 export function toExtraWithRemovedSensitiveData(
   extra: Record<string, unknown>

--- a/apps/mobile/src/utils/reportError.ts
+++ b/apps/mobile/src/utils/reportError.ts
@@ -1,7 +1,11 @@
 import * as Sentry from '@sentry/react-native'
 import {initReportError} from '@vexl-next/resources-utils/src/reportErrorFromResourcesUtils'
 import {Effect} from 'effect'
-import {toExtraWithRemovedSensitiveData} from './removeSensitiveData'
+import {
+  toErrorJsonWithRemovedSensitiveData,
+  toErrorWithRemovedSensitiveData,
+  toExtraWithRemovedSensitiveData,
+} from './removeSensitiveData'
 
 export type LogLvl = 'info' | 'warn' | 'error' | 'fatal'
 export type SeverityLevel =
@@ -35,18 +39,23 @@ function reportError(
   error: Error,
   extra?: Record<string, unknown>
 ): void {
+  const strippedError = toErrorWithRemovedSensitiveData(error)
+  const strippedExtra = extra
+    ? toExtraWithRemovedSensitiveData(extra)
+    : undefined
+
   if (!__DEV__) {
-    Sentry.captureException(error, {
+    Sentry.captureException(strippedError, {
       level: logLvlToSentryLvl(lvl),
-      extra: extra ? toExtraWithRemovedSensitiveData(extra) : undefined,
+      extra: strippedExtra,
     })
   }
   getConsoleLvl(lvl)(
     '‼️ there was an error reported. See hermes logs',
-    error,
-    JSON.stringify(extra, null, 2)
+    toErrorJsonWithRemovedSensitiveData(error),
+    JSON.stringify(strippedExtra, null, 2)
   )
-  getConsoleLvl(lvl)(error, extra)
+  getConsoleLvl(lvl)(toErrorJsonWithRemovedSensitiveData(error), strippedExtra)
 }
 
 export default reportError

--- a/apps/notification-service/src/__tests__/routes/notificationToken/invalidateNotificationToken.test.ts
+++ b/apps/notification-service/src/__tests__/routes/notificationToken/invalidateNotificationToken.test.ts
@@ -6,6 +6,7 @@ import {
   makeCommonHeaders,
 } from '@vexl-next/rest-api/src/commonHeaders'
 import {Effect, Option, Schema} from 'effect'
+import {NotificationTokensDb} from '../../../services/NotificationTokensDb'
 import {NodeTestingApp} from '../../utils/NodeTestingApp'
 import {runPromiseInMockedEnvironment} from '../../utils/runPromiseInMockedEnvironment'
 
@@ -33,6 +34,7 @@ describe('InvalidateNotificationToken', () => {
     await runPromiseInMockedEnvironment(
       Effect.gen(function* (_) {
         const app = yield* _(NodeTestingApp)
+        const db = yield* _(NotificationTokensDb)
 
         // First create a secret
         const createResp = yield* _(
@@ -73,6 +75,75 @@ describe('InvalidateNotificationToken', () => {
         )
 
         expect(resp._tag).toEqual('Right')
+        const tokenOwner = yield* _(
+          db.findSecretByNotificationToken(generateResp.right.token)
+        )
+        expect(Option.isNone(tokenOwner)).toEqual(true)
+      })
+    )
+  })
+
+  it('Should keep token when invalidated with a different secret', async () => {
+    await runPromiseInMockedEnvironment(
+      Effect.gen(function* (_) {
+        const app = yield* _(NodeTestingApp)
+        const db = yield* _(NotificationTokensDb)
+
+        const firstSecret = yield* _(
+          app.NotificationTokenGroup.CreateNotificationSecret({
+            payload: {
+              expoNotificationToken: validExpoToken,
+            },
+            headers: validHeaders,
+          }),
+          Effect.either
+        )
+
+        expect(firstSecret._tag).toEqual('Right')
+        if (firstSecret._tag !== 'Right') return
+
+        const secondSecret = yield* _(
+          app.NotificationTokenGroup.CreateNotificationSecret({
+            payload: {
+              expoNotificationToken: validExpoToken,
+            },
+            headers: validHeaders,
+          }),
+          Effect.either
+        )
+
+        expect(secondSecret._tag).toEqual('Right')
+        if (secondSecret._tag !== 'Right') return
+
+        const generateResp = yield* _(
+          app.NotificationTokenGroup.generateNotificationToken({
+            payload: {
+              secret: firstSecret.right.secret,
+            },
+          }),
+          Effect.either
+        )
+
+        expect(generateResp._tag).toEqual('Right')
+        if (generateResp._tag !== 'Right') return
+
+        const resp = yield* _(
+          app.NotificationTokenGroup.invalidateNotificationToken({
+            payload: {
+              secret: secondSecret.right.secret,
+              tokenToInvalidate: generateResp.right.token,
+            },
+          }),
+          Effect.either
+        )
+
+        expect(resp._tag).toEqual('Right')
+        const tokenOwner = yield* _(
+          db.findSecretByNotificationToken(generateResp.right.token)
+        )
+        expect(Option.isSome(tokenOwner)).toEqual(true)
+        if (Option.isNone(tokenOwner)) return
+        expect(tokenOwner.value.secret).toEqual(firstSecret.right.secret)
       })
     )
   })

--- a/apps/notification-service/src/routes/notificationToken/invalidateNotificationTokenHandler.ts
+++ b/apps/notification-service/src/routes/notificationToken/invalidateNotificationTokenHandler.ts
@@ -1,7 +1,7 @@
 import {HttpApiBuilder} from '@effect/platform/index'
 import {NotificationApiSpecification} from '@vexl-next/rest-api/src/services/notification/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
-import {Effect} from 'effect'
+import {Effect, Option} from 'effect'
 import {NotificationTokensDb} from '../../services/NotificationTokensDb'
 
 export const invalidateNotificationTokenHandler = HttpApiBuilder.handler(
@@ -14,8 +14,16 @@ export const invalidateNotificationTokenHandler = HttpApiBuilder.handler(
         const {payload} = req
 
         const db = yield* NotificationTokensDb
+        const secretForToken = yield* db.findSecretByNotificationToken(
+          payload.tokenToInvalidate
+        )
 
-        yield* db.deleteNotificationToken(payload.tokenToInvalidate)
+        if (
+          Option.isSome(secretForToken) &&
+          secretForToken.value.secret === payload.secret
+        ) {
+          yield* db.deleteNotificationToken(payload.tokenToInvalidate)
+        }
       })
     )
 )

--- a/apps/user-service/src/__tests__/eraseUser/verifyAndEraseUser.test.ts
+++ b/apps/user-service/src/__tests__/eraseUser/verifyAndEraseUser.test.ts
@@ -69,6 +69,52 @@ describe('Verify and erase user', () => {
     )
   })
 
+  it('Should reject replayed erase verification ids', async () => {
+    await runPromiseInMockedEnvironment(
+      Effect.gen(function* (_) {
+        const client = yield* _(NodeTestingApp)
+
+        const initResponse = yield* _(initVerification)
+
+        expect(initResponse.verificationId).toBeDefined()
+
+        checkVerificationMock.mockReturnValueOnce(Effect.succeed('valid'))
+        const checkResponse = yield* _(
+          client.EraseUser.verifyAndEraseuser({
+            payload: {
+              verificationId: initResponse.verificationId,
+              code: '123456',
+            },
+          })
+        )
+
+        expect(
+          checkResponse.shortLivedTokenForErasingUserOnContactService
+        ).toBeDefined()
+
+        const replayResponse = yield* _(
+          client.EraseUser.verifyAndEraseuser({
+            payload: {
+              verificationId: initResponse.verificationId,
+              code: '123456',
+            },
+          }),
+          Effect.either
+        )
+
+        const VerifyCodeErrors = Schema.Union(
+          UnableToGenerateChallengeError,
+          VerificationNotFoundError,
+          InvalidVerificationError,
+          InvalidVerificationIdError,
+          UnableToVerifySmsCodeError
+        )
+
+        expectErrorResponse(VerifyCodeErrors)(replayResponse)
+      })
+    )
+  })
+
   it('Should return error response when verification unsuccessful', async () => {
     await runPromiseInMockedEnvironment(
       Effect.gen(function* (_) {

--- a/apps/user-service/src/__tests__/eraseUser/verifyAndEraseUser.test.ts
+++ b/apps/user-service/src/__tests__/eraseUser/verifyAndEraseUser.test.ts
@@ -9,7 +9,7 @@ import {
   VerificationNotFoundError,
 } from '@vexl-next/rest-api/src/services/user/contracts'
 import {expectErrorResponse} from '@vexl-next/server-utils/src/tests/expectErrorResponse'
-import {Effect, Schema} from 'effect'
+import {Effect, Either, Schema} from 'effect'
 import {NodeTestingApp} from '../utils/NodeTestingApp'
 import {
   checkVerificationMock,
@@ -20,6 +20,13 @@ import {runPromiseInMockedEnvironment} from '../utils/runPromiseInMockedEnvironm
 const phoneNumberToTest = Schema.decodeSync(E164PhoneNumber)('+420733333333')
 const validTurnstileToken = Schema.decodeSync(TurnstileToken)(
   'valid-turnstile-token'
+)
+const VerifyCodeErrors = Schema.Union(
+  UnableToGenerateChallengeError,
+  VerificationNotFoundError,
+  InvalidVerificationError,
+  InvalidVerificationIdError,
+  UnableToVerifySmsCodeError
 )
 
 beforeEach(() => {
@@ -102,15 +109,42 @@ describe('Verify and erase user', () => {
           Effect.either
         )
 
-        const VerifyCodeErrors = Schema.Union(
-          UnableToGenerateChallengeError,
-          VerificationNotFoundError,
-          InvalidVerificationError,
-          InvalidVerificationIdError,
-          UnableToVerifySmsCodeError
+        expectErrorResponse(VerifyCodeErrors)(replayResponse)
+      })
+    )
+  })
+
+  it('Should atomically reject concurrent replayed erase verification ids', async () => {
+    await runPromiseInMockedEnvironment(
+      Effect.gen(function* (_) {
+        const client = yield* _(NodeTestingApp)
+
+        const initResponse = yield* _(initVerification)
+
+        expect(initResponse.verificationId).toBeDefined()
+
+        checkVerificationMock.mockReturnValue(Effect.succeed('valid'))
+        const verifyRequest = client.EraseUser.verifyAndEraseuser({
+          payload: {
+            verificationId: initResponse.verificationId,
+            code: '123456',
+          },
+        }).pipe(Effect.either)
+
+        const [firstResponse, secondResponse] = yield* _(
+          Effect.all([verifyRequest, verifyRequest], {concurrency: 'unbounded'})
         )
 
-        expectErrorResponse(VerifyCodeErrors)(replayResponse)
+        const successCount =
+          Number(Either.isRight(firstResponse)) +
+          Number(Either.isRight(secondResponse))
+        expect(successCount).toBe(1)
+
+        const failedResponse = Either.isLeft(firstResponse)
+          ? firstResponse
+          : secondResponse
+
+        expectErrorResponse(VerifyCodeErrors)(failedResponse)
       })
     )
   })
@@ -126,7 +160,7 @@ describe('Verify and erase user', () => {
         checkVerificationMock.mockReturnValueOnce(
           Effect.fail(
             new UnableToVerifySmsCodeError({
-              reason: 'BadCode' as const,
+              reason: 'BadCode',
               status: 400,
               code: '100104',
             })
@@ -140,13 +174,6 @@ describe('Verify and erase user', () => {
             },
           }),
           Effect.either
-        )
-        const VerifyCodeErrors = Schema.Union(
-          UnableToGenerateChallengeError,
-          VerificationNotFoundError,
-          InvalidVerificationError,
-          InvalidVerificationIdError,
-          UnableToVerifySmsCodeError
         )
 
         expectErrorResponse(VerifyCodeErrors)(checkResponse)

--- a/apps/user-service/src/__tests__/login/verifyCode.test.ts
+++ b/apps/user-service/src/__tests__/login/verifyCode.test.ts
@@ -74,6 +74,53 @@ describe('Verify code', () => {
     )
   })
 
+  it('Should reject replayed verification ids', async () => {
+    await runPromiseInMockedEnvironment(
+      Effect.gen(function* (_) {
+        const client = yield* _(NodeTestingApp)
+        const initResponse = yield* _(initVerification)
+
+        expect(initResponse.verificationId).toBeDefined()
+        expect(initResponse.expirationAt).toBeDefined()
+
+        checkVerificationMock.mockReturnValueOnce(Effect.succeed('valid'))
+        const keypair = generatePrivateKey()
+        const checkResponse = yield* _(
+          client.Login.verifyCode({
+            payload: {
+              userPublicKey: keypair.publicKeyPemBase64,
+              id: initResponse.verificationId,
+              code: '123456',
+            },
+          })
+        )
+
+        expect(checkResponse.challenge).toBeDefined()
+
+        const replayResponse = yield* _(
+          client.Login.verifyCode({
+            payload: {
+              userPublicKey: keypair.publicKeyPemBase64,
+              id: initResponse.verificationId,
+              code: '123456',
+            },
+          }),
+          Effect.either
+        )
+
+        const VerifyCodeErrors = Schema.Union(
+          UnableToGenerateChallengeError,
+          VerificationNotFoundError,
+          InvalidVerificationError,
+          InvalidVerificationIdError,
+          UnableToVerifySmsCodeError
+        )
+
+        expectErrorResponse(VerifyCodeErrors)(replayResponse)
+      })
+    )
+  })
+
   it('Should return error response when verification unsuccessful', async () => {
     await runPromiseInMockedEnvironment(
       Effect.gen(function* (_) {

--- a/apps/user-service/src/routes/eraseUser/handlers/verifyAndEraseUser.ts
+++ b/apps/user-service/src/routes/eraseUser/handlers/verifyAndEraseUser.ts
@@ -4,11 +4,14 @@ import {UnableToVerifySmsCodeError} from '@vexl-next/rest-api/src/services/user/
 import {UserApiSpecification} from '@vexl-next/rest-api/src/services/user/specification'
 import {hashPhoneNumber} from '@vexl-next/server-utils/src/generateUserAuthData'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {RedisService} from '@vexl-next/server-utils/src/RedisService'
 import {createShortLivedTokenForErasingUser} from '@vexl-next/server-utils/src/shortLivedTokenForErasingUserUtils'
-import {Effect, Option} from 'effect'
+import {Effect, Option, Schema} from 'effect'
 import {loginCodeDummyForAll} from '../../../configs'
 import {checkVerification} from '../../../utils/smsVerificationUtils'
 import {validateAndDecodeVerificationId} from '../utils'
+
+const USED_ERASE_VERIFICATION_ID_PREFIX = 'usedEraseVerificationId:'
 
 export const verifyAndEraseUser = HttpApiBuilder.handler(
   UserApiSpecification,
@@ -22,13 +25,31 @@ export const verifyAndEraseUser = HttpApiBuilder.handler(
       const decodedVerificationId = yield* _(
         validateAndDecodeVerificationId(verificationId)
       )
+      const redis = yield* _(RedisService)
+      const verificationIdWasUsed = yield* _(
+        redis.exists(`${USED_ERASE_VERIFICATION_ID_PREFIX}${verificationId}`),
+        Effect.catchAll(
+          (e) => new UnexpectedServerError({status: 500, cause: e})
+        )
+      )
+
+      if (verificationIdWasUsed) {
+        return yield* _(
+          new UnableToVerifySmsCodeError({
+            status: 400,
+            code: '100104',
+            reason: 'BadCode',
+          })
+        )
+      }
+
       if (Option.isSome(dummyCodeForAll)) {
         if (dummyCodeForAll.value !== req.payload.code)
           return yield* _(
             new UnableToVerifySmsCodeError({
               status: 400,
-              code: '100104' as const,
-              reason: 'BadCode' as const,
+              code: '100104',
+              reason: 'BadCode',
             })
           )
       } else {
@@ -43,6 +64,13 @@ export const verifyAndEraseUser = HttpApiBuilder.handler(
         hashPhoneNumber(decodedVerificationId.phoneNumber),
         Effect.flatMap((hashedPhoneNumber) =>
           createShortLivedTokenForErasingUser(hashedPhoneNumber)
+        ),
+        Effect.tap(() =>
+          redis.set(Schema.Boolean)(
+            `${USED_ERASE_VERIFICATION_ID_PREFIX}${verificationId}`,
+            true,
+            {expiresAt: decodedVerificationId.expiresAt}
+          )
         ),
         Effect.catchAll(
           (e) => new UnexpectedServerError({status: 500, cause: e})

--- a/apps/user-service/src/routes/eraseUser/handlers/verifyAndEraseUser.ts
+++ b/apps/user-service/src/routes/eraseUser/handlers/verifyAndEraseUser.ts
@@ -26,22 +26,7 @@ export const verifyAndEraseUser = HttpApiBuilder.handler(
         validateAndDecodeVerificationId(verificationId)
       )
       const redis = yield* _(RedisService)
-      const verificationIdWasUsed = yield* _(
-        redis.exists(`${USED_ERASE_VERIFICATION_ID_PREFIX}${verificationId}`),
-        Effect.catchAll(
-          (e) => new UnexpectedServerError({status: 500, cause: e})
-        )
-      )
-
-      if (verificationIdWasUsed) {
-        return yield* _(
-          new UnableToVerifySmsCodeError({
-            status: 400,
-            code: '100104',
-            reason: 'BadCode',
-          })
-        )
-      }
+      const usedVerificationIdRedisKey = `${USED_ERASE_VERIFICATION_ID_PREFIX}${verificationId}`
 
       if (Option.isSome(dummyCodeForAll)) {
         if (dummyCodeForAll.value !== req.payload.code)
@@ -60,17 +45,29 @@ export const verifyAndEraseUser = HttpApiBuilder.handler(
           })
         )
       }
+      const verificationIdWasClaimed = yield* _(
+        redis.setIfNotExists(Schema.Boolean)(usedVerificationIdRedisKey, true, {
+          expiresAt: decodedVerificationId.expiresAt,
+        }),
+        Effect.catchAll(
+          (e) => new UnexpectedServerError({status: 500, cause: e})
+        )
+      )
+
+      if (!verificationIdWasClaimed) {
+        return yield* _(
+          new UnableToVerifySmsCodeError({
+            status: 400,
+            code: '100104',
+            reason: 'BadCode',
+          })
+        )
+      }
+
       return yield* _(
         hashPhoneNumber(decodedVerificationId.phoneNumber),
         Effect.flatMap((hashedPhoneNumber) =>
           createShortLivedTokenForErasingUser(hashedPhoneNumber)
-        ),
-        Effect.tap(() =>
-          redis.set(Schema.Boolean)(
-            `${USED_ERASE_VERIFICATION_ID_PREFIX}${verificationId}`,
-            true,
-            {expiresAt: decodedVerificationId.expiresAt}
-          )
         ),
         Effect.catchAll(
           (e) => new UnexpectedServerError({status: 500, cause: e})

--- a/apps/user-service/src/routes/login/handlers/verifyCodeHandler.ts
+++ b/apps/user-service/src/routes/login/handlers/verifyCodeHandler.ts
@@ -50,6 +50,7 @@ export const verifyCodeHandler = HttpApiBuilder.handler(
       } satisfies ChallengeVerificationState
 
       yield* _(loginDb.storeChallengeVerificationState(verificationState))
+      yield* _(loginDb.deletePhoneVerificationState(req.payload.id))
 
       return new VerifyPhoneNumberResponse({
         challenge: verificationState.challenge,

--- a/packages/cryptography/src/operations/aes.test.ts
+++ b/packages/cryptography/src/operations/aes.test.ts
@@ -65,6 +65,16 @@ describe('aes gcm', () => {
       aesGCMDecrypt({data: encrypted, password: 'bad password'})
     }).toThrow('Unsupported state or unable to authenticate data')
   })
+
+  it('Should fail when decrypting unsupported future aes gcm versions', () => {
+    const data = 'some data'
+    const encrypted = aesGCMEncrypt({data, password})
+    const encryptedWithUnsupportedVersion = encrypted.replace(/^001\./, '002.')
+
+    expect(() => {
+      aesGCMDecrypt({data: encryptedWithUnsupportedVersion, password})
+    }).toThrow('Unsupported AES-GCM data version')
+  })
 })
 
 describe('aes ctr', () => {

--- a/packages/cryptography/src/operations/aes.test.ts
+++ b/packages/cryptography/src/operations/aes.test.ts
@@ -28,24 +28,29 @@ describe('aes gcm', () => {
     expect(decrypted).toEqual(data)
   })
 
-  it('Should output data as expected', () => {
+  it('Should use a random iv for new encryptions', () => {
     const data = 'Another some messag'
     const staticPass = 'This is something'
-    const encrypt = aesGCMEncrypt({data, password: staticPass})
+    const encrypted1 = aesGCMEncrypt({data, password: staticPass})
+    const encrypted2 = aesGCMEncrypt({data, password: staticPass})
 
-    expect(encrypt).toEqual(
-      '000.AEW+Xc++na8J9NdjRYP4lSA7Tg==.CDQUB6lB7S9XWKirY5DbVg=='
+    expect(encrypted1).not.toEqual(encrypted2)
+    expect(aesGCMDecrypt({data: encrypted1, password: staticPass})).toEqual(
+      data
+    )
+    expect(aesGCMDecrypt({data: encrypted2, password: staticPass})).toEqual(
+      data
     )
   })
 
   it('Should fail when decrypting with bad security tag', () => {
     const data = 'some data'
     const encrypted = aesGCMEncrypt({data, password})
-    const [version, payload] = encrypted.split('.')
+    const [version, iv, payload] = encrypted.split('.')
     const crypto = getCrypto()
     expect(() => {
       aesGCMDecrypt({
-        data: `${version}.${payload}.${crypto
+        data: `${version}.${iv}.${payload}.${crypto
           .randomBytes(16)
           .toString('base64')}`,
         password,

--- a/packages/cryptography/src/operations/aes.ts
+++ b/packages/cryptography/src/operations/aes.ts
@@ -54,7 +54,7 @@ export function aesGCMDecrypt({
   const cipherKey = stretchedPass.subarray(0, 32)
   const iv = stretchedPass.subarray(32, 32 + 12)
 
-  if (version > 0) {
+  if (version === 1) {
     const [ivBase64, encrypted, authTag] = data.split('.')
     if (!authTag || !encrypted || !ivBase64) throw new Error('Bad data')
 
@@ -70,6 +70,8 @@ export function aesGCMDecrypt({
       'utf8'
     )}`
   }
+
+  if (version !== 0) throw new Error('Unsupported AES-GCM data version')
 
   const [encrypted, authTag] = data.split('.')
   if (!authTag || !encrypted) throw new Error('Bad data')

--- a/packages/cryptography/src/operations/aes.ts
+++ b/packages/cryptography/src/operations/aes.ts
@@ -16,21 +16,22 @@ export function aesGCMEncrypt({
     password,
     SALT,
     PBKDF2ITER,
-    32 + 12,
+    32,
     'sha1'
   )
 
-  const cipherKey = stretchedPass.subarray(0, 32)
-  const iv = stretchedPass.subarray(32, 32 + 12)
+  const iv = crypto.randomBytes(12)
 
-  const cipher = crypto.createCipheriv(CYPHER_ALGORITHM, cipherKey, iv)
+  const cipher = crypto.createCipheriv(CYPHER_ALGORITHM, stretchedPass, iv)
 
   const encrypted = Buffer.concat([cipher.update(data, 'utf8'), cipher.final()])
   const authTag = cipher.getAuthTag()
 
   return appendVersion(
-    `${encrypted.toString('base64')}.${authTag.toString('base64')}`,
-    1
+    `${iv.toString('base64')}.${encrypted.toString('base64')}.${authTag.toString(
+      'base64'
+    )}`,
+    2
   )
 }
 
@@ -42,7 +43,7 @@ export function aesGCMDecrypt({
   password: string
 }): string {
   const crypto = getCrypto()
-  const {data} = parseStringWithVersion(dataWithVersion)
+  const {data, version} = parseStringWithVersion(dataWithVersion)
   const stretchedPass = crypto.pbkdf2Sync(
     password,
     SALT,
@@ -53,10 +54,26 @@ export function aesGCMDecrypt({
   const cipherKey = stretchedPass.subarray(0, 32)
   const iv = stretchedPass.subarray(32, 32 + 12)
 
-  const decipher = crypto.createDecipheriv(CYPHER_ALGORITHM, cipherKey, iv)
+  if (version > 0) {
+    const [ivBase64, encrypted, authTag] = data.split('.')
+    if (!authTag || !encrypted || !ivBase64) throw new Error('Bad data')
+
+    const decipher = crypto.createDecipheriv(
+      CYPHER_ALGORITHM,
+      cipherKey,
+      Buffer.from(ivBase64, 'base64')
+    )
+
+    decipher.setAuthTag(Buffer.from(authTag, 'base64'))
+
+    return `${decipher.update(encrypted, 'base64', 'utf8')}${decipher.final(
+      'utf8'
+    )}`
+  }
 
   const [encrypted, authTag] = data.split('.')
   if (!authTag || !encrypted) throw new Error('Bad data')
+  const decipher = crypto.createDecipheriv(CYPHER_ALGORITHM, cipherKey, iv)
   decipher.setAuthTag(Buffer.from(authTag, 'base64'))
 
   return `${decipher.update(encrypted, 'base64', 'utf8')}${decipher.final(

--- a/packages/cryptography/src/operations/eciesLegacy.test.ts
+++ b/packages/cryptography/src/operations/eciesLegacy.test.ts
@@ -70,3 +70,14 @@ it('Should encrypt and decrypt message with secp256k1 key', async () => {
     })
   ).toEqual(message)
 })
+
+it('Should reject malformed ciphertext without hanging', async () => {
+  const key = generatePrivateKey()
+
+  await expect(
+    eciesLegacyDecrypt({
+      privateKey: key.privateKeyPemBase64,
+      data: '123',
+    })
+  ).rejects.toThrow('Invalid ECIES legacy ciphertext')
+})

--- a/packages/cryptography/src/operations/eciesLegacy.ts
+++ b/packages/cryptography/src/operations/eciesLegacy.ts
@@ -75,11 +75,29 @@ function getNextPart(
 
   let partLengthIndex = startOffset
   while (data.charAt(partLengthIndex) !== 'A') {
-    partLengthChars.push(data.charAt(partLengthIndex))
+    if (partLengthIndex >= data.length) {
+      throw new Error('Invalid ECIES legacy ciphertext')
+    }
+
+    const nextLengthChar = data.charAt(partLengthIndex)
+    if (!/^\d$/.test(nextLengthChar)) {
+      throw new Error('Invalid ECIES legacy ciphertext')
+    }
+
+    partLengthChars.push(nextLengthChar)
     partLengthIndex = partLengthIndex + 1
   }
-  const partLength = parseInt(partLengthChars.join(''))
+  const partLength = Number.parseInt(partLengthChars.join(''), 10)
   const partEndsAt = partLengthIndex + 1 + partLength
+
+  if (
+    !Number.isSafeInteger(partLength) ||
+    partLength < 0 ||
+    partEndsAt > data.length
+  ) {
+    throw new Error('Invalid ECIES legacy ciphertext')
+  }
+
   const part = data.slice(partLengthIndex + 1, partEndsAt)
 
   return {

--- a/packages/rest-api/src/services/content/specification.ts
+++ b/packages/rest-api/src/services/content/specification.ts
@@ -13,6 +13,7 @@ import {BtcPayServerWebhookHeader} from '../../btcPayServerWebhookHeader'
 import {CommonHeaders} from '../../commonHeaders'
 import {MaxExpectedDailyCall} from '../../MaxExpectedDailyCountAnnotation'
 import {NoContentResponse} from '../../NoContentResponse.brand'
+import {RateLimitingMiddleware} from '../../rateLimititing'
 import {
   BlogsArticlesResponse,
   CreateInvoiceError,
@@ -152,6 +153,7 @@ const DonationsApiGroup = HttpApiGroup.make('Donations')
   .add(GetInvoiceStatusTypeEndpoint)
 
 export const ContentApiSpecification = HttpApi.make('Content API')
+  .middleware(RateLimitingMiddleware)
   .add(CmsContentApiGroup)
   .add(NewsAndAnnouncementsApiGroup)
   .add(VexlProductNotificationsApiGroup)

--- a/packages/server-utils/src/RateLimiting/index.test.ts
+++ b/packages/server-utils/src/RateLimiting/index.test.ts
@@ -17,6 +17,7 @@ import {rateLimitPerIpMultiplierConfig} from '../commonConfigs'
 import {expectErrorResponse} from '../tests/expectErrorResponse'
 import {mockedRateLimitingLayer} from '../tests/mockedRateLimitingLayer'
 import {rateLimitingMiddlewareLayer} from './rateLimitngMiddlewareLayer'
+import {normalizePath} from './utils'
 
 const TestEndpoint = HttpApiEndpoint.post(
   'testEndpoint',
@@ -73,6 +74,13 @@ beforeEach(async () => {
 })
 
 describe('Rate Limiting Middleware', () => {
+  it('uses the same route key for query string variants', () => {
+    expect(normalizePath('/api/v1/test?nonce=1')).toEqual('/api/v1/test')
+    expect(normalizePath('/api/v1/test?nonce=2#fragment')).toEqual(
+      '/api/v1/test'
+    )
+  })
+
   it('allows requests under the rate limit', async () => {
     await runPromiseInMocked(
       Effect.gen(function* (_) {

--- a/packages/server-utils/src/RateLimiting/rateLimitngMiddlewareLayer.ts
+++ b/packages/server-utils/src/RateLimiting/rateLimitngMiddlewareLayer.ts
@@ -14,7 +14,7 @@ import {
 import {getConnectingIp} from '../getConnectingIp'
 import {makeMiddlewareEffect} from '../makeMiddlewareEffect'
 import {reportRateLimit} from './metrics'
-import {buildRateLimitingLimitsForEndpoints} from './utils'
+import {buildRateLimitingLimitsForEndpoints, normalizePath} from './utils'
 
 export const rateLimitingMiddlewareLayer = (
   spec: HttpApi.HttpApi<any, any, any, any>
@@ -67,13 +67,14 @@ export const rateLimitingMiddlewareLayer = (
         }
 
         const request = yield* _(HttpServerRequest.HttpServerRequest)
-        const endpointLimit = getEndpointLimit(request.method, request.url)
+        const route = normalizePath(request.url)
+        const endpointLimit = getEndpointLimit(request.method, route)
 
         // This means that the endpoint is not defined in the API spec. Let it pass to return 404 (or docs)
         if (endpointLimit._tag === 'noRouteFound') {
           yield* _(
             Effect.logInfo('No rate limiting route found for endpoint', {
-              route: request.url,
+              route,
               method: request.method,
             })
           )
@@ -85,7 +86,7 @@ export const rateLimitingMiddlewareLayer = (
           yield* _(
             Effect.fail(
               new UnexpectedServerError({
-                message: `Could not determine rate limit for endpoint ${request.method} ${request.url}`,
+                message: `Could not determine rate limit for endpoint ${request.method} ${route}`,
               })
             )
           )
@@ -97,7 +98,7 @@ export const rateLimitingMiddlewareLayer = (
         yield* _(
           Effect.log('Rate limiting check', {
             ip: connectingIp,
-            route: request.url,
+            route,
             method: request.method,
             limit,
           })
@@ -106,7 +107,7 @@ export const rateLimitingMiddlewareLayer = (
         const rateLimitResult = yield* _(
           rateLimiting.incrementAndRateLimitIp({
             ip: connectingIp,
-            route: request.url,
+            route,
             method: request.method,
             limit,
           })
@@ -116,7 +117,7 @@ export const rateLimitingMiddlewareLayer = (
           reportRateLimit({
             allowed: rateLimitResult.allowed,
             method: request.method,
-            route: request.url,
+            route,
             limit,
           })
         )
@@ -125,7 +126,7 @@ export const rateLimitingMiddlewareLayer = (
           yield* _(
             Effect.logInfo('Rate limiting ip', {
               ip: connectingIp,
-              route: request.url,
+              route,
               method: request.method,
             })
           )

--- a/packages/server-utils/src/RedisService.ts
+++ b/packages/server-utils/src/RedisService.ts
@@ -51,6 +51,14 @@ export interface RedisOperations {
     opts?: {expiresAt?: UnixMilliseconds}
   ) => Effect.Effect<void, ParseResult.ParseError | RedisError, R>
 
+  setIfNotExists: <A, I, R>(
+    schema: Schema.Schema<A, I, R>
+  ) => (
+    key: string,
+    value: A,
+    opts?: {expiresAt?: UnixMilliseconds}
+  ) => Effect.Effect<boolean, ParseResult.ParseError | RedisError, R>
+
   insertToSet: <A, I, R>(
     schema: Schema.Schema<A, I, R>
   ) => (
@@ -267,6 +275,27 @@ export class RedisService extends Context.Tag('RedisService')<
           Effect.withSpan('Redis set', {attributes: {key, value, expiresAt}})
         )
       }
+
+      const setStringIfNotExists = (
+        key: string,
+        value: string,
+        expiresAt?: UnixMilliseconds
+      ): Effect.Effect<boolean, RedisError> =>
+        Effect.tryPromise({
+          try: async () => {
+            const result =
+              expiresAt === undefined
+                ? await redisClient.set(key, value, 'NX')
+                : await redisClient.set(key, value, 'PXAT', expiresAt, 'NX')
+
+            return result === 'OK'
+          },
+          catch: (e) => new RedisError({cause: e}),
+        }).pipe(
+          Effect.withSpan('Redis set if not exists', {
+            attributes: {key, value, expiresAt},
+          })
+        )
 
       const deleteKey = (key: string): Effect.Effect<void, RedisError> =>
         // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
@@ -493,6 +522,16 @@ export class RedisService extends Context.Tag('RedisService')<
             encode(value).pipe(
               Effect.flatMap((encoded) =>
                 setString(key, encoded, opts?.expiresAt)
+              )
+            )
+        },
+        setIfNotExists: (schema) => {
+          const encode = Schema.encode(Schema.parseJson(schema))
+
+          return (key, value, opts) =>
+            encode(value).pipe(
+              Effect.flatMap((encoded) =>
+                setStringIfNotExists(key, encoded, opts?.expiresAt)
               )
             )
         },

--- a/packages/server-utils/src/tests/mockedRedisLayer.ts
+++ b/packages/server-utils/src/tests/mockedRedisLayer.ts
@@ -1,4 +1,4 @@
-import {Effect, HashMap, Layer, Ref, Schema} from 'effect'
+import {Effect, HashMap, Layer, Option, Ref, Schema} from 'effect'
 import {isNonEmptyReadonlyArray} from 'effect/Array'
 import {NoSuchElementException} from 'effect/Cause'
 import {RedisService, type RedisOperations} from '../RedisService'
@@ -27,10 +27,22 @@ export const mockedRedisLayer = Layer.effect(
       >(HashMap.empty())
     )
 
+    const valueExists = (
+      hm: HashMap.HashMap<string, {expiration: number; value: string}>,
+      key: string
+    ): boolean =>
+      HashMap.get(hm, key).pipe(
+        Option.match({
+          onNone: () => false,
+          onSome: (value) =>
+            value.expiration === -1 || value.expiration > Date.now(),
+        })
+      )
+
     const toReturn: RedisOperations = {
       delete: (key: string) => Ref.update(state, HashMap.remove(key)),
       exists: (key: string) =>
-        Ref.get(state).pipe(Effect.map((hm) => HashMap.has(hm, key))),
+        Ref.get(state).pipe(Effect.map((hm) => valueExists(hm, key))),
 
       setExpiresAt: (key: string, expiresAt: number) =>
         Ref.update(state, (hm) =>
@@ -59,6 +71,22 @@ export const mockedRedisLayer = Layer.effect(
                 expiration: opts?.expiresAt ?? -1,
                 value: encoded,
               })
+            )
+          )
+        ),
+      setIfNotExists: (schema) => (key: string, value: any, opts) =>
+        Schema.encode(Schema.parseJson(schema))(value).pipe(
+          Effect.flatMap((encoded) =>
+            Ref.modify(state, (hm) =>
+              valueExists(hm, key)
+                ? [false, hm]
+                : [
+                    true,
+                    HashMap.set(hm, key, {
+                      expiration: opts?.expiresAt ?? -1,
+                      value: encoded,
+                    }),
+                  ]
             )
           )
         ),


### PR DESCRIPTION
## What changed

This PR fixes the highest-risk findings from a repository-wide Codex Security scan:

- blocks absolute URL SSRF in the backoffice catch-all proxy
- restricts backoffice S3 upload proxying to signed AWS S3 club-image URLs
- randomizes AES-GCM IVs while preserving legacy ciphertext decrypt
- rejects malformed legacy ECIES ciphertext instead of looping forever
- redacts mobile error reports and stops carrying full session data in sanity-check errors
- requires notification-token ownership for token invalidation
- consumes successful login and erase verification tokens
- normalizes rate-limit route keys so query strings cannot split buckets
- enables the content API rate-limiting middleware tag

## Why

The scan found several public or sensitive trust-boundary failures: server-side URL control, cryptographic nonce reuse, sensitive session leakage, authorization bypass on notification tokens, replayable verification artifacts, and inert or bypassable rate limiting.

## Validation

Passed:

- `yarn turbo:typecheck`
- `yarn turbo:format` after `yarn turbo:format:fix`
- `yarn turbo:lint`
- `yarn workspace @vexl-next/cryptography test --runInBand src/operations/aes.test.ts src/operations/eciesLegacy.test.ts`
- `yarn workspace @vexl-next/server-utils test --runInBand src/RateLimiting/index.test.ts`
- `yarn workspace @vexl-next/user-service test --runInBand src/__tests__/login/verifyCode.test.ts src/__tests__/eraseUser/verifyAndEraseUser.test.ts`

Attempted but blocked by local environment:

- `yarn workspace @vexl-next/notification-service test --runInBand src/__tests__/routes/notificationToken/invalidateNotificationToken.test.ts`
- Blocker: local Postgres refused connection on `localhost:5432`; no running Docker/Postgres test service was available.

## Scan artifacts

Local scan bundle:

`/tmp/codex-security-scans/vexl-next/808718999bad_20260512T080033Z`
