### PR TITLE
Allow pasted phone numbers in onboarding

### DIFF
--- a/apps/mobile/src/components/LoginFlow/components/PhoneNumberScreen.tsx
+++ b/apps/mobile/src/components/LoginFlow/components/PhoneNumberScreen.tsx
@@ -1,20 +1,10 @@
 import {useFocusEffect} from '@react-navigation/native'
-import {
-  toE164PhoneNumber,
-  type E164PhoneNumber,
-} from '@vexl-next/domain/src/general/E164PhoneNumber.brand'
+import {type E164PhoneNumber} from '@vexl-next/domain/src/general/E164PhoneNumber.brand'
 import {Typography, XStack, YStack} from '@vexl-next/ui'
 import {Effect, Option} from 'effect'
 import {useAtomValue, useSetAtom} from 'jotai'
-import type {CountryCode} from 'libphonenumber-js'
-import {
-  AsYouType,
-  getExampleNumber,
-  isSupportedCountry,
-} from 'libphonenumber-js'
-import examples from 'libphonenumber-js/examples.mobile.json'
 import React, {useCallback, useEffect, useRef, useState} from 'react'
-import {Keyboard, TextInput} from 'react-native'
+import {Keyboard, StyleSheet, TextInput} from 'react-native'
 import {getCountryByCca2, type ICountry} from 'react-native-country-select'
 import {type LoginFlowStackScreenProps} from '../../../navigationTypes'
 import {
@@ -25,12 +15,16 @@ import {useTranslation} from '../../../utils/localization/I18nProvider'
 import {useShowLoadingOverlay} from '../../LoadingOverlayProvider'
 import {initPhoneVerificationAtom} from '../api/initPhoneVerificationAtom'
 import {selectedCountryCodeAtom} from '../atoms/selectedCountryCodeAtom'
+import {
+  DEFAULT_COUNTRY,
+  countryCallingCode,
+  getGroupLengths,
+  parsePhoneNumberInput,
+  splitNationalNumberIntoGroups,
+} from '../utils/phoneNumberInput'
 import LoginFlowScreen, {LoginFlowText, LoginFlowTitle} from './LoginFlowScreen'
 
 type Props = LoginFlowStackScreenProps<'PhoneNumber'>
-const FALLBACK_NATIONAL_NUMBER_LENGTH = 15
-const FALLBACK_GROUP_LENGTH = 3
-const DEFAULT_COUNTRY = getCountryByCca2('CZ')
 
 function NumberGroup({
   length,
@@ -49,90 +43,6 @@ function NumberGroup({
   )
 }
 
-function supportedCountryCode(
-  country: ICountry | undefined
-): CountryCode | undefined {
-  if (country === undefined) return undefined
-  return isSupportedCountry(country.cca2) ? country.cca2 : undefined
-}
-
-function countryCallingCode(country: ICountry | undefined): string {
-  return country?.idd.root ?? '+420'
-}
-
-function getNationalNumberLength(country: ICountry | undefined): number {
-  const countryCode = supportedCountryCode(country)
-  if (countryCode === undefined) return FALLBACK_NATIONAL_NUMBER_LENGTH
-
-  return (
-    getExampleNumber(countryCode, examples)?.nationalNumber.length ??
-    FALLBACK_NATIONAL_NUMBER_LENGTH
-  )
-}
-
-function getGroupLengths(country: ICountry | undefined): readonly number[] {
-  const countryCode = supportedCountryCode(country)
-  const exampleNumber =
-    countryCode === undefined
-      ? undefined
-      : getExampleNumber(countryCode, examples)
-
-  if (exampleNumber === undefined) {
-    const groups: number[] = []
-    const maxLength = getNationalNumberLength(country)
-
-    for (let remainingDigits = maxLength; remainingDigits > 0; ) {
-      const groupLength = Math.min(FALLBACK_GROUP_LENGTH, remainingDigits)
-      groups.push(groupLength)
-      remainingDigits -= groupLength
-    }
-
-    return groups
-  }
-
-  const formattedExample = new AsYouType().input(exampleNumber.number)
-  const nationalExample = formattedExample
-    .substring(countryCallingCode(country).length)
-    .trim()
-  const groups = nationalExample.match(/\d+/g)
-
-  if (groups === null) return [exampleNumber.nationalNumber.length]
-
-  const groupLengths: number[] = []
-  for (const group of groups) {
-    groupLengths.push(group.length)
-  }
-
-  return groupLengths
-}
-
-function splitNationalNumberIntoGroups(
-  nationalNumber: string,
-  country: ICountry | undefined
-): readonly string[] {
-  const groups: string[] = []
-  let currentIndex = 0
-
-  for (const groupLength of getGroupLengths(country)) {
-    groups.push(
-      nationalNumber.substring(currentIndex, currentIndex + groupLength)
-    )
-    currentIndex += groupLength
-  }
-
-  while (currentIndex < nationalNumber.length) {
-    groups.push(
-      nationalNumber.substring(
-        currentIndex,
-        currentIndex + FALLBACK_GROUP_LENGTH
-      )
-    )
-    currentIndex += FALLBACK_GROUP_LENGTH
-  }
-
-  return groups
-}
-
 export default function PhoneNumberScreen({
   navigation,
 }: Props): React.ReactElement {
@@ -145,11 +55,16 @@ export default function PhoneNumberScreen({
   const [phoneNumber, setPhoneNumber] = useState<
     Option.Option<E164PhoneNumber>
   >(Option.none())
+  // Prevent atom sync from clearing a number that came from the phone input.
+  const pendingCountryCodeFromPhoneInputRef = useRef<string | undefined>(
+    undefined
+  )
   const navigationInProgressRef = useRef(false)
   const loadingOverlay = useShowLoadingOverlay()
   const initPhoneVerification = useSetAtom(initPhoneVerificationAtom)
   const phoneNumberGroupLengths = getGroupLengths(selectedCountry)
   const selectedCountryCode = useAtomValue(selectedCountryCodeAtom)
+  const setSelectedCountryCode = useSetAtom(selectedCountryCodeAtom)
   const displayedPhoneNumberGroups = splitNationalNumberIntoGroups(
     nationalNumber,
     selectedCountry
@@ -200,12 +115,20 @@ export default function PhoneNumberScreen({
 
   useEffect(() => {
     if (selectedCountryCode === undefined) return
-    if (selectedCountry?.cca2 === selectedCountryCode) return
+    if (selectedCountry?.cca2 === selectedCountryCode) {
+      pendingCountryCodeFromPhoneInputRef.current = undefined
+      return
+    }
 
     const country = getCountryByCca2(selectedCountryCode)
     if (country === undefined) return
 
     setSelectedCountry(country)
+    if (pendingCountryCodeFromPhoneInputRef.current === selectedCountryCode) {
+      pendingCountryCodeFromPhoneInputRef.current = undefined
+      return
+    }
+
     setNationalNumber('')
     setPhoneNumber(Option.none())
   }, [selectedCountryCode, selectedCountry?.cca2])
@@ -253,19 +176,6 @@ export default function PhoneNumberScreen({
           pressStyle={{opacity: 0.8}}
           width="100%"
         >
-          <TextInput
-            autoFocus
-            keyboardType="number-pad"
-            onChangeText={(value) => {
-              const digits = value.replace(/\D/g, '')
-              setNationalNumber(digits)
-              setPhoneNumber(toE164PhoneNumber(`${callingCode}${digits}`))
-            }}
-            ref={inputRef}
-            style={{height: 1, opacity: 0, position: 'absolute', width: 1}}
-            submitBehavior="submit"
-            value={nationalNumber}
-          />
           <Typography
             color="$foregroundPrimary"
             onPress={() => {
@@ -280,9 +190,60 @@ export default function PhoneNumberScreen({
           >
             {callingCode}
           </Typography>
-          {phoneNumberGroupElements}
+          <XStack
+            alignItems="center"
+            gap="$4"
+            justifyContent="center"
+            pos="relative"
+          >
+            <TextInput
+              autoComplete="tel"
+              autoFocus
+              caretHidden
+              keyboardType="phone-pad"
+              onChangeText={(value) => {
+                const parsedInput = parsePhoneNumberInput(
+                  value,
+                  selectedCountry
+                )
+                const parsedCountryCode = parsedInput.selectedCountry?.cca2
+
+                setNationalNumber(parsedInput.nationalNumber)
+                setPhoneNumber(parsedInput.phoneNumber)
+                setSelectedCountry(parsedInput.selectedCountry)
+                if (parsedCountryCode !== selectedCountry?.cca2) {
+                  pendingCountryCodeFromPhoneInputRef.current =
+                    parsedCountryCode
+                  setSelectedCountryCode(parsedCountryCode)
+                }
+              }}
+              ref={inputRef}
+              style={styles.phoneNumberInput}
+              submitBehavior="submit"
+              textContentType="telephoneNumber"
+              value={nationalNumber}
+            />
+            {phoneNumberGroupElements}
+          </XStack>
         </XStack>
       </YStack>
     </LoginFlowScreen>
   )
 }
+
+const styles = StyleSheet.create({
+  phoneNumberInput: {
+    backgroundColor: 'transparent',
+    bottom: 0,
+    color: 'transparent',
+    left: 0,
+    minWidth: '100%',
+    opacity: 0.01,
+    position: 'absolute',
+    right: 0,
+    textAlign: 'center',
+    top: 0,
+    width: '100%',
+    zIndex: 1,
+  },
+})

--- a/apps/mobile/src/components/LoginFlow/utils/phoneNumberInput.test.ts
+++ b/apps/mobile/src/components/LoginFlow/utils/phoneNumberInput.test.ts
@@ -1,0 +1,95 @@
+import {Option} from 'effect'
+import {getCountryByCca2, type ICountry} from 'react-native-country-select'
+import {
+  parsePhoneNumberInput,
+  splitNationalNumberIntoGroups,
+} from './phoneNumberInput'
+
+function country(countryCode: string): ICountry {
+  const country = getCountryByCca2(countryCode)
+  if (country === undefined) throw new Error(`Missing country ${countryCode}`)
+
+  return country
+}
+
+function phoneNumberValue(
+  phoneNumber: ReturnType<typeof parsePhoneNumberInput>['phoneNumber']
+): string | undefined {
+  return Option.isSome(phoneNumber) ? phoneNumber.value : undefined
+}
+
+describe('parsePhoneNumberInput', () => {
+  it('keeps typed national digits under the selected country', () => {
+    const result = parsePhoneNumberInput('777 123 456', country('CZ'))
+
+    expect(result.selectedCountry?.cca2).toBe('CZ')
+    expect(result.nationalNumber).toBe('777123456')
+    expect(phoneNumberValue(result.phoneNumber)).toBe('+420777123456')
+  })
+
+  it('accepts a pasted international number and updates the selected country', () => {
+    const result = parsePhoneNumberInput('+421 901 123 456', country('CZ'))
+
+    expect(result.selectedCountry?.cca2).toBe('SK')
+    expect(result.nationalNumber).toBe('901123456')
+    expect(phoneNumberValue(result.phoneNumber)).toBe('+421901123456')
+  })
+
+  it('accepts a pasted international number without a plus when it is longer than the selected national number', () => {
+    const result = parsePhoneNumberInput('421 901 123 456', country('CZ'))
+
+    expect(result.selectedCountry?.cca2).toBe('SK')
+    expect(result.nationalNumber).toBe('901123456')
+    expect(phoneNumberValue(result.phoneNumber)).toBe('+421901123456')
+  })
+
+  it('accepts a 00-prefixed pasted international number', () => {
+    const result = parsePhoneNumberInput('00421 901 123 456', country('CZ'))
+
+    expect(result.selectedCountry?.cca2).toBe('SK')
+    expect(result.nationalNumber).toBe('901123456')
+    expect(phoneNumberValue(result.phoneNumber)).toBe('+421901123456')
+  })
+
+  it('uses the pasted number if it was inserted after existing input', () => {
+    const result = parsePhoneNumberInput('777+421 901 123 456', country('CZ'))
+
+    expect(result.selectedCountry?.cca2).toBe('SK')
+    expect(result.nationalNumber).toBe('901123456')
+    expect(phoneNumberValue(result.phoneNumber)).toBe('+421901123456')
+  })
+
+  it('uses a 00-prefixed pasted number if it was inserted after existing input', () => {
+    const result = parsePhoneNumberInput('77700421901123456', country('CZ'))
+
+    expect(result.selectedCountry?.cca2).toBe('SK')
+    expect(result.nationalNumber).toBe('901123456')
+    expect(phoneNumberValue(result.phoneNumber)).toBe('+421901123456')
+  })
+
+  it('uses a digit-only pasted number if it was inserted after existing input', () => {
+    const result = parsePhoneNumberInput('777421901123456', country('CZ'))
+
+    expect(result.selectedCountry?.cca2).toBe('SK')
+    expect(result.nationalNumber).toBe('901123456')
+    expect(phoneNumberValue(result.phoneNumber)).toBe('+421901123456')
+  })
+
+  it('keeps incomplete input editable', () => {
+    const result = parsePhoneNumberInput('777', country('CZ'))
+
+    expect(result.selectedCountry?.cca2).toBe('CZ')
+    expect(result.nationalNumber).toBe('777')
+    expect(phoneNumberValue(result.phoneNumber)).toBeUndefined()
+  })
+})
+
+describe('splitNationalNumberIntoGroups', () => {
+  it('keeps the selected country grouping', () => {
+    expect(splitNationalNumberIntoGroups('777123456', country('CZ'))).toEqual([
+      '777',
+      '123',
+      '456',
+    ])
+  })
+})

--- a/apps/mobile/src/components/LoginFlow/utils/phoneNumberInput.ts
+++ b/apps/mobile/src/components/LoginFlow/utils/phoneNumberInput.ts
@@ -1,0 +1,211 @@
+import {
+  toE164PhoneNumber,
+  type E164PhoneNumber,
+} from '@vexl-next/domain/src/general/E164PhoneNumber.brand'
+import {Option} from 'effect'
+import type {CountryCode} from 'libphonenumber-js'
+import {
+  AsYouType,
+  getExampleNumber,
+  isSupportedCountry,
+  parsePhoneNumberFromString,
+} from 'libphonenumber-js'
+import examples from 'libphonenumber-js/examples.mobile.json'
+import {getCountryByCca2, type ICountry} from 'react-native-country-select'
+
+const FALLBACK_NATIONAL_NUMBER_LENGTH = 15
+const FALLBACK_GROUP_LENGTH = 3
+const NON_DIGIT_REGEX = /\D/g
+
+export const DEFAULT_COUNTRY = getCountryByCca2('CZ')
+
+export interface PhoneNumberInputState {
+  readonly selectedCountry: ICountry | undefined
+  readonly nationalNumber: string
+  readonly phoneNumber: Option.Option<E164PhoneNumber>
+}
+
+export function supportedCountryCode(
+  country: ICountry | undefined
+): CountryCode | undefined {
+  if (country === undefined) return undefined
+  return isSupportedCountry(country.cca2) ? country.cca2 : undefined
+}
+
+export function countryCallingCode(country: ICountry | undefined): string {
+  return country?.idd.root ?? '+420'
+}
+
+function digitsOnly(value: string): string {
+  return value.replace(NON_DIGIT_REGEX, '')
+}
+
+export function getNationalNumberLength(country: ICountry | undefined): number {
+  const countryCode = supportedCountryCode(country)
+  if (countryCode === undefined) return FALLBACK_NATIONAL_NUMBER_LENGTH
+
+  return (
+    getExampleNumber(countryCode, examples)?.nationalNumber.length ??
+    FALLBACK_NATIONAL_NUMBER_LENGTH
+  )
+}
+
+export function getGroupLengths(
+  country: ICountry | undefined
+): readonly number[] {
+  const countryCode = supportedCountryCode(country)
+  const exampleNumber =
+    countryCode === undefined
+      ? undefined
+      : getExampleNumber(countryCode, examples)
+
+  if (exampleNumber === undefined) {
+    const groups: number[] = []
+    const maxLength = getNationalNumberLength(country)
+
+    for (let remainingDigits = maxLength; remainingDigits > 0; ) {
+      const groupLength = Math.min(FALLBACK_GROUP_LENGTH, remainingDigits)
+      groups.push(groupLength)
+      remainingDigits -= groupLength
+    }
+
+    return groups
+  }
+
+  const formattedExample = new AsYouType().input(exampleNumber.number)
+  const nationalExample = formattedExample
+    .substring(countryCallingCode(country).length)
+    .trim()
+  const groups = nationalExample.match(/\d+/g)
+
+  if (groups === null) return [exampleNumber.nationalNumber.length]
+
+  const groupLengths: number[] = []
+  for (const group of groups) {
+    groupLengths.push(group.length)
+  }
+
+  return groupLengths
+}
+
+export function splitNationalNumberIntoGroups(
+  nationalNumber: string,
+  country: ICountry | undefined
+): readonly string[] {
+  const groups: string[] = []
+  let currentIndex = 0
+
+  for (const groupLength of getGroupLengths(country)) {
+    groups.push(
+      nationalNumber.substring(currentIndex, currentIndex + groupLength)
+    )
+    currentIndex += groupLength
+  }
+
+  while (currentIndex < nationalNumber.length) {
+    groups.push(
+      nationalNumber.substring(
+        currentIndex,
+        currentIndex + FALLBACK_GROUP_LENGTH
+      )
+    )
+    currentIndex += FALLBACK_GROUP_LENGTH
+  }
+
+  return groups
+}
+
+function normalizeInternationalPrefix(value: string): string {
+  const plusIndex = value.indexOf('+')
+  if (plusIndex >= 0) return value.substring(plusIndex).trim()
+
+  const internationalPrefixIndex = value.indexOf('00')
+  if (internationalPrefixIndex >= 0)
+    return `+${value.substring(internationalPrefixIndex + 2).trim()}`
+
+  return value.trim()
+}
+
+function parsePhoneNumberFromInputValue(
+  value: string,
+  selectedCountry: ICountry | undefined
+): PhoneNumberInputState | undefined {
+  const normalizedValue = normalizeInternationalPrefix(value)
+  const countryCode = supportedCountryCode(selectedCountry)
+  const parsedPhoneNumber =
+    countryCode === undefined
+      ? parsePhoneNumberFromString(normalizedValue)
+      : parsePhoneNumberFromString(normalizedValue, countryCode)
+
+  if (parsedPhoneNumber?.isValid() !== true) return undefined
+
+  const phoneNumber = toE164PhoneNumber(parsedPhoneNumber.number)
+  if (Option.isNone(phoneNumber)) return undefined
+
+  return {
+    nationalNumber: digitsOnly(parsedPhoneNumber.nationalNumber),
+    phoneNumber,
+    selectedCountry:
+      parsedPhoneNumber.country === undefined
+        ? selectedCountry
+        : (getCountryByCca2(parsedPhoneNumber.country) ?? selectedCountry),
+  }
+}
+
+function parseDigitOnlyInternationalPhoneNumber(
+  value: string,
+  selectedCountry: ICountry | undefined
+): PhoneNumberInputState | undefined {
+  const digits = digitsOnly(value)
+  const nationalNumberLength = getNationalNumberLength(selectedCountry)
+  if (digits.length <= nationalNumberLength) return undefined
+
+  const parsedPhoneNumber = parsePhoneNumberFromInputValue(
+    `+${digits}`,
+    selectedCountry
+  )
+  if (parsedPhoneNumber !== undefined) return parsedPhoneNumber
+
+  for (
+    let suffixStartIndex = 1;
+    suffixStartIndex < digits.length;
+    suffixStartIndex++
+  ) {
+    const suffix = digits.substring(suffixStartIndex)
+    if (suffix.length <= nationalNumberLength) return undefined
+
+    const parsedSuffixPhoneNumber = parsePhoneNumberFromInputValue(
+      `+${suffix}`,
+      selectedCountry
+    )
+    if (parsedSuffixPhoneNumber !== undefined) return parsedSuffixPhoneNumber
+  }
+
+  return undefined
+}
+
+export function parsePhoneNumberInput(
+  value: string,
+  selectedCountry: ICountry | undefined
+): PhoneNumberInputState {
+  const parsedPhoneNumber = parsePhoneNumberFromInputValue(
+    value,
+    selectedCountry
+  )
+  if (parsedPhoneNumber !== undefined) return parsedPhoneNumber
+
+  const parsedDigitOnlyInternationalPhoneNumber =
+    parseDigitOnlyInternationalPhoneNumber(value, selectedCountry)
+  if (parsedDigitOnlyInternationalPhoneNumber !== undefined)
+    return parsedDigitOnlyInternationalPhoneNumber
+
+  const nationalNumber = digitsOnly(value)
+
+  return {
+    nationalNumber,
+    phoneNumber: toE164PhoneNumber(
+      `${countryCallingCode(selectedCountry)}${nationalNumber}`
+    ),
+    selectedCountry,
+  }
+}


### PR DESCRIPTION
Closes #2477

## Summary
- parse pasted international phone numbers in the onboarding phone-number input instead of prefixing them twice
- keep normal national-number typing behavior and update the selected country when a pasted number includes another country code
- make the displayed number groups a native paste target via a transparent phone input overlay

## Verification
- yarn turbo:typecheck
- yarn turbo:format:fix, then yarn turbo:format
- yarn turbo:lint
- yarn workspace @vexl-next/mobile-app jest src/components/LoginFlow/utils/phoneNumberInput.test.ts --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced phone number input with intelligent automatic country detection from international phone numbers
  * Improved phone number formatting with organized digit grouping for better readability

* **Style**
  * Removed calling code display element for a cleaner interface
  * Optimized phone input overlay for improved visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->