### PR TITLE
Limit Dependabot to security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,18 @@
 version: 2
+
+# We only want Dependabot *security* updates — PRs that fix known
+# vulnerabilities. Those are enabled in the repo security settings and are NOT
+# affected by `open-pull-requests-limit`. Setting the limit to 0 disables
+# routine *version* updates, so Dependabot won't open a PR for every new
+# release; it will still open PRs to remediate security advisories.
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-      time: "03:00"
-      timezone: "Europe/Prague"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
+    open-pull-requests-limit: 0
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
-      time: "03:00"
-      timezone: "Europe/Prague"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## What

Disables Dependabot **version** updates (a PR per new release) while keeping Dependabot **security** updates (PRs that remediate known vulnerabilities).

Sets `open-pull-requests-limit: 0` for both the `github-actions` and `npm` ecosystems. Per GitHub's docs, this limit applies only to version-update PRs — security-update PRs are unaffected.

## Why

Version updates were generating a steady stream of routine PRs (e.g. the six npm PRs combined in #2552). We only want Dependabot to open PRs when there's an actual security advisory to fix.

## Confirmed setup

Security updates already flow independently of this file:
- Dependabot **alerts**: enabled
- Dependabot **security updates** (`automated-security-fixes`): `{"enabled": true, "paused": false}`

So after this change, Dependabot stops opening routine version bumps but will still open PRs to fix vulnerabilities.

> Note: `time`/`timezone` and the github-actions `groups` block were removed since they only governed version-update PR scheduling/batching, which is now disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency settings to focus on security-related updates.
  * Routine version update pull requests are now disabled, while security fixes can still be applied.
  * Simplified update scheduling for package and GitHub Actions dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->