### PR TITLE
Display notice when filtering leaves few offers

### DIFF
--- a/apps/mobile/src/components/CurrentBtcPrice.tsx
+++ b/apps/mobile/src/components/CurrentBtcPrice.tsx
@@ -27,8 +27,10 @@ import {formatDecimal} from '../utils/localization/formatting'
 import {formattingLocaleAtom} from '../utils/localization/formattingLocaleAtom'
 import {localizedDateTimeActionAtom} from '../utils/localization/localizedNumbersAtoms'
 
-interface Props
-  extends Omit<TypographyProps, 'children' | 'color' | 'variant'> {
+interface Props extends Omit<
+  TypographyProps,
+  'children' | 'color' | 'variant'
+> {
   customBtcPriceAtom?: PrimitiveAtom<number> | undefined
   currencyAtom: Atom<CurrencyCode | undefined>
   disabled?: boolean

--- a/apps/mobile/src/components/GlobalDialog.tsx
+++ b/apps/mobile/src/components/GlobalDialog.tsx
@@ -22,8 +22,10 @@ type DialogBackgroundColor = React.ComponentProps<
   typeof Stack
 >['backgroundColor']
 
-interface DialogTextInputProps
-  extends Omit<UiInputProps, 'autoFocus' | 'onChangeText' | 'value'> {
+interface DialogTextInputProps extends Omit<
+  UiInputProps,
+  'autoFocus' | 'onChangeText' | 'value'
+> {
   readonly icon?: unknown
   readonly onClearPress?: () => void
   readonly showClearButton?: boolean

--- a/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/FewFilteredOffersNotice.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/FewFilteredOffersNotice.tsx
@@ -1,0 +1,60 @@
+import {useNavigation} from '@react-navigation/native'
+import {Button, Typography} from '@vexl-next/ui'
+import React, {useCallback} from 'react'
+import {Stack} from 'tamagui'
+import {useTranslation} from '../../../../../utils/localization/I18nProvider'
+
+export const FEW_FILTERED_OFFERS_NOTICE_MAX_COUNT = 3
+
+export function shouldShowFewFilteredOffersNotice({
+  isMarketplaceNarrowingActive,
+  offersCount,
+}: {
+  readonly isMarketplaceNarrowingActive: boolean
+  readonly offersCount: number
+}): boolean {
+  return (
+    isMarketplaceNarrowingActive &&
+    offersCount > 0 &&
+    offersCount <= FEW_FILTERED_OFFERS_NOTICE_MAX_COUNT
+  )
+}
+
+function FewFilteredOffersNotice({
+  withHorizontalPadding = true,
+}: {
+  readonly withHorizontalPadding?: boolean
+}): React.JSX.Element {
+  const {t} = useTranslation()
+  const navigation = useNavigation()
+
+  const onEditFiltersPress = useCallback(() => {
+    navigation.navigate('FilterOffers')
+  }, [navigation])
+
+  return (
+    <Stack
+      gap="$5"
+      paddingTop="$5"
+      paddingHorizontal={withHorizontalPadding ? '$5' : '$0'}
+    >
+      <Typography
+        color="$foregroundSecondary"
+        textAlign="center"
+        variant="description"
+      >
+        {t('marketplace.fewOffersAfterFiltering')}
+      </Typography>
+      <Button
+        variant="tertiary"
+        size="small"
+        onPress={onEditFiltersPress}
+        width="100%"
+      >
+        {t('marketplace.editFilters')}
+      </Button>
+    </Stack>
+  )
+}
+
+export default FewFilteredOffersNotice

--- a/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/MarketplaceScreenContent.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/MarketplaceScreenContent.tsx
@@ -5,6 +5,7 @@ import {useAtomValue, useSetAtom} from 'jotai'
 import React, {useCallback, useMemo, useRef} from 'react'
 import {Stack} from 'tamagui'
 import {useAreOffersLoading} from '../../../../../state/marketplace'
+import {isMarketplaceNarrowingActiveAtom} from '../../../../../state/marketplace/atoms/filterAtoms'
 import {filteredOffersIncludingLocationFilterAtomsAtom} from '../../../../../state/marketplace/atoms/filteredOffers'
 import {myOffersSortedAtomsAtom} from '../../../../../state/marketplace/atoms/myOffers'
 import {areThereOffersToSeeInMarketplaceWithoutFiltersAtom} from '../../../../../state/marketplace/atoms/offersToSeeInMarketplace'
@@ -17,6 +18,9 @@ import OffersList from '../../../../OffersList'
 import {InsideScreenListHeader, useInsideScreenScroll} from '../../InsideScreen'
 import {type MarketplaceTab} from '../index'
 import AllOffersListHeader from './AllOffersListHeader'
+import FewFilteredOffersNotice, {
+  shouldShowFewFilteredOffersNotice,
+} from './FewFilteredOffersNotice'
 import FilteredOffersEmptyState from './FilteredOffersEmptyState'
 import MyOffersEmptyList from './MyOffersEmptyList'
 import MyOffersListHeader from './MyOffersListHeader'
@@ -83,6 +87,9 @@ function MarketplaceScreenContent({
   const areThereOffersWithoutFilters = useAtomValue(
     areThereOffersToSeeInMarketplaceWithoutFiltersAtom
   )
+  const isMarketplaceNarrowingActive = useAtomValue(
+    isMarketplaceNarrowingActiveAtom
+  )
   const loading = useAreOffersLoading()
 
   useHandleRedirectToContactsScreen()
@@ -130,6 +137,18 @@ function MarketplaceScreenContent({
         : undefined
       : MyOffersEmptyList
 
+  const listFooterComponent = useMemo(
+    () =>
+      activeTab === 'allOffers' &&
+      shouldShowFewFilteredOffersNotice({
+        isMarketplaceNarrowingActive,
+        offersCount: allOffersAtoms.length,
+      }) ? (
+        <FewFilteredOffersNotice />
+      ) : null,
+    [activeTab, allOffersAtoms.length, isMarketplaceNarrowingActive]
+  )
+
   useAppState(
     useCallback(
       (state) => {
@@ -163,6 +182,7 @@ function MarketplaceScreenContent({
         scrollToTopRef={scrollToTopRef}
         ListHeaderComponent={listHeaderComponent}
         ListEmptyComponent={listEmptyComponent}
+        ListFooterComponent={listFooterComponent}
         offersAtoms={offersAtoms}
         onRefresh={activeTab === 'allOffers' ? handleRefresh : undefined}
         refreshing={

--- a/apps/mobile/src/components/LoginFlow/components/Countdown.tsx
+++ b/apps/mobile/src/components/LoginFlow/components/Countdown.tsx
@@ -4,8 +4,10 @@ import React, {useEffect, useState} from 'react'
 
 type TypographyProps = React.ComponentProps<typeof Typography>
 
-interface Props
-  extends Omit<TypographyProps, 'children' | 'color' | 'variant'> {
+interface Props extends Omit<
+  TypographyProps,
+  'children' | 'color' | 'variant'
+> {
   countUntil: Luxon.DateTime
   onFinished: () => void
   color?: TypographyProps['color']

--- a/apps/mobile/src/components/MapViewScreen/components/MapBottomSheet.tsx
+++ b/apps/mobile/src/components/MapViewScreen/components/MapBottomSheet.tsx
@@ -20,9 +20,16 @@ import Animated, {
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {scheduleOnRN} from 'react-native-worklets'
 import {getTokens} from 'tamagui'
-import {filteredOffersForVisibleMapRegionAtom} from '../../../state/marketplace/atoms/filteredOffers'
+import {isMarketplaceNarrowingActiveAtom} from '../../../state/marketplace/atoms/filterAtoms'
+import {
+  filteredOffersForMapAtom,
+  filteredOffersForVisibleMapRegionAtom,
+} from '../../../state/marketplace/atoms/filteredOffers'
 import atomKeyExtractor from '../../../utils/atomUtils/atomKeyExtractor'
 import {useTranslation} from '../../../utils/localization/I18nProvider'
+import FewFilteredOffersNotice, {
+  shouldShowFewFilteredOffersNotice,
+} from '../../InsideRouter/components/MarketplaceScreen/components/FewFilteredOffersNotice'
 import SearchOffers from '../../InsideRouter/components/MarketplaceScreen/components/SearchOffers'
 import OfferOnMarketplace from '../../OfferOnMarketplace'
 import {selectMapViewOfferActionAtom} from '../atoms'
@@ -143,6 +150,16 @@ function renderOfferItem({
 function BottomSheetOfferList(): React.JSX.Element {
   const [listLoaded, setListLoaded] = useState(false)
   const offerAtoms = useAtomValue(mapOffersSplitAtom)
+  const filteredMapOffers = useAtomValue(filteredOffersForMapAtom)
+  const isMarketplaceNarrowingActive = useAtomValue(
+    isMarketplaceNarrowingActiveAtom
+  )
+  const showFewFilteredOffersNotice =
+    offerAtoms.length > 0 &&
+    shouldShowFewFilteredOffersNotice({
+      isMarketplaceNarrowingActive,
+      offersCount: filteredMapOffers.length,
+    })
 
   const handleListLoad = useCallback(() => {
     setListLoaded(true)
@@ -160,6 +177,11 @@ function BottomSheetOfferList(): React.JSX.Element {
         keyExtractor={atomKeyExtractor}
         ItemSeparatorComponent={BottomSheetItemSeparator}
         ListEmptyComponent={OffersListEmptyState}
+        ListFooterComponent={
+          showFewFilteredOffersNotice ? (
+            <FewFilteredOffersNotice withHorizontalPadding={false} />
+          ) : null
+        }
         onLoad={handleListLoad}
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{

--- a/apps/mobile/src/components/OffersList/index.tsx
+++ b/apps/mobile/src/components/OffersList/index.tsx
@@ -24,8 +24,10 @@ function renderItem(
   return <OffersListItem isFirst={info.index === 0} offerAtom={info.item} />
 }
 
-export interface Props
-  extends Omit<FlashListProps<Atom<OneOfferInState>>, 'renderItem' | 'data'> {
+export interface Props extends Omit<
+  FlashListProps<Atom<OneOfferInState>>,
+  'renderItem' | 'data'
+> {
   readonly offersAtoms: Array<Atom<OneOfferInState>>
   readonly scrollToTopRef?: React.RefObject<(() => void) | null>
 }

--- a/apps/mobile/src/state/marketplace/atoms/filterAtoms.ts
+++ b/apps/mobile/src/state/marketplace/atoms/filterAtoms.ts
@@ -146,7 +146,15 @@ export const resetLocationFilterActionAtom = atom(null, (get, set) => {
   }))
 })
 
-export const isFilterActiveAtom = atom((get) => {
+function isOffersFilterActive({
+  allClubsCount,
+  filter,
+  includeSort,
+}: {
+  readonly allClubsCount: number
+  readonly filter: OffersFilter
+  readonly includeSort: boolean
+}): boolean {
   // singlePriceCurrency and singlePrice are used only to calculate Product and Other offers filter SATS value for Price component
   // this value is stored, but it's not one of the filtering conditions
   // those values are used to calculate SATS value when filtering Product/Other offers
@@ -160,19 +168,22 @@ export const isFilterActiveAtom = atom((get) => {
     currency,
     amountBottomLimit,
     amountTopLimit,
+    sort,
     ...offersFilterFromStorage
-  } = get(offersFilterFromStorageAtom)
+  } = filter
 
   const {
     singlePriceCurrency: spc,
     text: t,
     filterBarOptions: fbo,
+    sort: initialSort,
     ...filterInitialState
   } = offersFilterInitialState
 
   return !OffersFilterEquals(
     {
       ...offersFilterFromStorage,
+      ...(includeSort ? {sort} : {}),
       filterBarOptions: fbo,
       currency: isAmountFilterEnabled({amountBottomLimit, amountTopLimit})
         ? currency
@@ -191,18 +202,46 @@ export const isFilterActiveAtom = atom((get) => {
         : undefined,
       location: location?.length === 0 ? undefined : location,
       clubsUuids:
-        offersFilterFromStorage.clubsUuids?.length ===
-        Record.values(get(clubsToKeyHolderAtom)).length
+        offersFilterFromStorage.clubsUuids?.length === allClubsCount
           ? undefined
           : offersFilterFromStorage.clubsUuids,
     } satisfies OffersFilter,
-    {...filterInitialState, filterBarOptions: fbo}
+    {
+      ...filterInitialState,
+      ...(includeSort ? {sort: initialSort} : {}),
+      filterBarOptions: fbo,
+    }
   )
+}
+
+export const isFilterActiveAtom = atom((get) => {
+  return isOffersFilterActive({
+    allClubsCount: Record.values(get(clubsToKeyHolderAtom)).length,
+    filter: get(offersFilterFromStorageAtom),
+    includeSort: true,
+  })
 })
 
 export const isTextFilterActiveAtom = atom(
   (get) => !!get(offersFilterFromStorageAtom).text
 )
+
+export const isMarketplaceNarrowingActiveAtom = atom((get) => {
+  const selectedFilterBarOptions = get(filterBarOptionsAtom)
+  const isFilterBarNarrowingActive =
+    selectedFilterBarOptions.size > 0 &&
+    selectedFilterBarOptions.size < MarketplaceFilterBarOption.literals.length
+
+  return (
+    isOffersFilterActive({
+      allClubsCount: Record.values(get(clubsToKeyHolderAtom)).length,
+      filter: get(offersFilterFromStorageAtom),
+      includeSort: false,
+    }) ||
+    get(isTextFilterActiveAtom) ||
+    isFilterBarNarrowingActive
+  )
+})
 
 export const resetFilterInStorageActionAtom = atom(null, (get, set) => {
   const {filterBarOptions, ...restOfOffersFilterInitialState} =

--- a/packages/localization/base.json
+++ b/packages/localization/base.json
@@ -1364,6 +1364,7 @@
   "marketplace.noOffersYet": "No offers yet.",
   "marketplace.tryAdjustingFilters": "Try adjusting or clearing your filters.",
   "marketplace.tryAdjustingMapOrClearingFilters": "Try moving the map or adjusting your filters.",
+  "marketplace.fewOffersAfterFiltering": "We found only a few results. Try editing your filters to see more options.",
   "marketplace.editFilters": "Edit filters",
   "marketplace.loadingMap": "Loading map",
   "marketplace.loadingOffers": "Loading offers",

--- a/packages/localization/en-base.json
+++ b/packages/localization/en-base.json
@@ -1364,6 +1364,7 @@
   "marketplace.noOffersYet": "No offers yet.",
   "marketplace.tryAdjustingFilters": "Try adjusting or clearing your filters.",
   "marketplace.tryAdjustingMapOrClearingFilters": "Try moving the map or adjusting your filters.",
+  "marketplace.fewOffersAfterFiltering": "We found only a few results. Try editing your filters to see more options.",
   "marketplace.editFilters": "Edit filters",
   "marketplace.loadingMap": "Loading map",
   "marketplace.loadingOffers": "Loading offers",


### PR DESCRIPTION
## Summary
- show a marketplace footer notice when active filtering leaves 1-3 offers
- reuse the same notice in the map bottom sheet
- add the English localization key for the notice copy

## Verification
- yarn turbo:typecheck
- yarn turbo:format
- yarn turbo:lint

Closes #2459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Marketplace now displays a notice when users have filtered offers and receive only a few results, encouraging them to edit filters for more options. This notice appears across marketplace and map views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->