### PR TITLE
feat: #2485 - Suggest amount screen on trade checklist should have "Save" not "Send" button

### DIFF
--- a/apps/mobile/src/components/TradeChecklistFlow/components/CalculateAmountFlow/components/CalculateAmountScreen/index.tsx
+++ b/apps/mobile/src/components/TradeChecklistFlow/components/CalculateAmountFlow/components/CalculateAmountScreen/index.tsx
@@ -106,7 +106,7 @@ function CalculateAmountScreen({
         onPress: onFooterButtonPress,
         text: isOtherSideAmountDataNewerThanMine
           ? t('common.accept')
-          : t('common.send'),
+          : t('common.save'),
         variant: isOtherSideAmountDataNewerThanMine ? 'secondary' : 'primary',
       }}
     >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the amount calculation flow’s footer button text to show **Save** instead of **Send** for the standard scenario.
  * The **Accept** label for the newer-amount scenario remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->