### PR TITLE
fix #2526: Common friends displayed on offer should reflect imported contacts

### DIFF
--- a/apps/mobile/src/components/AccountScreen/components/UserBanner.tsx
+++ b/apps/mobile/src/components/AccountScreen/components/UserBanner.tsx
@@ -1,5 +1,12 @@
 import {useNavigation} from '@react-navigation/native'
-import {Avatar, Button, tokens, Typography, XStack, YStack} from '@vexl-next/ui'
+import {
+  Avatar,
+  CardButton,
+  tokens,
+  Typography,
+  XStack,
+  YStack,
+} from '@vexl-next/ui'
 import {parsePhoneNumber} from 'awesome-phonenumber'
 import {useAtomValue} from 'jotai'
 import React, {useCallback, useMemo} from 'react'
@@ -70,12 +77,12 @@ function UserBanner(): React.ReactElement {
         </Typography>
       </YStack>
       <XStack gap="$3">
-        <Button size="small" variant="tertiary" onPress={handleSharePress}>
+        <CardButton contrast onPress={handleSharePress}>
           {t('common.share')}
-        </Button>
-        <Button size="small" variant="tertiary" onPress={handleEditPress}>
+        </CardButton>
+        <CardButton contrast onPress={handleEditPress}>
           {t('common.edit')}
-        </Button>
+        </CardButton>
       </XStack>
     </XStack>
   )

--- a/apps/mobile/src/components/ChatDetailScreen/atoms/index.tsx
+++ b/apps/mobile/src/components/ChatDetailScreen/atoms/index.tsx
@@ -47,8 +47,13 @@ import {
   type ChatWithMessages,
 } from '../../../state/chat/domain'
 import {getChatState} from '../../../state/chat/utils/offerStates'
+import {importedContactsHashesAtom} from '../../../state/contacts/atom/contactsStore'
 import {createBtcPriceForCurrencyAtom} from '../../../state/currentBtcPriceAtoms'
 import {offerForChatOriginAtom} from '../../../state/marketplace/atoms/offersState'
+import {
+  deriveVisibleCommonFriendsForChat,
+  deriveVisibleCommonFriendsForOffer,
+} from '../../../state/marketplace/utils/visibleCommonFriends'
 import * as amount from '../../../state/tradeChecklist/utils/amount'
 import {getLatestAmountDataMessage} from '../../../state/tradeChecklist/utils/amount'
 import * as dateAndTime from '../../../state/tradeChecklist/utils/dateAndTime'
@@ -323,28 +328,65 @@ export const chatMolecule = molecule((getMolecule, getScope) => {
 
   const commonConnectionsHashesAtom = atom((get) => {
     const offer = get(offerForChatAtom)
+    const importedContactsHashes = get(importedContactsHashesAtom)
+    const requestMessage = get(requestMessageAtom)
     const commonFriendsForMyOffer = pipe(
-      get(requestMessageAtom),
-      Option.map((message) => message.message.commonFriends),
-      Option.getOrElse(() => [] as const)
+      requestMessage,
+      Option.flatMap((message) =>
+        Option.fromNullable(message.message.commonFriends)
+      ),
+      Option.getOrElse(() => [])
+    )
+    const verifiedCommonFriendsForMyOffer = pipe(
+      requestMessage,
+      Option.flatMap((message) =>
+        Option.fromNullable(message.message.verifiedCommonFriends)
+      ),
+      Option.getOrElse(() => [])
     )
 
-    return offer?.ownershipInfo
-      ? (commonFriendsForMyOffer ?? [])
-      : (offer?.offerInfo.privatePart.commonFriends ?? [])
+    if (!offer) return []
+
+    if (offer.ownershipInfo) {
+      return deriveVisibleCommonFriendsForChat({
+        commonFriends: commonFriendsForMyOffer,
+        verifiedCommonFriends: verifiedCommonFriendsForMyOffer,
+        importedContactsHashes,
+      }).commonFriends
+    }
+
+    return deriveVisibleCommonFriendsForOffer({
+      offerInfo: offer.offerInfo,
+      importedContactsHashes,
+    }).commonFriends
   })
 
   const verifiedConnectionsHashesAtom = atom((get) => {
     const offer = get(offerForChatAtom)
+    const commonConnectionsHashes = get(commonConnectionsHashesAtom)
+    const importedContactsHashes = get(importedContactsHashesAtom)
     const verifiedCommonFriendsForMyOffer = pipe(
       get(requestMessageAtom),
-      Option.map((message) => message.message.verifiedCommonFriends),
-      Option.getOrElse(() => [] as const)
+      Option.flatMap((message) =>
+        Option.fromNullable(message.message.verifiedCommonFriends)
+      ),
+      Option.getOrElse(() => [])
     )
 
-    return offer?.ownershipInfo
-      ? verifiedCommonFriendsForMyOffer
-      : (offer?.offerInfo.privatePart.verifiedCommonFriends ?? [])
+    if (!offer) return []
+
+    if (offer.ownershipInfo) {
+      return deriveVisibleCommonFriendsForChat({
+        commonFriends: commonConnectionsHashes,
+        verifiedCommonFriends: verifiedCommonFriendsForMyOffer,
+        importedContactsHashes,
+      }).verifiedCommonFriends
+    }
+
+    return deriveVisibleCommonFriendsForOffer({
+      offerInfo: offer.offerInfo,
+      importedContactsHashes,
+    }).verifiedCommonFriends
   })
 
   const commonConnectionsCountAtom = selectAtom(

--- a/apps/mobile/src/components/CommonFriends/index.tsx
+++ b/apps/mobile/src/components/CommonFriends/index.tsx
@@ -126,7 +126,7 @@ function CommonFriends({
   const verifiedHashesSet = useMemo(
     () =>
       showVerifiedContacts
-        ? new Set(verifiedConnectionsHashes ?? [])
+        ? new Set(verifiedConnectionsHashes)
         : new Set<HashedPhoneNumber>(),
     [showVerifiedContacts, verifiedConnectionsHashes]
   )

--- a/apps/mobile/src/components/CommonFriends/index.tsx
+++ b/apps/mobile/src/components/CommonFriends/index.tsx
@@ -126,7 +126,7 @@ function CommonFriends({
   const verifiedHashesSet = useMemo(
     () =>
       showVerifiedContacts
-        ? new Set(verifiedConnectionsHashes)
+        ? new Set(verifiedConnectionsHashes ?? [])
         : new Set<HashedPhoneNumber>(),
     [showVerifiedContacts, verifiedConnectionsHashes]
   )

--- a/apps/mobile/src/components/ContactPreferencesFlow/components/ContactListSelect/atom.ts
+++ b/apps/mobile/src/components/ContactPreferencesFlow/components/ContactListSelect/atom.ts
@@ -456,6 +456,42 @@ export const contactSelectMolecule = molecule((_, getScope) => {
           },
         })
 
+        const contactsPermissionsGranted = params.saveToPhone
+          ? yield* _(areContactsPermissionsGranted())
+          : false
+
+        const addContactToPhoneSuccess =
+          params.saveToPhone && contactsPermissionsGranted
+            ? yield* _(
+                set(addContactToPhoneActionAtom, {
+                  customName: contactName,
+                  number: normalizedNumber.value,
+                }),
+                Effect.catchTag('ErrorAddingContactToPhoneContacts', () =>
+                  pipe(
+                    set(globalDialogAtom, {
+                      title: t(
+                        'contacts.errorAddingContactToYourPhoneContacts'
+                      ),
+                      subtitle: t(
+                        'addContactDialog.contactCouldNotBeSavedToPhoneDescription'
+                      ),
+                      positiveButtonText: t('common.close'),
+                    }),
+                    Effect.as(false)
+                  )
+                )
+              )
+            : false
+
+        if (
+          params.saveToPhone &&
+          contactsPermissionsGranted &&
+          !addContactToPhoneSuccess
+        ) {
+          return false
+        }
+
         set(storedContactsAtom, (prev) => [
           ...pipe(
             prev,
@@ -471,27 +507,11 @@ export const contactSelectMolecule = molecule((_, getScope) => {
             computedValues: Option.some(manualContact.computedValues),
           },
         ])
-
-        const contactsPermissionsGranted = params.saveToPhone
-          ? yield* _(areContactsPermissionsGranted())
-          : false
-
-        if (params.saveToPhone && contactsPermissionsGranted) {
-          yield* _(
-            set(addContactToPhoneActionAtom, {
-              customName: contactName,
-              number: normalizedNumber.value,
-            }),
-            Effect.catchTag('ErrorAddingContactToPhoneContacts', (e) => {
-              showErrorAlert({
-                title: t('contacts.errorAddingContactToYourPhoneContacts'),
-                error: e,
-              })
-
-              return Effect.succeed(false)
-            })
-          )
-        }
+        set(selectedNumbersAtom, (selectedNumbers) => {
+          const nextSelectedNumbers = new Set(selectedNumbers)
+          nextSelectedNumbers.add(normalizedNumber.value)
+          return nextSelectedNumbers
+        })
 
         set(searchTextAtom, '')
         reloadContacts()

--- a/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/MarketplaceFirstOfferBanner.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/MarketplaceFirstOfferBanner.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import CreateOfferMarketplaceSuggestion from './CreateOfferMarketplaceSuggestion'
+import EnableNotificationsMarketplaceSuggestion from './EnableNotificationsMarketplaceSuggestion'
+import ImportContactsMarketplaceSuggestion from './ImportContactsMarketplaceSuggestion'
+import ImportNewContactsMarketplaceSuggestion from './ImportNewContactsMarketplaceSuggestion'
+import MissingProductCategoriesMarketplaceSuggestion from './MissingProductCategoriesMarketplaceSuggestion'
+
+interface Props {
+  readonly marketplaceFirstOfferBanner:
+    | 'missingProductCategories'
+    | 'importNewContacts'
+    | 'importContacts'
+    | 'enableNotifications'
+    | 'createOffer'
+}
+
+function MarketplaceFirstOfferBanner({
+  marketplaceFirstOfferBanner,
+}: Props): React.ReactElement {
+  if (marketplaceFirstOfferBanner === 'importNewContacts') {
+    return <ImportNewContactsMarketplaceSuggestion />
+  }
+
+  if (marketplaceFirstOfferBanner === 'importContacts') {
+    return <ImportContactsMarketplaceSuggestion />
+  }
+
+  if (marketplaceFirstOfferBanner === 'missingProductCategories') {
+    return (
+      <MissingProductCategoriesMarketplaceSuggestion placement="allOffers" />
+    )
+  }
+
+  if (marketplaceFirstOfferBanner === 'enableNotifications') {
+    return <EnableNotificationsMarketplaceSuggestion />
+  }
+
+  return <CreateOfferMarketplaceSuggestion />
+}
+
+export default MarketplaceFirstOfferBanner

--- a/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/MarketplaceScreenContent.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/MarketplaceScreenContent.tsx
@@ -9,7 +9,10 @@ import {isMarketplaceNarrowingActiveAtom} from '../../../../../state/marketplace
 import {filteredOffersIncludingLocationFilterAtomsAtom} from '../../../../../state/marketplace/atoms/filteredOffers'
 import {myOffersSortedAtomsAtom} from '../../../../../state/marketplace/atoms/myOffers'
 import {areThereOffersToSeeInMarketplaceWithoutFiltersAtom} from '../../../../../state/marketplace/atoms/offersToSeeInMarketplace'
-import {shouldShowMissingProductCategoriesInMyOffersSuggestionAtom} from '../../../../../state/marketplace/atoms/offerSuggestionVisible'
+import {
+  marketplaceFirstOfferBannerAtom,
+  shouldShowMissingProductCategoriesInMyOffersSuggestionAtom,
+} from '../../../../../state/marketplace/atoms/offerSuggestionVisible'
 import {refreshOffersActionAtom} from '../../../../../state/marketplace/atoms/refreshOffersActionAtom'
 import {showMarketplaceIntroDialogIfNeededActionAtom} from '../../../../../state/marketplace/atoms/showMarketplaceIntroDialogIfNeededActionAtom'
 import {useHandleRedirectToContactsScreen} from '../../../../../state/useHandleRedirectToContactsScreen'
@@ -23,6 +26,7 @@ import FewFilteredOffersNotice, {
   shouldShowFewFilteredOffersNotice,
 } from './FewFilteredOffersNotice'
 import FilteredOffersEmptyState from './FilteredOffersEmptyState'
+import MarketplaceFirstOfferBanner from './MarketplaceFirstOfferBanner'
 import MissingProductCategoriesMarketplaceSuggestion from './MissingProductCategoriesMarketplaceSuggestion'
 import MyOffersEmptyList from './MyOffersEmptyList'
 import MyOffersListHeader from './MyOffersListHeader'
@@ -103,6 +107,9 @@ function MarketplaceScreenContent({
   const isMarketplaceNarrowingActive = useAtomValue(
     isMarketplaceNarrowingActiveAtom
   )
+  const marketplaceFirstOfferBanner = useAtomValue(
+    marketplaceFirstOfferBannerAtom
+  )
   const loading = useAreOffersLoading()
 
   useHandleRedirectToContactsScreen()
@@ -162,6 +169,16 @@ function MarketplaceScreenContent({
     [activeTab, allOffersAtoms.length, isMarketplaceNarrowingActive]
   )
 
+  const itemAfterFirstOffer = useMemo(
+    () =>
+      activeTab === 'allOffers' && marketplaceFirstOfferBanner != null ? (
+        <MarketplaceFirstOfferBanner
+          marketplaceFirstOfferBanner={marketplaceFirstOfferBanner}
+        />
+      ) : null,
+    [activeTab, marketplaceFirstOfferBanner]
+  )
+
   useAppState(
     useCallback(
       (state) => {
@@ -197,6 +214,7 @@ function MarketplaceScreenContent({
         ListEmptyComponent={listEmptyComponent}
         ListFooterComponent={listFooterComponent}
         offersAtoms={offersAtoms}
+        itemAfterFirstOffer={itemAfterFirstOffer}
         onRefresh={activeTab === 'allOffers' ? handleRefresh : undefined}
         refreshing={
           activeTab === 'allOffers' && !isAllOffersEmptyStateVisible

--- a/apps/mobile/src/components/OfferAuthorBanner.tsx
+++ b/apps/mobile/src/components/OfferAuthorBanner.tsx
@@ -19,6 +19,7 @@ import {
   useGetAllClubsForIds,
   useGetAllClubsNamesForIds,
 } from '../state/clubs/atom/clubsWithMembersAtom'
+import {useVisibleCommonFriendsForOffer} from '../state/marketplace/hooks/useVisibleCommonFriendsForOffer'
 import {getOtherSideFriendLevel} from '../utils/chat/getOtherSideFriendLevel'
 import {formatInteger} from '../utils/localization/formatting'
 import {formattingLocaleAtom} from '../utils/localization/formattingLocaleAtom'
@@ -43,7 +44,8 @@ function OfferAuthorBanner({
 }): React.ReactElement {
   const {t} = useTranslation()
   const theme = useTheme()
-  const commonFriendsCount = offer.offerInfo.privatePart.commonFriends.length
+  const visibleCommonFriends = useVisibleCommonFriendsForOffer(offer.offerInfo)
+  const commonFriendsCount = visibleCommonFriends.commonFriends.length
   const locale = useAtomValue(formattingLocaleAtom)
   const localizedCommonFriendsCount = formatInteger(commonFriendsCount, locale)
   const clubsForOffer = useGetAllClubsForIds(

--- a/apps/mobile/src/components/OfferDetailScreen/index.tsx
+++ b/apps/mobile/src/components/OfferDetailScreen/index.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../state/chat/utils/offerStates'
 import {useGetAllClubsForIds} from '../../state/clubs/atom/clubsWithMembersAtom'
 import {useSingleOffer} from '../../state/marketplace'
+import {useVisibleCommonFriendsForOffer} from '../../state/marketplace/hooks/useVisibleCommonFriendsForOffer'
 import {useTranslation} from '../../utils/localization/I18nProvider'
 import {formatInteger} from '../../utils/localization/formatting'
 import {formattingLocaleAtom} from '../../utils/localization/formattingLocaleAtom'
@@ -139,7 +140,8 @@ function OfferDetailScrollContent({
   const theme = useTheme()
   const {footerHeightAtom} = useScreenFooterHeight()
   const footerHeight = useAtomValue(footerHeightAtom)
-  const commonFriendsCount = offer.offerInfo.privatePart.commonFriends.length
+  const visibleCommonFriends = useVisibleCommonFriendsForOffer(offer.offerInfo)
+  const commonFriendsCount = visibleCommonFriends.commonFriends.length
   const otherSideClubs = useGetAllClubsForIds(
     offer.offerInfo.privatePart.clubIds
   )
@@ -170,9 +172,9 @@ function OfferDetailScrollContent({
 
         {hasCommonFriendsOrClubs ? (
           <CommonFriends
-            commonConnectionsHashes={offer.offerInfo.privatePart.commonFriends}
+            commonConnectionsHashes={visibleCommonFriends.commonFriends}
             verifiedConnectionsHashes={
-              offer.offerInfo.privatePart.verifiedCommonFriends
+              visibleCommonFriends.verifiedCommonFriends
             }
             otherSideClubs={otherSideClubs}
           />

--- a/apps/mobile/src/components/OfferOnMarketplace.tsx
+++ b/apps/mobile/src/components/OfferOnMarketplace.tsx
@@ -14,6 +14,7 @@ import {
   smallestClubForIdsAtom,
   useGetAllClubsNamesForIds,
 } from '../state/clubs/atom/clubsWithMembersAtom'
+import {useVisibleCommonFriendsForOffer} from '../state/marketplace/hooks/useVisibleCommonFriendsForOffer'
 import {isProductOfferMissingCategory} from '../state/marketplace/utils/isProductOfferMissingCategory'
 import {getOtherSideFriendLevel} from '../utils/chat/getOtherSideFriendLevel'
 import {isOfferExpired} from '../utils/isOfferExpired'
@@ -51,6 +52,7 @@ export default function OfferOnMarketplace({
   const isPausedMyOffer = isMine && !publicPart.active
   const rerequestLimitDays = useAtomValue(offerRerequestLimitDaysAtom)
   const getAmountLabel = useSetAtom(getAmountLabelActionAtom)
+  const visibleCommonFriends = useVisibleCommonFriendsForOffer(offer.offerInfo)
 
   const smallestClub = useAtomValue(
     useMemo(
@@ -88,7 +90,7 @@ export default function OfferOnMarketplace({
     : (getOtherSideFriendLevel({offerInfo: offer.offerInfo, t}) ??
       t('offer.friendOfFriend'))
 
-  const commonFriendsCount = privatePart.commonFriends.length
+  const commonFriendsCount = visibleCommonFriends.commonFriends.length
   const commonFriendsText = !isMine
     ? t('marketplace.commonFriendsFormatted', {
         localizedString: formatInteger(commonFriendsCount, locale),

--- a/apps/mobile/src/components/OffersList/OffersListItem.tsx
+++ b/apps/mobile/src/components/OffersList/OffersListItem.tsx
@@ -1,4 +1,4 @@
-import {useNavigation, useRoute} from '@react-navigation/native'
+import {useNavigation} from '@react-navigation/native'
 import {type OneOfferInState} from '@vexl-next/domain/src/general/offers'
 import {Option} from 'effect'
 import {useAtomValue, type Atom} from 'jotai'
@@ -10,57 +10,19 @@ import {
   getRequestState,
   shouldUseGrayscaleColours,
 } from '../../state/chat/utils/offerStates'
-import {marketplaceFirstOfferBannerAtom} from '../../state/marketplace/atoms/offerSuggestionVisible'
 import {useTranslation} from '../../utils/localization/I18nProvider'
 import {offerRerequestLimitDaysAtom} from '../../utils/versionService/atoms'
-import CreateOfferMarketplaceSuggestion from '../InsideRouter/components/MarketplaceScreen/components/CreateOfferMarketplaceSuggestion'
-import EnableNotificationsMarketplaceSuggestion from '../InsideRouter/components/MarketplaceScreen/components/EnableNotificationsMarketplaceSuggestion'
-import ImportContactsMarketplaceSuggestion from '../InsideRouter/components/MarketplaceScreen/components/ImportContactsMarketplaceSuggestion'
-import ImportNewContactsMarketplaceSuggestion from '../InsideRouter/components/MarketplaceScreen/components/ImportNewContactsMarketplaceSuggestion'
-import MissingProductCategoriesMarketplaceSuggestion from '../InsideRouter/components/MarketplaceScreen/components/MissingProductCategoriesMarketplaceSuggestion'
 import OfferOnMarketplace from '../OfferOnMarketplace'
 
 interface Props {
-  readonly isFirst: boolean
   readonly offerAtom: Atom<OneOfferInState>
 }
 
-function MarketplaceFirstOfferBanner(): React.ReactElement | null {
-  const marketplaceFirstOfferBanner = useAtomValue(
-    marketplaceFirstOfferBannerAtom
-  )
-
-  if (marketplaceFirstOfferBanner == null) return null
-
-  return (
-    <>
-      <Stack height="$5" />
-      <Stack px="$5">
-        {marketplaceFirstOfferBanner === 'importNewContacts' ? (
-          <ImportNewContactsMarketplaceSuggestion />
-        ) : marketplaceFirstOfferBanner === 'importContacts' ? (
-          <ImportContactsMarketplaceSuggestion />
-        ) : marketplaceFirstOfferBanner === 'missingProductCategories' ? (
-          <MissingProductCategoriesMarketplaceSuggestion placement="allOffers" />
-        ) : marketplaceFirstOfferBanner === 'enableNotifications' ? (
-          <EnableNotificationsMarketplaceSuggestion />
-        ) : (
-          <CreateOfferMarketplaceSuggestion />
-        )}
-      </Stack>
-    </>
-  )
-}
-
-function OffersListItem({isFirst, offerAtom}: Props): React.ReactElement {
+function OffersListItem({offerAtom}: Props): React.ReactElement {
   const {t} = useTranslation()
   const navigation = useNavigation()
-  const route = useRoute()
   const offer = useAtomValue(offerAtom)
   const rerequestLimitDays = useAtomValue(offerRerequestLimitDaysAtom)
-  const marketplaceFirstOfferBanner = useAtomValue(
-    marketplaceFirstOfferBannerAtom
-  )
 
   const isMine = useMemo(
     () => !!offer.ownershipInfo?.adminId,
@@ -251,9 +213,6 @@ function OffersListItem({isFirst, offerAtom}: Props): React.ReactElement {
           }
         />
       </Stack>
-      {route.name === 'Marketplace' && isFirst && !isMyOffer ? (
-        <MarketplaceFirstOfferBanner />
-      ) : null}
     </>
   )
 }

--- a/apps/mobile/src/components/OffersList/index.tsx
+++ b/apps/mobile/src/components/OffersList/index.tsx
@@ -7,7 +7,7 @@ import {
 import {type OneOfferInState} from '@vexl-next/domain/src/general/offers'
 import {Stack, tokens, useTheme} from '@vexl-next/ui'
 import {type Atom} from 'jotai'
-import React, {useEffect, useMemo, useRef} from 'react'
+import React, {useCallback, useEffect, useMemo, useRef} from 'react'
 import {RefreshControl} from 'react-native'
 import Animated from 'react-native-reanimated'
 import atomKeyExtractor from '../../utils/atomUtils/atomKeyExtractor'
@@ -15,20 +15,26 @@ import usePixelsFromBottomWhereTabsEnd from '../InsideRouter/utils'
 import OffersListItem from './OffersListItem'
 
 const ItemSeparatorComponent = (): React.ReactElement => <Stack h="$5" />
+interface ItemSeparatorProps {
+  readonly leadingItem?: Atom<OneOfferInState>
+}
+
 const ReanimatedFlashList: React.ComponentType<any> =
   Animated.createAnimatedComponent(FlashList)
 
 function renderItem(
   info: ListRenderItemInfo<Atom<OneOfferInState>>
 ): React.ReactElement {
-  return <OffersListItem isFirst={info.index === 0} offerAtom={info.item} />
+  return <OffersListItem offerAtom={info.item} />
 }
 
 export interface Props extends Omit<
   FlashListProps<Atom<OneOfferInState>>,
-  'renderItem' | 'data'
+  'renderItem' | 'data' | 'ListFooterComponent'
 > {
   readonly offersAtoms: Array<Atom<OneOfferInState>>
+  readonly itemAfterFirstOffer?: React.ReactElement | null
+  readonly ListFooterComponent?: React.ReactElement | null
   readonly scrollToTopRef?: React.RefObject<(() => void) | null>
 }
 
@@ -36,6 +42,7 @@ function OffersList({
   onRefresh,
   refreshing,
   offersAtoms,
+  itemAfterFirstOffer,
   scrollToTopRef,
   ListEmptyComponent,
   ListHeaderComponent,
@@ -54,6 +61,40 @@ function OffersList({
     }),
     [bottomOffset, externalContentContainerStyle]
   )
+
+  const firstOfferAtom = offersAtoms[0]
+
+  const itemSeparatorComponent = useCallback(
+    ({leadingItem}: ItemSeparatorProps): React.ReactElement => {
+      if (itemAfterFirstOffer != null && leadingItem === firstOfferAtom) {
+        return (
+          <>
+            <Stack h="$5" />
+            <Stack px="$5">{itemAfterFirstOffer}</Stack>
+            <Stack h="$5" />
+          </>
+        )
+      }
+
+      return <ItemSeparatorComponent />
+    },
+    [firstOfferAtom, itemAfterFirstOffer]
+  )
+
+  const listFooterComponent = useMemo((): React.ReactElement | null => {
+    if (itemAfterFirstOffer == null || offersAtoms.length !== 1) {
+      return ListFooterComponent ?? null
+    }
+
+    return (
+      <>
+        <Stack h="$5" />
+        <Stack px="$5">{itemAfterFirstOffer}</Stack>
+        <Stack h="$5" />
+        {ListFooterComponent}
+      </>
+    )
+  }, [ListFooterComponent, itemAfterFirstOffer, offersAtoms.length])
 
   useEffect(() => {
     if (!scrollToTopRef) return
@@ -81,10 +122,10 @@ function OffersList({
           tintColor={theme.foregroundSecondary.get()}
         />
       }
-      ItemSeparatorComponent={ItemSeparatorComponent}
+      ItemSeparatorComponent={itemSeparatorComponent}
       progressViewOffset={20}
       ListHeaderComponent={ListHeaderComponent}
-      ListFooterComponent={ListFooterComponent}
+      ListFooterComponent={listFooterComponent}
       ListEmptyComponent={ListEmptyComponent}
       showsVerticalScrollIndicator={false}
       contentContainerStyle={contentContainerStyle}

--- a/apps/mobile/src/state/marketplace/atoms/filteredOffers.ts
+++ b/apps/mobile/src/state/marketplace/atoms/filteredOffers.ts
@@ -2,7 +2,10 @@ import {Latitude, Longitude} from '@vexl-next/domain/src/utility/geoCoordinates'
 import {Array, Schema} from 'effect'
 import {atom} from 'jotai'
 import {splitAtom} from 'jotai/utils'
-import {importedContactsAtom} from '../../contacts/atom/contactsStore'
+import {
+  importedContactsAtom,
+  importedContactsHashesAtom,
+} from '../../contacts/atom/contactsStore'
 import {
   filterMarketplaceOffers,
   filterOffersByCircularLocation,
@@ -40,8 +43,13 @@ export const filteredOffersIgnoreLocationAtom = atom((get) => {
     offers: filtered,
     importedContacts: get(importedContactsAtom),
   })
+  const sort = filter.sort ?? 'NEWEST_OFFER'
 
-  return sortOffers(filteredByText, filter.sort ?? 'NEWEST_OFFER')
+  return sortOffers(
+    filteredByText,
+    sort,
+    sort === 'MOST_CONNECTIONS' ? get(importedContactsHashesAtom) : undefined
+  )
 })
 
 export const filteredOffersForMapAtom = atom((get) => {

--- a/apps/mobile/src/state/marketplace/atoms/myOffers.ts
+++ b/apps/mobile/src/state/marketplace/atoms/myOffers.ts
@@ -12,6 +12,7 @@ import {focusAtom} from 'jotai-optics'
 import {splitAtom} from 'jotai/utils'
 import {apiAtom} from '../../../api'
 import {atomWithParsedMmkvStorage} from '../../../utils/atomUtils/atomWithParsedMmkvStorage'
+import {importedContactsHashesAtom} from '../../contacts/atom/contactsStore'
 import {sessionDataOrDummyAtom} from '../../session'
 import {isProductOfferMissingCategory} from '../utils/isProductOfferMissingCategory'
 import sortOffers from '../utils/sortOffers'
@@ -32,7 +33,13 @@ export const myOffersSortedAtom = atom((get) => {
   const sortingOptions = get(selectedMyOffersSortingOptionAtom)
   const myOffers = get(myOffersAtom)
 
-  return sortOffers(myOffers, sortingOptions)
+  return sortOffers(
+    myOffers,
+    sortingOptions,
+    sortingOptions === 'MOST_CONNECTIONS'
+      ? get(importedContactsHashesAtom)
+      : undefined
+  )
 })
 
 export const myOffersSortedAtomsAtom = splitAtom(

--- a/apps/mobile/src/state/marketplace/atoms/offersToSeeInMarketplace.ts
+++ b/apps/mobile/src/state/marketplace/atoms/offersToSeeInMarketplace.ts
@@ -1,9 +1,11 @@
 import {type OfferInfo} from '@vexl-next/domain/src/general/offers'
+import {Array, pipe} from 'effect'
 import {atom} from 'jotai'
 import {isOfferExpired} from '../../../utils/isOfferExpired'
 import {isDeveloperAtom} from '../../../utils/preferences'
 import reportError from '../../../utils/reportError'
 import {importedContactsHashesAtom} from '../../contacts/atom/contactsStore'
+import {deriveVisibleCommonFriendsForOffer} from '../utils/visibleCommonFriends'
 import {offersAtom} from './offersState'
 
 export function alertAndReportInPersonOffersWithoutLocation(
@@ -52,28 +54,49 @@ export const offersToSeeInMarketplaceAtom = atom((get) => {
     offers.map((one) => one.offerInfo)
   )
 
-  return offers.filter(
-    (oneOffer) =>
-      // only active offers
-      oneOffer.offerInfo.publicPart.active &&
-      // only not expired offers
-      !isOfferExpired(oneOffer.offerInfo.publicPart.expirationDate) &&
-      // Not mine offers
-      !oneOffer.ownershipInfo &&
-      // Not reported offers
-      !oneOffer.flags.reported &&
-      // Offers that has at least one common contact or are first degree
-      (oneOffer.offerInfo.privatePart.commonFriends.some((one) =>
-        importedContactsHashes.includes(one)
-      ) ||
-        oneOffer.offerInfo.privatePart.friendLevel.includes('FIRST_DEGREE') ||
-        oneOffer.offerInfo.privatePart.friendLevel.includes('CLUB')) &&
-      // Filter offers that are set to be in person but have no location
-      (isDeveloper ||
-        oneOffer.offerInfo.publicPart.locationState.length === 0 ||
-        oneOffer.offerInfo.publicPart.locationState.includes('ONLINE') ||
-        (oneOffer.offerInfo.publicPart.locationState.includes('IN_PERSON') &&
-          oneOffer.offerInfo.publicPart.location.length > 0))
+  return pipe(
+    offers,
+    Array.filter((oneOffer) => {
+      const visibleCommonFriends = deriveVisibleCommonFriendsForOffer({
+        offerInfo: oneOffer.offerInfo,
+        importedContactsHashes,
+      })
+
+      return (
+        // only active offers
+        oneOffer.offerInfo.publicPart.active &&
+        // only not expired offers
+        !isOfferExpired(oneOffer.offerInfo.publicPart.expirationDate) &&
+        // Not mine offers
+        !oneOffer.ownershipInfo &&
+        // Not reported offers
+        !oneOffer.flags.reported &&
+        // Offers that has at least one visible common contact or are first degree
+        (Array.isNonEmptyReadonlyArray(visibleCommonFriends.commonFriends) ||
+          pipe(
+            oneOffer.offerInfo.privatePart.friendLevel,
+            Array.some((one) => one === 'FIRST_DEGREE')
+          ) ||
+          pipe(
+            oneOffer.offerInfo.privatePart.friendLevel,
+            Array.some((one) => one === 'CLUB')
+          )) &&
+        // Filter offers that are set to be in person but have no location
+        (isDeveloper ||
+          oneOffer.offerInfo.publicPart.locationState.length === 0 ||
+          pipe(
+            oneOffer.offerInfo.publicPart.locationState,
+            Array.some((one) => one === 'ONLINE')
+          ) ||
+          (pipe(
+            oneOffer.offerInfo.publicPart.locationState,
+            Array.some((one) => one === 'IN_PERSON')
+          ) &&
+            Array.isNonEmptyReadonlyArray(
+              oneOffer.offerInfo.publicPart.location
+            )))
+      )
+    })
   )
 })
 

--- a/apps/mobile/src/state/marketplace/hooks/useVisibleCommonFriendsForOffer.ts
+++ b/apps/mobile/src/state/marketplace/hooks/useVisibleCommonFriendsForOffer.ts
@@ -1,0 +1,23 @@
+import {type OfferInfo} from '@vexl-next/domain/src/general/offers'
+import {useAtomValue} from 'jotai'
+import {useMemo} from 'react'
+import {importedContactsHashesAtom} from '../../contacts/atom/contactsStore'
+import {
+  deriveVisibleCommonFriendsForOffer,
+  type VisibleCommonFriends,
+} from '../utils/visibleCommonFriends'
+
+export function useVisibleCommonFriendsForOffer(
+  offerInfo: OfferInfo
+): VisibleCommonFriends {
+  const importedContactsHashes = useAtomValue(importedContactsHashesAtom)
+
+  return useMemo(
+    () =>
+      deriveVisibleCommonFriendsForOffer({
+        offerInfo,
+        importedContactsHashes,
+      }),
+    [importedContactsHashes, offerInfo]
+  )
+}

--- a/apps/mobile/src/state/marketplace/utils/filterOffersByText.ts
+++ b/apps/mobile/src/state/marketplace/utils/filterOffersByText.ts
@@ -1,6 +1,8 @@
 import {type OneOfferInState} from '@vexl-next/domain/src/general/offers'
+import {Array, Option, pipe} from 'effect'
 
 import {type StoredContactWithComputedValues} from '../../contacts/domain'
+import {deriveVisibleCommonFriendsForOffer} from './visibleCommonFriends'
 
 const DIVIDER = ' ## '
 export default function filterOffersByText({
@@ -14,36 +16,78 @@ export default function filterOffersByText({
 }): OneOfferInState[] {
   // TODO - better search. This is just a placeholder
 
-  const wordsToSearchFor = text.toUpperCase().trim().split(' ').filter(Boolean)
+  const wordsToSearchFor = pipe(
+    text.toUpperCase().trim().split(' '),
+    Array.filter(Boolean)
+  )
+  const importedContactsHashes = pipe(
+    importedContacts,
+    Array.map((contact) => contact.computedValues.hash)
+  )
+  const contactsByHash = new Map<
+    StoredContactWithComputedValues['computedValues']['hash'],
+    StoredContactWithComputedValues[]
+  >()
 
-  const offersWithSearchableString = offers.map((offer) => ({
-    offer,
-    searchableString: [
-      offer.offerInfo.publicPart.listingType,
-      offer.offerInfo.publicPart.offerDescription,
-      offer.offerInfo.privatePart.commonFriends
-        .map((hash) =>
-          importedContacts
-            .filter((one) => one.computedValues.hash === hash)
-            .map((o) =>
-              [o.info.name, o.computedValues.normalizedNumber].join(DIVIDER)
-            )
-            .join(DIVIDER)
-        )
-        .join(DIVIDER),
-      offer.offerInfo.publicPart.location
-        ?.map((one) => one.address ?? '')
-        .join(DIVIDER),
-    ]
-      .join(DIVIDER)
-      .toUpperCase(),
-  }))
-
-  return offersWithSearchableString
-    .filter((oneOffer) =>
-      wordsToSearchFor.every((oneWordToSearchFor) =>
-        oneOffer.searchableString.includes(oneWordToSearchFor)
-      )
+  for (const contact of importedContacts) {
+    const contactsForHash = pipe(
+      Option.fromNullable(contactsByHash.get(contact.computedValues.hash)),
+      Option.getOrElse((): StoredContactWithComputedValues[] => [])
     )
-    .map((one) => one.offer)
+    contactsByHash.set(contact.computedValues.hash, [
+      ...contactsForHash,
+      contact,
+    ])
+  }
+
+  const offersWithSearchableString = pipe(
+    offers,
+    Array.map((offer) => {
+      const visibleCommonFriends = deriveVisibleCommonFriendsForOffer({
+        offerInfo: offer.offerInfo,
+        importedContactsHashes,
+      })
+
+      return {
+        offer,
+        searchableString: [
+          offer.offerInfo.publicPart.listingType,
+          offer.offerInfo.publicPart.offerDescription,
+          pipe(
+            visibleCommonFriends.commonFriends,
+            Array.flatMap((hash) =>
+              pipe(
+                Option.fromNullable(contactsByHash.get(hash)),
+                Option.getOrElse((): StoredContactWithComputedValues[] => [])
+              )
+            ),
+            Array.map((contact) =>
+              [contact.info.name, contact.computedValues.normalizedNumber].join(
+                DIVIDER
+              )
+            )
+          ).join(DIVIDER),
+          pipe(
+            offer.offerInfo.publicPart.location ?? [],
+            Array.map((one) => one.address ?? '')
+          ).join(DIVIDER),
+        ]
+          .join(DIVIDER)
+          .toUpperCase(),
+      }
+    })
+  )
+
+  return pipe(
+    offersWithSearchableString,
+    Array.filter((oneOffer) =>
+      pipe(
+        wordsToSearchFor,
+        Array.every((oneWordToSearchFor) =>
+          oneOffer.searchableString.includes(oneWordToSearchFor)
+        )
+      )
+    ),
+    Array.map((one) => one.offer)
+  )
 }

--- a/apps/mobile/src/state/marketplace/utils/sortOffers.ts
+++ b/apps/mobile/src/state/marketplace/utils/sortOffers.ts
@@ -1,13 +1,32 @@
+import {type HashedPhoneNumber} from '@vexl-next/domain/src/general/HashedPhoneNumber.brand'
 import {
   type OneOfferInState,
   type Sort,
 } from '@vexl-next/domain/src/general/offers'
+import {deriveVisibleCommonFriendsForOffer} from './visibleCommonFriends'
 
 export default function sortOffers<T extends OneOfferInState>(
   offers: readonly T[],
-  sort: Sort
+  sort: Sort,
+  importedContactsHashes?: readonly HashedPhoneNumber[]
 ): T[] {
   const toReturn = [...offers]
+  const commonFriendsCounts =
+    sort === 'MOST_CONNECTIONS' ? new Map<OneOfferInState, number>() : undefined
+
+  if (commonFriendsCounts !== undefined) {
+    for (const offer of toReturn) {
+      commonFriendsCounts.set(
+        offer,
+        importedContactsHashes === undefined
+          ? 0
+          : deriveVisibleCommonFriendsForOffer({
+              offerInfo: offer.offerInfo,
+              importedContactsHashes,
+            }).commonFriends.length
+      )
+    }
+  }
 
   toReturn.sort((a, b) => {
     const aIsMyOffer = !!a.ownershipInfo
@@ -38,10 +57,9 @@ export default function sortOffers<T extends OneOfferInState>(
         a.offerInfo.publicPart.amountTopLimit
       )
     if (sort === 'MOST_CONNECTIONS') {
-      return (
-        b.offerInfo.privatePart.commonFriends.length -
-        a.offerInfo.privatePart.commonFriends.length
-      )
+      const aCommonFriendsCount = commonFriendsCounts?.get(a) ?? 0
+      const bCommonFriendsCount = commonFriendsCounts?.get(b) ?? 0
+      return bCommonFriendsCount - aCommonFriendsCount
     }
     // default ordering: NEWEST_OFFER
     return b.offerInfo.id - a.offerInfo.id

--- a/apps/mobile/src/state/marketplace/utils/visibleCommonFriends.ts
+++ b/apps/mobile/src/state/marketplace/utils/visibleCommonFriends.ts
@@ -1,0 +1,61 @@
+import {type HashedPhoneNumber} from '@vexl-next/domain/src/general/HashedPhoneNumber.brand'
+import {type OfferInfo} from '@vexl-next/domain/src/general/offers'
+import {Array} from 'effect'
+
+export interface VisibleCommonFriends {
+  readonly commonFriends: readonly HashedPhoneNumber[]
+  readonly verifiedCommonFriends: readonly HashedPhoneNumber[]
+}
+
+export function deriveVisibleCommonFriendsFromHashes({
+  commonFriends,
+  verifiedCommonFriends = [],
+  importedContactsHashes,
+}: {
+  readonly commonFriends: readonly HashedPhoneNumber[]
+  readonly verifiedCommonFriends?: readonly HashedPhoneNumber[]
+  readonly importedContactsHashes: readonly HashedPhoneNumber[]
+}): VisibleCommonFriends {
+  const visibleCommonFriends = Array.intersection(
+    Array.union(commonFriends, verifiedCommonFriends),
+    importedContactsHashes
+  )
+
+  return {
+    commonFriends: visibleCommonFriends,
+    verifiedCommonFriends: Array.intersection(
+      verifiedCommonFriends,
+      importedContactsHashes
+    ),
+  }
+}
+
+export function deriveVisibleCommonFriendsForOffer({
+  offerInfo,
+  importedContactsHashes,
+}: {
+  readonly offerInfo: OfferInfo
+  readonly importedContactsHashes: readonly HashedPhoneNumber[]
+}): VisibleCommonFriends {
+  return deriveVisibleCommonFriendsFromHashes({
+    commonFriends: offerInfo.privatePart.commonFriends,
+    verifiedCommonFriends: offerInfo.privatePart.verifiedCommonFriends,
+    importedContactsHashes,
+  })
+}
+
+export function deriveVisibleCommonFriendsForChat({
+  commonFriends,
+  verifiedCommonFriends,
+  importedContactsHashes,
+}: {
+  readonly commonFriends: readonly HashedPhoneNumber[] | undefined
+  readonly verifiedCommonFriends: readonly HashedPhoneNumber[] | undefined
+  readonly importedContactsHashes: readonly HashedPhoneNumber[]
+}): VisibleCommonFriends {
+  return deriveVisibleCommonFriendsFromHashes({
+    commonFriends: commonFriends ?? [],
+    verifiedCommonFriends: verifiedCommonFriends ?? [],
+    importedContactsHashes,
+  })
+}

--- a/packages/localization/ar-base.json
+++ b/packages/localization/ar-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "تقدر تعدّل جهة الاتصال هذه في أي وقت.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "تمت إضافة جهة الاتصال إلى Vexl فقط",
   "addContactDialog.contactAddedToVexlOnlyDescription": "ما قدر Vexl يحفظ جهة الاتصال هذه على هاتفك لأن الوصول إلى جهات الاتصال معطّل. افتح الإعدادات للسماح بالوصول.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "لم تتم إضافة جهة الاتصال إلى Vexl لأنه تعذّر حفظها في جهات اتصال هاتفك. حاول مرة أخرى، أو أوقف خيار \"الحفظ أيضًا على هاتفك\" لإضافتها إلى Vexl فقط.",
   "addContactDialog.contactAlreadyAddedTitle": "جهة الاتصال مضافة بالفعل",
   "addContactDialog.contactAlreadyAddedDescription": "رقم الهاتف هذا موجود بالفعل في جهات اتصال Vexl عندك. تقدر تعدّله من قائمة جهات الاتصال.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Would you like to change the name for {{name}}?",

--- a/packages/localization/base.json
+++ b/packages/localization/base.json
@@ -973,6 +973,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "You can edit this contact anytime.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Contact added to Vexl only",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl could not save this contact to your phone because Contacts access is disabled. Open settings to allow access.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "The contact was not added to Vexl because it could not be saved to your phone contacts. Try again, or turn off \"Also save to your phone\" to add it only to Vexl.",
   "addContactDialog.contactAlreadyAddedTitle": "Contact already added",
   "addContactDialog.contactAlreadyAddedDescription": "This phone number is already in your Vexl contacts. You can edit it from your contact list.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Would you like to change {{name}}'s name?",

--- a/packages/localization/bg-base.json
+++ b/packages/localization/bg-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Можеш да редактираш този контакт по всяко време.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Контактът е добавен само във Vexl",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl не можа да запази този контакт в телефона ти, защото достъпът до Контакти е изключен. Отвори настройките, за да разрешиш достъп.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Контактът не беше добавен във Vexl, защото не можа да бъде запазен в контактите на телефона ти. Опитай отново или изключи „Запази и в телефона си“, за да го добавиш само във Vexl.",
   "addContactDialog.contactAlreadyAddedTitle": "Контактът вече е добавен",
   "addContactDialog.contactAlreadyAddedDescription": "Този телефонен номер вече е в контактите ти във Vexl. Можеш да го редактираш от списъка си с контакти.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Искате ли да промените името на {{name}}?",

--- a/packages/localization/cs-base.json
+++ b/packages/localization/cs-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Tenhle kontakt můžeš kdykoli upravit.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Kontakt přidán jen do Vexlu",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl nemohl uložit tenhle kontakt do tvého telefonu, protože je vypnutý přístup ke Kontaktům. Otevři nastavení a povol přístup.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Kontakt nebyl přidán do Vexlu, protože se ho nepodařilo uložit do kontaktů telefonu. Zkus to znovu, nebo vypni „Uložit také do telefonu“ a přidej ho jen do Vexlu.",
   "addContactDialog.contactAlreadyAddedTitle": "Kontakt už je přidaný",
   "addContactDialog.contactAlreadyAddedDescription": "Tohle telefonní číslo už máš ve svých kontaktech ve Vexlu. Můžeš ho upravit v seznamu kontaktů.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Chceš pro toto číslo změnit jméno z uloženého {{name}}?",

--- a/packages/localization/de-base.json
+++ b/packages/localization/de-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Du kannst diesen Kontakt jederzeit bearbeiten.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Kontakt nur zu Vexl hinzugefügt",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl konnte diesen Kontakt nicht auf deinem Handy speichern, weil der Zugriff auf Kontakte deaktiviert ist. Öffne die Einstellungen, um den Zugriff zu erlauben.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Der Kontakt wurde nicht zu Vexl hinzugefügt, weil er nicht in deinen Telefonkontakten gespeichert werden konnte. Versuche es erneut oder deaktiviere „Auch auf deinem Telefon speichern“, um ihn nur zu Vexl hinzuzufügen.",
   "addContactDialog.contactAlreadyAddedTitle": "Kontakt bereits hinzugefügt",
   "addContactDialog.contactAlreadyAddedDescription": "Diese Telefonnummer ist bereits in deinen Vexl-Kontakten. Du kannst sie in deiner Kontaktliste bearbeiten.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Möchtest du den Namen {{Name}} für diese Rufnummer ändern?",

--- a/packages/localization/en-base.json
+++ b/packages/localization/en-base.json
@@ -973,6 +973,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "You can edit this contact anytime.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Contact added to Vexl only",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl could not save this contact to your phone because Contacts access is disabled. Open settings to allow access.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "The contact was not added to Vexl because it could not be saved to your phone contacts. Try again, or turn off \"Also save to your phone\" to add it only to Vexl.",
   "addContactDialog.contactAlreadyAddedTitle": "Contact already added",
   "addContactDialog.contactAlreadyAddedDescription": "This phone number is already in your Vexl contacts. You can edit it from your contact list.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Would you like to change {{name}}'s name?",

--- a/packages/localization/es-base.json
+++ b/packages/localization/es-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Puedes editar este contacto cuando quieras.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Contacto añadido solo a Vexl",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl no pudo guardar este contacto en tu teléfono porque el acceso a Contactos está desactivado. Abre los ajustes para permitir el acceso.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "El contacto no se añadió a Vexl porque no se pudo guardar en los contactos de tu teléfono. Inténtalo de nuevo o desactiva «Guardar también en tu teléfono» para añadirlo solo a Vexl.",
   "addContactDialog.contactAlreadyAddedTitle": "Contacto ya añadido",
   "addContactDialog.contactAlreadyAddedDescription": "Este número de teléfono ya está en tus contactos de Vexl. Puedes editarlo desde tu lista de contactos.",
   "addContactDialog.wouldYouLikeToChangeTheName": "¿Quieres cambiar el nombre de {{name}}?",

--- a/packages/localization/fa-base.json
+++ b/packages/localization/fa-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "هر وقت خواستی می‌تونی این مخاطب رو ویرایش کنی.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "مخاطب فقط به Vexl اضافه شد",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl نتونست این مخاطب رو توی گوشی‌ات ذخیره کنه چون دسترسی به مخاطبین غیرفعاله. تنظیمات رو باز کن تا دسترسی رو بدی.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "مخاطب به Vexl اضافه نشد، چون امکان ذخیره آن در مخاطبین تلفن شما وجود نداشت. دوباره تلاش کنید، یا گزینه «همچنین در تلفن شما ذخیره شود» را خاموش کنید تا فقط به Vexl اضافه شود.",
   "addContactDialog.contactAlreadyAddedTitle": "این مخاطب قبلاً اضافه شده",
   "addContactDialog.contactAlreadyAddedDescription": "این شماره تلفن همین حالا هم توی مخاطبین Vexl تو هست. می‌تونی از فهرست مخاطبینت ویرایشش کنی.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Would you like to change the name for {{name}}?",

--- a/packages/localization/fi-base.json
+++ b/packages/localization/fi-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Voit muokata tätä yhteystietoa milloin vain.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Yhteystieto lisätty vain Vexliin",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl ei voinut tallentaa tätä yhteystietoa puhelimeesi, koska Yhteystiedot-käyttöoikeus on pois päältä. Avaa asetukset ja salli käyttö.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Yhteystietoa ei lisätty Vexliin, koska sitä ei voitu tallentaa puhelimesi yhteystietoihin. Yritä uudelleen tai poista käytöstä \"Tallenna myös puhelimeesi\", jotta se lisätään vain Vexliin.",
   "addContactDialog.contactAlreadyAddedTitle": "Yhteystieto on jo lisätty",
   "addContactDialog.contactAlreadyAddedDescription": "Tämä puhelinnumero on jo Vexl-yhteystiedoissasi. Voit muokata sitä yhteystietolistastasi.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Would you like to change the name for {{name}}?",

--- a/packages/localization/fr-base.json
+++ b/packages/localization/fr-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Tu peux modifier ce contact à tout moment.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Contact ajouté uniquement à Vexl",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl n'a pas pu enregistrer ce contact sur ton téléphone, car l'accès aux contacts est désactivé. Ouvre les réglages pour autoriser l'accès.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Le contact n’a pas été ajouté à Vexl, car il n’a pas pu être enregistré dans les contacts de ton téléphone. Réessaie, ou désactive « Enregistrer aussi sur ton téléphone » pour l’ajouter uniquement à Vexl.",
   "addContactDialog.contactAlreadyAddedTitle": "Contact déjà ajouté",
   "addContactDialog.contactAlreadyAddedDescription": "Ce numéro de téléphone est déjà dans tes contacts Vexl. Tu peux le modifier depuis ta liste de contacts.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Would you like to change the name for {{name}} for this phone number?",

--- a/packages/localization/id-base.json
+++ b/packages/localization/id-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Kamu bisa edit kontak ini kapan saja.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Kontak hanya ditambahkan ke Vexl",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl tidak bisa menyimpan kontak ini ke ponselmu karena akses Kontak dinonaktifkan. Buka pengaturan untuk mengizinkan akses.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Kontak tidak ditambahkan ke Vexl karena tidak dapat disimpan ke kontak ponselmu. Coba lagi, atau matikan \"Simpan juga ke ponselmu\" untuk menambahkannya hanya ke Vexl.",
   "addContactDialog.contactAlreadyAddedTitle": "Kontak sudah ditambahkan",
   "addContactDialog.contactAlreadyAddedDescription": "Nomor telepon ini sudah ada di kontak Vexl-mu. Kamu bisa edit dari daftar kontakmu.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Would you like to change the name for {{name}}?",

--- a/packages/localization/it-base.json
+++ b/packages/localization/it-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Puoi modificare questo contatto in qualsiasi momento.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Contatto aggiunto solo a Vexl",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl non ha potuto salvare questo contatto sul tuo telefono perché l'accesso ai Contatti è disattivato. Apri le impostazioni per consentire l'accesso.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Il contatto non è stato aggiunto a Vexl perché non è stato possibile salvarlo nei contatti del telefono. Riprova oppure disattiva “Salva anche sul telefono” per aggiungerlo solo a Vexl.",
   "addContactDialog.contactAlreadyAddedTitle": "Contatto già aggiunto",
   "addContactDialog.contactAlreadyAddedDescription": "Questo numero di telefono è già nei tuoi contatti Vexl. Puoi modificarlo dalla tua lista contatti.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Would you like to change the name for {{name}} for this phone number?",

--- a/packages/localization/ja-base.json
+++ b/packages/localization/ja-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "この連絡先はいつでも編集できるよ。",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Vexlにだけ連絡先を追加したよ",
   "addContactDialog.contactAddedToVexlOnlyDescription": "連絡先へのアクセスがオフになっているため、Vexlはこの連絡先をスマホに保存できませんでした。設定を開いてアクセスを許可してね。",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "電話の連絡先に保存できなかったため、この連絡先はVexlに追加されませんでした。もう一度試すか、「電話にも保存」をオフにしてVexlにのみ追加してください。",
   "addContactDialog.contactAlreadyAddedTitle": "連絡先はすでに追加済み",
   "addContactDialog.contactAlreadyAddedDescription": "この電話番号はすでにVexlの連絡先に入っているよ。連絡先リストから編集できるよ。",
   "addContactDialog.wouldYouLikeToChangeTheName": "{{name}} の名前を変更しますか。",

--- a/packages/localization/nl-base.json
+++ b/packages/localization/nl-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Je kunt dit contact op elk moment bewerken.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Contact alleen aan Vexl toegevoegd",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl kon dit contact niet op je telefoon opslaan omdat toegang tot Contacten is uitgeschakeld. Open de instellingen om toegang toe te staan.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Het contact is niet toegevoegd aan Vexl omdat het niet kon worden opgeslagen in de contacten van je telefoon. Probeer het opnieuw of schakel \"Ook opslaan op je telefoon\" uit om het alleen aan Vexl toe te voegen.",
   "addContactDialog.contactAlreadyAddedTitle": "Contact al toegevoegd",
   "addContactDialog.contactAlreadyAddedDescription": "Dit telefoonnummer staat al in je Vexl-contacten. Je kunt het bewerken vanuit je contactenlijst.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Wilt u de naam van {{name}} veranderen?",

--- a/packages/localization/no-base.json
+++ b/packages/localization/no-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Du kan redigere denne kontakten når som helst.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Kontakt bare lagt til i Vexl",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl kunne ikke lagre denne kontakten på telefonen din fordi tilgang til Kontakter er slått av. Åpne innstillingene for å gi tilgang.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Kontakten ble ikke lagt til i Vexl fordi den ikke kunne lagres i telefonkontaktene dine. Prøv igjen, eller slå av «Lagre også på telefonen» for å legge den til bare i Vexl.",
   "addContactDialog.contactAlreadyAddedTitle": "Kontakt allerede lagt til",
   "addContactDialog.contactAlreadyAddedDescription": "Dette telefonnummeret finnes allerede i Vexl-kontaktene dine. Du kan redigere det fra kontaktlisten din.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Would you like to change the name for {{name}}?",

--- a/packages/localization/pcm-base.json
+++ b/packages/localization/pcm-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "You fit edit this contact anytime.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Contact add only for Vexl",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl no fit save this contact for your phone because Contacts access dey off. Open settings make you allow access.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Di contact no add for Vexl because e no fit save for your phone contacts. Try again, or off \"Also save to your phone\" make e add only for Vexl.",
   "addContactDialog.contactAlreadyAddedTitle": "Contact don already add",
   "addContactDialog.contactAlreadyAddedDescription": "This phone number dey your Vexl contacts already. You fit edit am from your contact list.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Would you like to change the name for {{name}}?",

--- a/packages/localization/pl-base.json
+++ b/packages/localization/pl-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Możesz edytować ten kontakt w każdej chwili.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Kontakt dodany tylko do Vexl",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl nie mógł zapisać tego kontaktu w Twoim telefonie, bo dostęp do Kontaktów jest wyłączony. Otwórz ustawienia, aby zezwolić na dostęp.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Kontakt nie został dodany do Vexl, ponieważ nie udało się zapisać go w kontaktach telefonu. Spróbuj ponownie albo wyłącz „Zapisz też w telefonie”, aby dodać go tylko do Vexl.",
   "addContactDialog.contactAlreadyAddedTitle": "Kontakt już dodany",
   "addContactDialog.contactAlreadyAddedDescription": "Ten numer telefonu jest już w Twoich kontaktach Vexl. Możesz go edytować z listy kontaktów.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Czy chcesz zmienić nazwę dla {{name}}?",

--- a/packages/localization/pt-base.json
+++ b/packages/localization/pt-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Podes editar este contacto a qualquer momento.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Contacto adicionado só ao Vexl",
   "addContactDialog.contactAddedToVexlOnlyDescription": "O Vexl não conseguiu guardar este contacto no teu telemóvel porque o acesso aos Contactos está desativado. Abre as definições para permitir o acesso.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "O contacto não foi adicionado ao Vexl porque não foi possível guardá-lo nos contactos do teu telefone. Tenta novamente ou desativa “Guardar também no teu telefone” para o adicionar apenas ao Vexl.",
   "addContactDialog.contactAlreadyAddedTitle": "Contacto já adicionado",
   "addContactDialog.contactAlreadyAddedDescription": "Este número de telefone já está nos teus contactos do Vexl. Podes editá-lo a partir da tua lista de contactos.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Would you like to change the name for {{name}} for this phone number?",

--- a/packages/localization/sk-base.json
+++ b/packages/localization/sk-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Tento kontakt môžeš kedykoľvek upraviť.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Kontakt pridaný iba do Vexl",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl nemohol uložiť tento kontakt do tvojho telefónu, pretože prístup ku Kontaktom je vypnutý. Otvor nastavenia a povoľ prístup.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Kontakt nebol pridaný do Vexlu, pretože sa ho nepodarilo uložiť do kontaktov v telefóne. Skús to znova alebo vypni „Uložiť aj do telefónu“ a pridaj ho iba do Vexlu.",
   "addContactDialog.contactAlreadyAddedTitle": "Kontakt už je pridaný",
   "addContactDialog.contactAlreadyAddedDescription": "Toto telefónne číslo už máš vo svojich Vexl kontaktoch. Môžeš ho upraviť zo svojho zoznamu kontaktov.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Chceš pre toto číslo zmeniť meno z uloženého {{name}}?",

--- a/packages/localization/sv-base.json
+++ b/packages/localization/sv-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Du kan redigera den här kontakten när som helst.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Kontakten lades bara till i Vexl",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl kunde inte spara den här kontakten i din telefon eftersom åtkomst till Kontakter är avstängd. Öppna inställningarna för att tillåta åtkomst.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Kontakten lades inte till i Vexl eftersom den inte kunde sparas i telefonens kontakter. Försök igen, eller stäng av ”Spara även på din telefon” för att bara lägga till den i Vexl.",
   "addContactDialog.contactAlreadyAddedTitle": "Kontakten är redan tillagd",
   "addContactDialog.contactAlreadyAddedDescription": "Det här telefonnumret finns redan bland dina Vexl-kontakter. Du kan redigera det från din kontaktlista.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Would you like to change the name for {{name}}?",

--- a/packages/localization/sw-base.json
+++ b/packages/localization/sw-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Unaweza kuhariri mwasiliani huyu wakati wowote.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Mwasiliani ameongezwa kwenye Vexl pekee",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl haikuweza kuhifadhi mwasiliani huyu kwenye simu yako kwa sababu ruhusa ya Contacts imezimwa. Fungua mipangilio ili kuruhusu ufikiaji.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Anwani haikuongezwa kwenye Vexl kwa sababu haikuweza kuhifadhiwa kwenye anwani za simu yako. Jaribu tena, au zima \"Hifadhi pia kwenye simu yako\" ili kuiongeza kwenye Vexl pekee.",
   "addContactDialog.contactAlreadyAddedTitle": "Mwasiliani tayari ameongezwa",
   "addContactDialog.contactAlreadyAddedDescription": "Namba hii ya simu tayari iko kwenye mawasiliano yako ya Vexl. Unaweza kuihariri kutoka kwenye orodha yako ya mawasiliano.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Je, ungependa kubadilisha jina la {{name}}?",

--- a/packages/localization/tr-base.json
+++ b/packages/localization/tr-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Bu kişiyi istediğin zaman düzenleyebilirsin.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Kişi yalnızca Vexl'e eklendi",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Kişiler erişimi kapalı olduğu için Vexl bu kişiyi telefonuna kaydedemedi. Erişime izin vermek için ayarları aç.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Kişi, telefon rehberine kaydedilemediği için Vexl’e eklenmedi. Tekrar deneyin veya yalnızca Vexl’e eklemek için \"Telefonuna da kaydet\" seçeneğini kapatın.",
   "addContactDialog.contactAlreadyAddedTitle": "Kişi zaten eklendi",
   "addContactDialog.contactAlreadyAddedDescription": "Bu telefon numarası zaten Vexl kişilerinde var. Kişi listenden düzenleyebilirsin.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Would you like to change the name for {{name}}?",

--- a/packages/localization/uk-base.json
+++ b/packages/localization/uk-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "Ти можеш відредагувати цей контакт будь-коли.",
   "addContactDialog.contactAddedToVexlOnlyTitle": "Контакт додано лише у Vexl",
   "addContactDialog.contactAddedToVexlOnlyDescription": "Vexl не зміг зберегти цей контакт у твоєму телефоні, бо доступ до Контактів вимкнено. Відкрий налаштування, щоб дозволити доступ.",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "Контакт не було додано до Vexl, бо його не вдалося зберегти в контактах телефону. Спробуй ще раз або вимкни «Також зберегти в телефоні», щоб додати його лише до Vexl.",
   "addContactDialog.contactAlreadyAddedTitle": "Контакт уже додано",
   "addContactDialog.contactAlreadyAddedDescription": "Цей номер телефону вже є у твоїх контактах Vexl. Ти можеш відредагувати його зі списку контактів.",
   "addContactDialog.wouldYouLikeToChangeTheName": "Would you like to change the name for {{name}}?",

--- a/packages/localization/zh-base.json
+++ b/packages/localization/zh-base.json
@@ -966,6 +966,7 @@
   "addContactDialog.youCanEditThisContactAnytime": "你随时都可以编辑这个联系人。",
   "addContactDialog.contactAddedToVexlOnlyTitle": "联系人仅已添加到 Vexl",
   "addContactDialog.contactAddedToVexlOnlyDescription": "由于通讯录访问权限已关闭，Vexl 无法把这个联系人保存到你的手机。打开设置来允许访问。",
+  "addContactDialog.contactCouldNotBeSavedToPhoneDescription": "联系人未添加到 Vexl，因为无法保存到你的手机通讯录。请重试，或关闭“也保存到手机”以仅添加到 Vexl。",
   "addContactDialog.contactAlreadyAddedTitle": "联系人已添加",
   "addContactDialog.contactAlreadyAddedDescription": "这个手机号已经在你的 Vexl 联系人里了。你可以从联系人列表里编辑它。",
   "addContactDialog.wouldYouLikeToChangeTheName": "您想要更改 {{name}} 的名称吗？",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marketplace and chat screens now show “common friends” using only the connections visible from imported contacts, improving consistency across cards, offer details, and common-friends navigation (including verified-only views).
  * Offer search now includes these visible “common friends” in its matching text.

* **Bug Fixes**
  * Improved contact selection: newly added contacts become selected immediately, default selection is more accurate, and submitted selections are persisted correctly.

* **Other Improvements**
  * Updated marketplace sorting/filtering so “most connections” and related logic reflect visible connections consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->