### PR TITLE
feat #2476: Display clubs reach in clubs section

### DIFF
--- a/apps/mobile/src/components/InsideRouter/components/CommunityScreen/components/ClubsScreen/components/ClubsList.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/CommunityScreen/components/ClubsScreen/components/ClubsList.tsx
@@ -109,7 +109,7 @@ function ClubsReachFooter(): React.JSX.Element {
   return (
     <YStack paddingTop="$3" gap="$2">
       <ClubReachCard
-        title="Clubs reach"
+        title={t('clubs.clubsReach')}
         reachLabel={t('offerForm.friendLevel.reachPeopleFormatted', {
           localizedString: formatInteger(clubsReach, locale),
         })}

--- a/apps/mobile/src/components/InsideRouter/components/CommunityScreen/components/ClubsScreen/components/ClubsList.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/CommunityScreen/components/ClubsScreen/components/ClubsList.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   ClubCard,
+  ClubReachCard,
   Stack,
   Typography,
   useTheme,
@@ -18,6 +19,7 @@ import {
 } from '../../../../../../../state/clubs/atom/clubsWithMembersAtom'
 import {syncAllClubsHandleStateWhenNotFoundActionAtom} from '../../../../../../../state/clubs/atom/refreshClubsActionAtom'
 import {type ClubWithMembers} from '../../../../../../../state/clubs/domain'
+import {clubsConnectionsReachAtom} from '../../../../../../../state/connections/atom/connectionStateAtom'
 import atomKeyExtractor from '../../../../../../../utils/atomUtils/atomKeyExtractor'
 import {useTranslation} from '../../../../../../../utils/localization/I18nProvider'
 import {formatInteger} from '../../../../../../../utils/localization/formatting'
@@ -99,6 +101,24 @@ function Separator(): React.JSX.Element {
   return <Stack height="$3" />
 }
 
+function ClubsReachFooter(): React.JSX.Element {
+  const {t} = useTranslation()
+  const clubsReach = useAtomValue(clubsConnectionsReachAtom)
+  const locale = useAtomValue(formattingLocaleAtom)
+
+  return (
+    <YStack paddingTop="$3" gap="$2">
+      <ClubReachCard
+        title="Clubs reach"
+        reachLabel={t('offerForm.friendLevel.reachPeopleFormatted', {
+          localizedString: formatInteger(clubsReach, locale),
+        })}
+      />
+      <Stack height="$2" />
+    </YStack>
+  )
+}
+
 export function ClubsList({
   navigation,
 }: {
@@ -151,7 +171,7 @@ export function ClubsList({
         />
       }
       ListFooterComponent={
-        isNonEmptyArray(clubsAtoms) ? <Stack height="$2" /> : null
+        isNonEmptyArray(clubsAtoms) ? <ClubsReachFooter /> : null
       }
     />
   )

--- a/packages/localization/base.json
+++ b/packages/localization/base.json
@@ -1287,6 +1287,7 @@
   "clubs.moreInfo": "More info",
   "clubs.commonFriends": "{{count}} common friends",
   "clubs.commonFriendsFormatted": "{{localizedString}} common friends",
+  "clubs.clubsReach": "Clubs reach",
   "clubs.expiresOn": "Expires on {{expirationDate}}",
   "clubs.moderator.inviteCodeLabel": "Invite code",
   "clubs.joinClub": "Join club",

--- a/packages/localization/en-base.json
+++ b/packages/localization/en-base.json
@@ -1287,6 +1287,7 @@
   "clubs.moreInfo": "More info",
   "clubs.commonFriends": "{{count}} common friends",
   "clubs.commonFriendsFormatted": "{{localizedString}} common friends",
+  "clubs.clubsReach": "Clubs reach",
   "clubs.expiresOn": "Expires on {{expirationDate}}",
   "clubs.moderator.inviteCodeLabel": "Invite code",
   "clubs.joinClub": "Join club",

--- a/packages/ui/src/components/ClubReachCard.tsx
+++ b/packages/ui/src/components/ClubReachCard.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import {styled, useTheme} from 'tamagui'
+
+import {ConferenceClub} from '../icons'
+import {XStack, YStack} from '../primitives'
+import {Typography} from './Typography'
+
+export interface ClubReachCardProps {
+  readonly title: string
+  readonly reachLabel: string
+}
+
+const ClubReachCardFrame = styled(XStack, {
+  name: 'ClubReachCard',
+  alignItems: 'center',
+  backgroundColor: '$backgroundTertiary',
+  borderRadius: '$5',
+  gap: '$4',
+  padding: '$4',
+})
+
+const ReachPill = styled(XStack, {
+  name: 'ClubReachCardPill',
+  alignItems: 'center',
+  alignSelf: 'flex-start',
+  backgroundColor: '$backgroundSecondary',
+  borderRadius: '$11',
+  gap: '$2',
+  maxWidth: '100%',
+  paddingHorizontal: '$3',
+  paddingVertical: '$2',
+})
+
+export function ClubReachCard({
+  title,
+  reachLabel,
+}: ClubReachCardProps): React.JSX.Element {
+  const theme = useTheme()
+  const iconColor = theme.foregroundSecondary.get()
+
+  return (
+    <ClubReachCardFrame>
+      <YStack flex={1} gap="$2">
+        <Typography variant="tabSmallBold" color="$foregroundPrimary">
+          {title}
+        </Typography>
+        <ReachPill>
+          <ConferenceClub size={16} color={iconColor} />
+          <Typography
+            variant="description"
+            color="$foregroundPrimary"
+            flexShrink={1}
+          >
+            {reachLabel}
+          </Typography>
+        </ReachPill>
+      </YStack>
+    </ClubReachCardFrame>
+  )
+}

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -33,6 +33,8 @@ export {Chip} from './Chip'
 export type {ChipProps} from './Chip'
 export {ClubCard} from './ClubCard'
 export type {ClubCardProps} from './ClubCard'
+export {ClubReachCard} from './ClubReachCard'
+export type {ClubReachCardProps} from './ClubReachCard'
 export {CommonFriends} from './CommonFriends'
 export type {CommonFriend, CommonFriendsProps} from './CommonFriends'
 export {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Clubs reach” footer card to the clubs list, displaying the current reach value with localization and integer formatting.
  * Introduced a reusable Club reach card component (icon + title + label) for consistent presentation.
* **Bug Fixes**
  * Updated the clubs list footer behavior to show the reach card when clubs are available, replacing the previous placeholder footer.
* **Documentation**
  * Added the new localized string for “Clubs reach” to the base and English catalogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->