### PR TITLE
Update scanned existing contact dialog

### DIFF
--- a/apps/mobile/src/components/CurrentBtcPrice.tsx
+++ b/apps/mobile/src/components/CurrentBtcPrice.tsx
@@ -27,8 +27,10 @@ import {formatDecimal} from '../utils/localization/formatting'
 import {formattingLocaleAtom} from '../utils/localization/formattingLocaleAtom'
 import {localizedDateTimeActionAtom} from '../utils/localization/localizedNumbersAtoms'
 
-interface Props
-  extends Omit<TypographyProps, 'children' | 'color' | 'variant'> {
+interface Props extends Omit<
+  TypographyProps,
+  'children' | 'color' | 'variant'
+> {
   customBtcPriceAtom?: PrimitiveAtom<number> | undefined
   currencyAtom: Atom<CurrencyCode | undefined>
   disabled?: boolean

--- a/apps/mobile/src/components/GlobalDialog.tsx
+++ b/apps/mobile/src/components/GlobalDialog.tsx
@@ -22,8 +22,10 @@ type DialogBackgroundColor = React.ComponentProps<
   typeof Stack
 >['backgroundColor']
 
-interface DialogTextInputProps
-  extends Omit<UiInputProps, 'autoFocus' | 'onChangeText' | 'value'> {
+interface DialogTextInputProps extends Omit<
+  UiInputProps,
+  'autoFocus' | 'onChangeText' | 'value'
+> {
   readonly icon?: unknown
   readonly onClearPress?: () => void
   readonly showClearButton?: boolean

--- a/apps/mobile/src/components/LoginFlow/components/Countdown.tsx
+++ b/apps/mobile/src/components/LoginFlow/components/Countdown.tsx
@@ -4,8 +4,10 @@ import React, {useEffect, useState} from 'react'
 
 type TypographyProps = React.ComponentProps<typeof Typography>
 
-interface Props
-  extends Omit<TypographyProps, 'children' | 'color' | 'variant'> {
+interface Props extends Omit<
+  TypographyProps,
+  'children' | 'color' | 'variant'
+> {
   countUntil: Luxon.DateTime
   onFinished: () => void
   color?: TypographyProps['color']

--- a/apps/mobile/src/components/OffersList/index.tsx
+++ b/apps/mobile/src/components/OffersList/index.tsx
@@ -24,8 +24,10 @@ function renderItem(
   return <OffersListItem isFirst={info.index === 0} offerAtom={info.item} />
 }
 
-export interface Props
-  extends Omit<FlashListProps<Atom<OneOfferInState>>, 'renderItem' | 'data'> {
+export interface Props extends Omit<
+  FlashListProps<Atom<OneOfferInState>>,
+  'renderItem' | 'data'
+> {
   readonly offersAtoms: Array<Atom<OneOfferInState>>
   readonly scrollToTopRef?: React.RefObject<(() => void) | null>
 }

--- a/apps/mobile/src/state/contacts/atom/addContactWithUiFeedbackAtom.ts
+++ b/apps/mobile/src/state/contacts/atom/addContactWithUiFeedbackAtom.ts
@@ -27,6 +27,7 @@ const editExistingContactActionAtom: ActionAtomType<
   [
     existingContact: StoredContactWithComputedValues & {
       avatar?: SvgStringOrImageUri
+      existingContactName: string
     },
   ],
   Effect.Effect<boolean, never>
@@ -37,6 +38,7 @@ const editExistingContactActionAtom: ActionAtomType<
     set,
     existingContact: StoredContactWithComputedValues & {
       avatar?: SvgStringOrImageUri
+      existingContactName: string
     }
   ) => {
     const {t} = get(translationAtom)
@@ -48,6 +50,7 @@ const editExistingContactActionAtom: ActionAtomType<
         set(showUpsertContactDialogAtom, {
           type: 'edit',
           contactName: existingContact.info.name,
+          existingContactName: existingContact.existingContactName,
           contactNumber: existingContact.computedValues.normalizedNumber,
           phoneContactId: existingContact.info.nonUniqueContactId,
           profileImage: existingContact.avatar,
@@ -295,6 +298,8 @@ export const addContactWithUiFeedbackActionAtom: ActionAtomType<
       ? set(editExistingContactActionAtom, {
           ...existingContact.value,
           computedValues: existingContact.value.computedValues,
+          info: {...existingContact.value.info, name: newContact.info.name},
+          existingContactName: existingContact.value.info.name,
           avatar: newContact.avatar,
         })
       : set(createContactWithUiFeedbackActionAtom, {

--- a/apps/mobile/src/state/contacts/atom/showUpsertContactDialogAtom.tsx
+++ b/apps/mobile/src/state/contacts/atom/showUpsertContactDialogAtom.tsx
@@ -4,6 +4,8 @@ import {toBasicError} from '@vexl-next/domain/src/utility/errors'
 import {
   Avatar,
   CellPhoneMobileDevice,
+  IconButton,
+  PencilWriteEdit,
   Selector,
   Stack,
   TextField,
@@ -18,6 +20,7 @@ import {atom, useAtomValue, type SetStateAction, type WritableAtom} from 'jotai'
 import React from 'react'
 import {Keyboard} from 'react-native'
 import {SvgXml} from 'react-native-svg'
+import {useTheme} from 'tamagui'
 import ContactPictureImage from '../../../components/ContactPictureImage'
 import {globalDialogAtom} from '../../../components/GlobalDialog'
 import {translationAtom} from '../../../utils/localization/I18nProvider'
@@ -26,6 +29,23 @@ import {type NonUniqueContactId} from '../domain'
 
 type StringAtom = WritableAtom<string, [SetStateAction<string>], void>
 type BooleanAtom = WritableAtom<boolean, [SetStateAction<boolean>], void>
+
+type ShowUpsertContactDialogParams =
+  | {
+      type: 'create'
+      contactName?: string
+      contactNumber: E164PhoneNumber
+      phoneContactId?: Option.Option<NonUniqueContactId>
+      profileImage?: SvgStringOrImageUri
+    }
+  | {
+      type: 'edit'
+      contactName: string
+      existingContactName: string
+      contactNumber: E164PhoneNumber
+      phoneContactId?: Option.Option<NonUniqueContactId>
+      profileImage?: SvgStringOrImageUri
+    }
 
 function safeParsePhoneNumber(contactNumber: E164PhoneNumber): string {
   try {
@@ -83,16 +103,94 @@ function UpsertContactDialogBody({
   )
 }
 
+function ContactExistsFromLinkDialogBody({
+  contactNameAtom,
+  contactNumber,
+  description,
+  fallbackContactName,
+  profileImage,
+  saveToPhoneAtom,
+  saveToPhoneLabel,
+  editLabel,
+}: {
+  contactNameAtom: StringAtom
+  contactNumber: string
+  description: string
+  fallbackContactName: string
+  profileImage?: SvgStringOrImageUri
+  saveToPhoneAtom: BooleanAtom
+  saveToPhoneLabel: string
+  editLabel: string
+}): React.JSX.Element {
+  const theme = useTheme()
+  const [isEditingName, setIsEditingName] = React.useState(false)
+  const currentContactName = useAtomValue(contactNameAtom)
+  const previewName = currentContactName.trim() || fallbackContactName
+
+  return (
+    <YStack gap="$5">
+      <Typography color="$foregroundSecondary" variant="paragraphSmall">
+        {description}
+      </Typography>
+      <YStack gap="$3">
+        <UpsertContactDialogContactRow
+          contactName={previewName}
+          contactNumber={contactNumber}
+          profileImage={profileImage}
+          rightElement={
+            isEditingName ? null : (
+              <IconButton
+                aria-label={editLabel}
+                backgroundColor="$backgroundSecondary"
+                onPress={() => {
+                  setIsEditingName(true)
+                }}
+              >
+                <PencilWriteEdit
+                  color={theme.foregroundPrimary.get()}
+                  size={20}
+                />
+              </IconButton>
+            )
+          }
+        />
+        {isEditingName ? (
+          <TextField
+            backgroundColor="$backgroundPrimary"
+            autoFocus
+            valueAtom={contactNameAtom}
+            placeholder={fallbackContactName}
+            showClear
+            onCheckmarkPress={() => {
+              Keyboard.dismiss()
+              setIsEditingName(false)
+            }}
+          />
+        ) : null}
+      </YStack>
+      <Selector
+        variant="switch"
+        backgroundColor="$backgroundPrimary"
+        label={saveToPhoneLabel}
+        icon={CellPhoneMobileDevice}
+        valueAtom={saveToPhoneAtom}
+      />
+    </YStack>
+  )
+}
+
 export function UpsertContactDialogContactRow({
   contactName,
   contactNumber,
   phoneContactId,
   profileImage,
+  rightElement,
 }: {
   readonly contactName: string
   readonly contactNumber: string
   readonly phoneContactId?: Option.Option<NonUniqueContactId>
   readonly profileImage?: SvgStringOrImageUri
+  readonly rightElement?: React.ReactNode
 }): React.JSX.Element {
   return (
     <XStack
@@ -124,6 +222,9 @@ export function UpsertContactDialogContactRow({
           {contactNumber}
         </Typography>
       </YStack>
+      {rightElement != null ? (
+        <Stack flexShrink={0}>{rightElement}</Stack>
+      ) : null}
     </XStack>
   )
 }
@@ -171,26 +272,14 @@ export interface UpsertContactDialogResult {
 
 export const showUpsertContactDialogAtom = atom(
   null,
-  (
-    get,
-    set,
-    params: {
-      type: 'create' | 'edit'
-      contactName?: string
-      contactNumber: E164PhoneNumber
-      phoneContactId?: Option.Option<NonUniqueContactId>
-      profileImage?: SvgStringOrImageUri
-    }
-  ) => {
+  (get, set, params: ShowUpsertContactDialogParams) => {
     const {t} = get(translationAtom)
-    const {type, contactName, contactNumber, phoneContactId, profileImage} =
-      params
-    const formattedContactNumber = safeParsePhoneNumber(contactNumber)
+    const formattedContactNumber = safeParsePhoneNumber(params.contactNumber)
     const isAlreadyInPhoneContacts = Option.isSome(
-      phoneContactId ?? Option.none()
+      params.phoneContactId ?? Option.none()
     )
-    const contactNameAtom = atom(contactName ?? '')
-    const saveToPhoneAtom = atom(true)
+    const contactNameAtom = atom(params.contactName ?? '')
+    const saveToPhoneAtom = atom(params.type === 'create')
     const positiveButtonDisabledAtom = atom(
       (get) => get(contactNameAtom).trim().length === 0
     )
@@ -199,38 +288,52 @@ export const showUpsertContactDialogAtom = atom(
       const confirmed = yield* _(
         set(globalDialogAtom, {
           title:
-            type === 'edit'
-              ? t('addContactDialog.editContact')
+            params.type === 'edit'
+              ? t('addContactDialog.contactExistsTitle')
               : t('addContactDialog.addContact'),
           negativeButtonText:
-            type === 'edit'
+            params.type === 'edit'
               ? t('addContactDialog.keepCurrent')
               : t('common.notNow'),
           positiveButtonText:
-            type === 'edit'
-              ? t('common.change')
+            params.type === 'edit'
+              ? t('addContactDialog.update')
               : t('addContactDialog.addContact'),
           positiveButtonDisabledAtom,
-          children: (
-            <UpsertContactDialogBody
-              contactNameAtom={contactNameAtom}
-              contactNumber={formattedContactNumber}
-              fallbackContactName={contactName}
-              placeholder={
-                type === 'edit'
-                  ? (contactName ?? '')
-                  : t('addContactDialog.addContactName')
-              }
-              phoneContactId={phoneContactId}
-              profileImage={profileImage}
-              saveToPhoneAtom={saveToPhoneAtom}
-              saveToPhoneLabel={
-                isAlreadyInPhoneContacts
-                  ? t('addContactDialog.updateInYourPhoneContacts')
-                  : t('addContactDialog.alsoSaveToYourPhone')
-              }
-            />
-          ),
+          children:
+            params.type === 'edit' ? (
+              <ContactExistsFromLinkDialogBody
+                contactNameAtom={contactNameAtom}
+                contactNumber={formattedContactNumber}
+                description={t('addContactDialog.contactExistsDescription', {
+                  contactName: params.existingContactName,
+                })}
+                fallbackContactName={params.contactName}
+                profileImage={params.profileImage}
+                saveToPhoneAtom={saveToPhoneAtom}
+                saveToPhoneLabel={
+                  isAlreadyInPhoneContacts
+                    ? t('addContactDialog.updateInYourPhoneContacts')
+                    : t('addContactDialog.alsoSaveToYourPhone')
+                }
+                editLabel={t('common.edit')}
+              />
+            ) : (
+              <UpsertContactDialogBody
+                contactNameAtom={contactNameAtom}
+                contactNumber={formattedContactNumber}
+                fallbackContactName={params.contactName}
+                placeholder={t('addContactDialog.addContactName')}
+                phoneContactId={params.phoneContactId}
+                profileImage={params.profileImage}
+                saveToPhoneAtom={saveToPhoneAtom}
+                saveToPhoneLabel={
+                  isAlreadyInPhoneContacts
+                    ? t('addContactDialog.updateInYourPhoneContacts')
+                    : t('addContactDialog.alsoSaveToYourPhone')
+                }
+              />
+            ),
         })
       )
 
@@ -242,7 +345,9 @@ export const showUpsertContactDialogAtom = atom(
 
       return {
         contactName:
-          get(contactNameAtom).trim() || contactName || contactNumber,
+          get(contactNameAtom).trim() ||
+          params.contactName ||
+          params.contactNumber,
         saveToPhone: get(saveToPhoneAtom),
       } satisfies UpsertContactDialogResult
     })


### PR DESCRIPTION
## Summary
- Update the duplicate-contact dialog used after scanning another person's contact QR/link.
- Preview the scanned profile name/avatar while showing the already-saved contact name in the description.
- Let the user edit the proposed name via the pencil action before choosing Update.

## Verification
- yarn turbo:typecheck
- yarn turbo:format (after yarn turbo:format:fix)
- yarn turbo:lint

Closes #2487

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to inline edit contact names in dialogs with a dedicated edit button to toggle between view and edit modes.
  * Improved contact dialog UI for existing contact scenarios with enhanced layout and controls.

* **Improvements**
  * Refined save-to-phone behavior based on whether you're creating or updating a contact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->