### PR TITLE
Fix BullMQ job IDs and guard invalid custom IDs

### DIFF
--- a/apps/notification-service/src/__tests__/throttledNotificationMq.test.ts
+++ b/apps/notification-service/src/__tests__/throttledNotificationMq.test.ts
@@ -1,0 +1,16 @@
+import {VexlNotificationTokenSecret} from '@vexl-next/domain/src/general/notifications/VexlNotificationToken'
+import {Schema} from 'effect/index'
+import {processThrottledNotificationsJobId} from '../services/ThrottledPushNotificationService/services/ThrottledNotificationJobId'
+
+describe('processThrottledNotificationsJobId', () => {
+  it('builds a BullMQ-safe job ID without Redis key separators', () => {
+    const token = Schema.decodeSync(VexlNotificationTokenSecret)(
+      'vexl_nt_secret_test'
+    )
+
+    const jobId = processThrottledNotificationsJobId(token)
+
+    expect(jobId).toBe('process-throttled-notifications-vexl_nt_secret_test')
+    expect(jobId).not.toContain(':')
+  })
+})

--- a/apps/notification-service/src/services/NotificationSocketMessaging/services/SendMessageTasksManager/utils.ts
+++ b/apps/notification-service/src/services/NotificationSocketMessaging/services/SendMessageTasksManager/utils.ts
@@ -1,6 +1,7 @@
 import {RedisNamespacePrefixConfig} from '@vexl-next/server-utils/src/commonConfigs'
+import {validateBullMqJobOptions} from '@vexl-next/server-utils/src/mqService'
 import {RedisConnectionService} from '@vexl-next/server-utils/src/RedisConnection'
-import {Queue as BullQueue, type Job, type JobsOptions, Worker} from 'bullmq'
+import {Queue, Worker, type Job, type JobsOptions} from 'bullmq'
 import {
   Context,
   Effect,
@@ -38,7 +39,7 @@ const createQueue = pipe(
     Effect.acquireRelease(
       Effect.try({
         try: () =>
-          new BullQueue(PENDING_TASKS_QUEUE_NAME, {
+          new Queue(PENDING_TASKS_QUEUE_NAME, {
             connection: redisConnection,
             prefix,
             defaultJobOptions: {
@@ -65,10 +66,22 @@ const createQueue = pipe(
   Effect.map(
     (queue) => (task: SendMessageTask, options?: JobsOptions) =>
       pipe(
-        task,
-        Schema.encode(SendMessageTask),
-        SendMessageTasksManagerError.wrapErrors(
-          'Error while encoding pending task data'
+        validateBullMqJobOptions(
+          options,
+          (forbiddenCharacter) =>
+            new SendMessageTasksManagerError({
+              cause: {forbiddenCharacter},
+              message: `Invalid BullMQ jobId for pending tasks queue: custom job IDs cannot contain "${forbiddenCharacter}"`,
+            })
+        ),
+        Effect.flatMap(() =>
+          pipe(
+            task,
+            Schema.encode(SendMessageTask),
+            SendMessageTasksManagerError.wrapErrors(
+              'Error while encoding pending task data'
+            )
+          )
         ),
         Effect.flatMap((data) =>
           Effect.tryPromise({

--- a/apps/notification-service/src/services/ThrottledPushNotificationService/services/ThrottledNotificationJobId.ts
+++ b/apps/notification-service/src/services/ThrottledPushNotificationService/services/ThrottledNotificationJobId.ts
@@ -1,0 +1,5 @@
+import {type VexlNotificationTokenSecret} from '@vexl-next/domain/src/general/notifications/VexlNotificationToken'
+
+export const processThrottledNotificationsJobId = (
+  token: VexlNotificationTokenSecret
+): string => `process-throttled-notifications-${token}`

--- a/apps/notification-service/src/services/ThrottledPushNotificationService/services/ThrottledNotificationMq.ts
+++ b/apps/notification-service/src/services/ThrottledPushNotificationService/services/ThrottledNotificationMq.ts
@@ -14,6 +14,7 @@ import {PushNotificationService} from '../../PushNotificationService'
 import {lockOnNotificationToken} from '../utils'
 import {LastTimeIssuedForNotificationTokenDb} from './LastTimeIssuedForNotificationTokenDb'
 import {NotificationWaitingToBeIssuedForNotificationToken} from './NotificationWaitingToBeIssuedForNotificationToken'
+export {processThrottledNotificationsJobId} from './ThrottledNotificationJobId'
 
 export class ProcessThrottledNotificationsError extends Data.TaggedError(
   'ProcessThrottledNotificationsError'
@@ -43,10 +44,6 @@ export const EnqueueProcessNotificationsContext = EnqueueTaskContext
 
 export type EnqueueProcessNotificationsContext =
   typeof EnqueueProcessNotificationsContext
-
-export const processThrottledNotificationsJobId = (
-  token: VexlNotificationTokenSecret
-): string => `process-throttled-notifications:${token}`
 
 export const processThrottledNotificationsWorker = consumerLayer(({token}) =>
   Effect.gen(function* (_) {

--- a/packages/localization/ar-base.json
+++ b/packages/localization/ar-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "الطرف الآخر يبيع منتجًا",
   "chatDetail.offerTitle.theirs.buyOther": "الطرف الآخر يريد شيئًا آخر",
   "chatDetail.offerTitle.theirs.sellOther": "الطرف الآخر يعرض شيئًا آخر",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/base.json
+++ b/packages/localization/base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "They're selling a product",
   "chatDetail.offerTitle.theirs.buyOther": "They want something else",
   "chatDetail.offerTitle.theirs.sellOther": "They're offering something else",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "Tap to read it.",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/bg-base.json
+++ b/packages/localization/bg-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "Продава продукт",
   "chatDetail.offerTitle.theirs.buyOther": "Иска нещо друго",
   "chatDetail.offerTitle.theirs.sellOther": "Предлага нещо друго",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/cs-base.json
+++ b/packages/localization/cs-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "Prodává produkt",
   "chatDetail.offerTitle.theirs.buyOther": "Chce něco jiného",
   "chatDetail.offerTitle.theirs.sellOther": "Nabízí něco jiného",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/de-base.json
+++ b/packages/localization/de-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "Die andere Person verkauft ein Produkt",
   "chatDetail.offerTitle.theirs.buyOther": "Die andere Person will etwas anderes",
   "chatDetail.offerTitle.theirs.sellOther": "Die andere Person bietet etwas anderes an",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/en-base.json
+++ b/packages/localization/en-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "They're selling a product",
   "chatDetail.offerTitle.theirs.buyOther": "They want something else",
   "chatDetail.offerTitle.theirs.sellOther": "They're offering something else",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "Tap to read it.",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/es-base.json
+++ b/packages/localization/es-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "Está vendiendo un producto",
   "chatDetail.offerTitle.theirs.buyOther": "Quiere otra cosa",
   "chatDetail.offerTitle.theirs.sellOther": "Ofrece otra cosa",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/fa-base.json
+++ b/packages/localization/fa-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "طرف مقابل یه محصول می‌فروشه",
   "chatDetail.offerTitle.theirs.buyOther": "طرف مقابل چیز دیگه‌ای می‌خواد",
   "chatDetail.offerTitle.theirs.sellOther": "طرف مقابل چیز دیگه‌ای پیشنهاد می‌ده",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/fi-base.json
+++ b/packages/localization/fi-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "Hän myy tuotetta",
   "chatDetail.offerTitle.theirs.buyOther": "Hän haluaa jotain muuta",
   "chatDetail.offerTitle.theirs.sellOther": "Hän tarjoaa jotain muuta",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/fr-base.json
+++ b/packages/localization/fr-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "L’autre personne vend un produit",
   "chatDetail.offerTitle.theirs.buyOther": "L’autre personne veut autre chose",
   "chatDetail.offerTitle.theirs.sellOther": "L’autre personne propose autre chose",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/id-base.json
+++ b/packages/localization/id-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "Dia menjual produk",
   "chatDetail.offerTitle.theirs.buyOther": "Dia mau sesuatu yang lain",
   "chatDetail.offerTitle.theirs.sellOther": "Dia menawarkan sesuatu yang lain",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/it-base.json
+++ b/packages/localization/it-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "L’altra persona sta vendendo un prodotto",
   "chatDetail.offerTitle.theirs.buyOther": "L’altra persona vuole qualcos’altro",
   "chatDetail.offerTitle.theirs.sellOther": "L’altra persona sta offrendo qualcos’altro",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/ja-base.json
+++ b/packages/localization/ja-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "相手は商品を販売中",
   "chatDetail.offerTitle.theirs.buyOther": "相手はほかのものを求めています",
   "chatDetail.offerTitle.theirs.sellOther": "相手はほかのものを提供中",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/nl-base.json
+++ b/packages/localization/nl-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "De ander verkoopt een product",
   "chatDetail.offerTitle.theirs.buyOther": "De ander wil iets anders",
   "chatDetail.offerTitle.theirs.sellOther": "De ander biedt iets anders aan",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/no-base.json
+++ b/packages/localization/no-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "Den andre selger et produkt",
   "chatDetail.offerTitle.theirs.buyOther": "Den andre vil ha noe annet",
   "chatDetail.offerTitle.theirs.sellOther": "Den andre tilbyr noe annet",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/pcm-base.json
+++ b/packages/localization/pcm-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "E dey sell product",
   "chatDetail.offerTitle.theirs.buyOther": "E wan anoda thing",
   "chatDetail.offerTitle.theirs.sellOther": "E dey offer anoda thing",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/pl-base.json
+++ b/packages/localization/pl-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "Druga strona sprzedaje produkt",
   "chatDetail.offerTitle.theirs.buyOther": "Druga strona chce coś innego",
   "chatDetail.offerTitle.theirs.sellOther": "Druga strona oferuje coś innego",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/pt-base.json
+++ b/packages/localization/pt-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "A outra pessoa está a vender um produto",
   "chatDetail.offerTitle.theirs.buyOther": "A outra pessoa quer outra coisa",
   "chatDetail.offerTitle.theirs.sellOther": "A outra pessoa está a oferecer outra coisa",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/sk-base.json
+++ b/packages/localization/sk-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "Predáva produkt",
   "chatDetail.offerTitle.theirs.buyOther": "Chce niečo iné",
   "chatDetail.offerTitle.theirs.sellOther": "Ponúka niečo iné",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/sv-base.json
+++ b/packages/localization/sv-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "Den andra personen säljer en produkt",
   "chatDetail.offerTitle.theirs.buyOther": "Den andra personen vill ha något annat",
   "chatDetail.offerTitle.theirs.sellOther": "Den andra personen erbjuder något annat",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/sw-base.json
+++ b/packages/localization/sw-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "Anauza bidhaa",
   "chatDetail.offerTitle.theirs.buyOther": "Anataka kitu kingine",
   "chatDetail.offerTitle.theirs.sellOther": "Anatoa kitu kingine",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/tr-base.json
+++ b/packages/localization/tr-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "Bir ürün satıyor",
   "chatDetail.offerTitle.theirs.buyOther": "Başka bir şey istiyor",
   "chatDetail.offerTitle.theirs.sellOther": "Başka bir şey sunuyor",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/uk-base.json
+++ b/packages/localization/uk-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "Продає товар",
   "chatDetail.offerTitle.theirs.buyOther": "Хоче щось інше",
   "chatDetail.offerTitle.theirs.sellOther": "Пропонує щось інше",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/localization/zh-base.json
+++ b/packages/localization/zh-base.json
@@ -1462,5 +1462,7 @@
   "chatDetail.offerTitle.theirs.sellProduct": "对方正在出售一件商品",
   "chatDetail.offerTitle.theirs.buyOther": "对方想要别的东西",
   "chatDetail.offerTitle.theirs.sellOther": "对方正在提供别的东西",
-  "contacts.processingContacts": "Processing contacts"
+  "contacts.processingContacts": "Processing contacts",
+  "messages.fallbackMessage.body": "You have received a new message in Vexl",
+  "messages.fallbackMessage.title": "New message in Vexl"
 }

--- a/packages/server-utils/src/__tests__/mqService.test.ts
+++ b/packages/server-utils/src/__tests__/mqService.test.ts
@@ -21,4 +21,20 @@ describe('validateBullMqJobOptions', () => {
 
     expect(Exit.isSuccess(result)).toBe(true)
   })
+
+  it('allows options without a custom job ID', async () => {
+    const result = await Effect.runPromiseExit(
+      validateBullMqJobOptions({}, (character) => ({character}))
+    )
+
+    expect(Exit.isSuccess(result)).toBe(true)
+  })
+
+  it('allows undefined options', async () => {
+    const result = await Effect.runPromiseExit(
+      validateBullMqJobOptions(undefined, (character) => ({character}))
+    )
+
+    expect(Exit.isSuccess(result)).toBe(true)
+  })
 })

--- a/packages/server-utils/src/__tests__/mqService.test.ts
+++ b/packages/server-utils/src/__tests__/mqService.test.ts
@@ -1,0 +1,24 @@
+import {Effect, Exit} from 'effect/index'
+import {validateBullMqJobOptions} from '../mqService'
+
+describe('validateBullMqJobOptions', () => {
+  it('fails before BullMQ receives a custom job ID containing a colon', async () => {
+    const result = await Effect.runPromiseExit(
+      validateBullMqJobOptions({jobId: 'invalid:job-id'}, (character) => ({
+        character,
+      }))
+    )
+
+    expect(Exit.isFailure(result)).toBe(true)
+  })
+
+  it('allows custom job IDs without colons', async () => {
+    const result = await Effect.runPromiseExit(
+      validateBullMqJobOptions({jobId: 'valid-job-id'}, (character) => ({
+        character,
+      }))
+    )
+
+    expect(Exit.isSuccess(result)).toBe(true)
+  })
+})

--- a/packages/server-utils/src/mqService.ts
+++ b/packages/server-utils/src/mqService.ts
@@ -19,6 +19,19 @@ export class MqServiceError extends Data.TaggedError('MqServiceError')<{
   message: string
 }> {}
 
+const BULLMQ_JOB_ID_FORBIDDEN_CHARACTER = ':'
+
+export const validateBullMqJobOptions = <E>(
+  options: JobsOptions | undefined,
+  onInvalidJobId: (forbiddenCharacter: string) => E
+): Effect.Effect<void, E> => {
+  if (options?.jobId?.includes(BULLMQ_JOB_ID_FORBIDDEN_CHARACTER)) {
+    return Effect.fail(onInvalidJobId(BULLMQ_JOB_ID_FORBIDDEN_CHARACTER))
+  }
+
+  return Effect.void
+}
+
 export type EnqueueTask<A, R> = (
   task: A,
   options?: JobsOptions
@@ -103,8 +116,15 @@ export const makeMqService = <A, I, R, TAG extends string>(
       Effect.map(
         (queue) => (task: A, options?: JobsOptions) =>
           pipe(
-            task,
-            Schema.encode(JobPayloadSchema),
+            validateBullMqJobOptions(
+              options,
+              (forbiddenCharacter) =>
+                new MqServiceError({
+                  cause: {forbiddenCharacter},
+                  message: `Invalid BullMQ jobId for ${queueName} queue: custom job IDs cannot contain "${forbiddenCharacter}"`,
+                })
+            ),
+            Effect.flatMap(() => pipe(task, Schema.encode(JobPayloadSchema))),
             Effect.flatMap((data) =>
               Effect.tryPromise({
                 try: async () => await queue.add(queueName, data, options),


### PR DESCRIPTION
## Summary
- Replace the throttled notification job ID separator with a BullMQ-safe hyphenated format.
- Add a shared guard in `server-utils` that rejects custom BullMQ `jobId` values containing `:` before they reach BullMQ.
- Apply the same guard to the pending notification tasks queue.
- Add regression coverage for the throttled notification job ID format and the new validation behavior.
- Update fallback notification localization strings.

## Testing
- `yarn turbo:typecheck --filter=@vexl-next/notification-service --filter=@vexl-next/server-utils`
- `yarn turbo:format`
- `yarn turbo:lint`
- `yarn workspace @vexl-next/server-utils jest mqService.test.ts`
- `yarn workspace @vexl-next/notification-service jest throttledNotificationMq.test.ts` was blocked locally by the notification-service Jest setup requiring Postgres on `localhost:5432`