### PR TITLE
Polish contact preferences empty state

### DIFF
--- a/apps/mobile/src/components/ContactPreferencesScreen/components/ContactListSelect/atom.ts
+++ b/apps/mobile/src/components/ContactPreferencesScreen/components/ContactListSelect/atom.ts
@@ -260,6 +260,9 @@ export const contactSelectMolecule = molecule((_, getScope) => {
 
     return contactsToDisplay.length !== 0
   })
+  const areThereAnySelectedContactsAtom = atom(
+    (get) => get(selectedNumbersAtom).size > 0
+  )
 
   const selectAllAtom = atom(
     (get) => {
@@ -528,6 +531,7 @@ export const contactSelectMolecule = molecule((_, getScope) => {
     addNewContactActionAtom,
     contactsFilterAtom,
     areThereAnyContactsToDisplayForSelectedTabAtom,
+    areThereAnySelectedContactsAtom,
     selectedNumbersAtom,
     syncDefaultSelectedContactsActionAtom,
     submitAllSelectedContactsActionAtom,

--- a/apps/mobile/src/components/ContactPreferencesScreen/components/ContactListSelect/index.tsx
+++ b/apps/mobile/src/components/ContactPreferencesScreen/components/ContactListSelect/index.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  DismissKeyboardOnPressOutside,
   KeyboardStickyView,
   Stack,
   XStack,
@@ -36,6 +37,7 @@ function ContactsListSelect({
 }): React.ReactElement {
   const {t} = useTranslation()
   const {
+    areThereAnySelectedContactsAtom,
     areThereAnyContactsToDisplayForSelectedTabAtom,
     isContactsPreparingAtom,
     newContactsToDisplayCountAtom,
@@ -45,6 +47,9 @@ function ContactsListSelect({
   const newContactsToDisplayCount = useAtomValue(newContactsToDisplayCountAtom)
   const areThereAnyContactsToDisplayForSelectedTab = useAtomValue(
     areThereAnyContactsToDisplayForSelectedTabAtom
+  )
+  const areThereAnySelectedContacts = useAtomValue(
+    areThereAnySelectedContactsAtom
   )
   const {selectedFilter, setSelectedFilter} = usePreparedContactsFilter(filter)
   const {isSubmittingContacts, submitSelectedContacts} =
@@ -58,10 +63,13 @@ function ContactsListSelect({
     submitBarHeightRef.current = measuredSubmitBarHeight
     setSubmitBarHeight(measuredSubmitBarHeight)
   }, [])
+  const shouldShowSubmitBar =
+    areThereAnyContactsToDisplayForSelectedTab || areThereAnySelectedContacts
+  const effectiveSubmitBarHeight = shouldShowSubmitBar ? submitBarHeight : 0
   const keyboardBottomSpacerHeight = useKeyboardAwareFooterListPadding({
     footerHeight: 0,
     footerHeightFallback: 0,
-    keyboardHeightOffset: submitBarHeight,
+    keyboardHeightOffset: effectiveSubmitBarHeight,
   })
 
   const shouldShowEmptyContactsState =
@@ -99,7 +107,7 @@ function ContactsListSelect({
 
   return (
     <Stack f={1} pos="relative">
-      <Stack f={1} pb={submitBarHeight}>
+      <Stack f={1} pb={effectiveSubmitBarHeight}>
         <Stack px="$5" pb="$3" gap="$3">
           <ContactsAccessPrivilegesInfoBanner />
           <XStack alignItems="center" gap="$3">
@@ -116,25 +124,32 @@ function ContactsListSelect({
           selectedFilter={selectedFilter}
           onSelectedFilterChange={setSelectedFilter}
         />
-        <Stack f={1} pos="relative">
-          <FilteredContacts
-            keyboardBottomSpacerHeight={keyboardBottomSpacerHeight}
-          />
-          <PreparingContactsOverlay visible={isContactsPreparing} zIndex={10} />
-        </Stack>
+        <DismissKeyboardOnPressOutside>
+          <Stack f={1} pos="relative">
+            <FilteredContacts
+              keyboardBottomSpacerHeight={keyboardBottomSpacerHeight}
+            />
+            <PreparingContactsOverlay
+              visible={isContactsPreparing}
+              zIndex={10}
+            />
+          </Stack>
+        </DismissKeyboardOnPressOutside>
       </Stack>
-      <KeyboardStickyView
-        style={{position: 'absolute', left: 0, right: 0, bottom: 0}}
-      >
-        <Stack px="$5" py="$4" onLayout={handleSubmitBarLayout}>
-          <Button
-            disabled={isSubmittingContacts}
-            onPress={submitSelectedContacts}
-          >
-            {t('common.submit')}
-          </Button>
-        </Stack>
-      </KeyboardStickyView>
+      {shouldShowSubmitBar ? (
+        <KeyboardStickyView
+          style={{position: 'absolute', left: 0, right: 0, bottom: 0}}
+        >
+          <Stack px="$5" py="$4" onLayout={handleSubmitBarLayout}>
+            <Button
+              disabled={isSubmittingContacts}
+              onPress={submitSelectedContacts}
+            >
+              {t('common.submit')}
+            </Button>
+          </Stack>
+        </KeyboardStickyView>
+      ) : null}
       <PreparingContactsOverlay
         labelKey="contacts.processingContacts"
         visible={isSubmittingContacts}

--- a/apps/mobile/src/components/CurrentBtcPrice.tsx
+++ b/apps/mobile/src/components/CurrentBtcPrice.tsx
@@ -27,8 +27,10 @@ import {formatDecimal} from '../utils/localization/formatting'
 import {formattingLocaleAtom} from '../utils/localization/formattingLocaleAtom'
 import {localizedDateTimeActionAtom} from '../utils/localization/localizedNumbersAtoms'
 
-interface Props
-  extends Omit<TypographyProps, 'children' | 'color' | 'variant'> {
+interface Props extends Omit<
+  TypographyProps,
+  'children' | 'color' | 'variant'
+> {
   customBtcPriceAtom?: PrimitiveAtom<number> | undefined
   currencyAtom: Atom<CurrencyCode | undefined>
   disabled?: boolean

--- a/apps/mobile/src/components/GlobalDialog.tsx
+++ b/apps/mobile/src/components/GlobalDialog.tsx
@@ -22,8 +22,10 @@ type DialogBackgroundColor = React.ComponentProps<
   typeof Stack
 >['backgroundColor']
 
-interface DialogTextInputProps
-  extends Omit<UiInputProps, 'autoFocus' | 'onChangeText' | 'value'> {
+interface DialogTextInputProps extends Omit<
+  UiInputProps,
+  'autoFocus' | 'onChangeText' | 'value'
+> {
   readonly icon?: unknown
   readonly onClearPress?: () => void
   readonly showClearButton?: boolean

--- a/apps/mobile/src/components/LoginFlow/components/Countdown.tsx
+++ b/apps/mobile/src/components/LoginFlow/components/Countdown.tsx
@@ -4,8 +4,10 @@ import React, {useEffect, useState} from 'react'
 
 type TypographyProps = React.ComponentProps<typeof Typography>
 
-interface Props
-  extends Omit<TypographyProps, 'children' | 'color' | 'variant'> {
+interface Props extends Omit<
+  TypographyProps,
+  'children' | 'color' | 'variant'
+> {
   countUntil: Luxon.DateTime
   onFinished: () => void
   color?: TypographyProps['color']

--- a/apps/mobile/src/components/OffersList/index.tsx
+++ b/apps/mobile/src/components/OffersList/index.tsx
@@ -24,8 +24,10 @@ function renderItem(
   return <OffersListItem isFirst={info.index === 0} offerAtom={info.item} />
 }
 
-export interface Props
-  extends Omit<FlashListProps<Atom<OneOfferInState>>, 'renderItem' | 'data'> {
+export interface Props extends Omit<
+  FlashListProps<Atom<OneOfferInState>>,
+  'renderItem' | 'data'
+> {
   readonly offersAtoms: Array<Atom<OneOfferInState>>
   readonly scrollToTopRef?: React.RefObject<(() => void) | null>
 }


### PR DESCRIPTION
## Summary
- Hide the contact submit footer when the active search/filter has no displayed contacts.
- Dismiss the keyboard when tapping the contact content/background area.

Fixes #2471

## Verification
- yarn turbo:typecheck
- yarn turbo:format
- yarn turbo:lint (passed with existing deprecation warnings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Submit bar visibility now adapts based on available contacts in the selected tab.
  * Keyboard can now be dismissed by tapping outside the input area.
  * Improved layout spacing and padding calculations for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->