### PR TITLE
fix: error with session

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,5 +1,5 @@
-const VERSION_CODE = 820
-const VERSION = '1.43.8'
+const VERSION_CODE = 830
+const VERSION = '1.43.9'
 const ENV_PRESET = process.env.ENV_PRESET
 const IS_LOCAL_ENV = ENV_PRESET === 'local'
 const COMMIT_HASH = process.env.EAS_BUILD_GIT_COMMIT_HASH ?? 'local'

--- a/apps/mobile/src/state/session/loadSession.test.ts
+++ b/apps/mobile/src/state/session/loadSession.test.ts
@@ -506,6 +506,35 @@ describe('loadSession', () => {
     expect(wasV2SecretWritten()).toBe(true)
   })
 
+  it('falls back to legacy secret when stale v2 secret can not decrypt the session', async () => {
+    const loadedSession = buildLoggedInSession(dummySession.version + 21)
+    const {encryptedSession, secretToken} =
+      encryptSessionForStorage(loadedSession)
+
+    asyncStorageGetItemMock.mockResolvedValueOnce(encryptedSession)
+    secretStoreGetItemAsyncMock
+      .mockResolvedValueOnce('stale-v2-secret-token')
+      .mockResolvedValueOnce(secretToken)
+
+    const result = await Effect.runPromise(loadSession({forceReload: false}))
+
+    expect(result.sessionLoaded).toBe(true)
+    expect(getDefaultStore().get(sessionHolderAtom)).toEqual({
+      state: 'loggedIn',
+      session: withExpectedSessionUpgrades(loadedSession),
+    })
+    expect(secretStoreGetItemAsyncMock).toHaveBeenCalledWith(
+      SECRET_TOKEN_KEY_V2
+    )
+    expect(secretStoreGetItemAsyncMock).toHaveBeenCalledWith(SECRET_TOKEN_KEY)
+    expect(secretStoreSetItemAsyncMock).toHaveBeenCalledWith(
+      SECRET_TOKEN_KEY_V2,
+      secretToken,
+      SECRET_TOKEN_KEY_V2_OPTIONS
+    )
+    expect(wasV2SecretWritten()).toBe(true)
+  })
+
   it('sets loggedOut when there is no session in async storage', async () => {
     asyncStorageGetItemMock.mockResolvedValueOnce(null)
 

--- a/apps/mobile/src/state/session/utils/readSessionFromStorage.ts
+++ b/apps/mobile/src/state/session/utils/readSessionFromStorage.ts
@@ -15,6 +15,13 @@ import {
 import {markV2SecretAsWritten, wasV2SecretWritten} from './v2SecretStorageFlag'
 import {SECRET_TOKEN_KEY_V2_OPTIONS} from './writeSessionToStorage'
 
+type SecretTokenSource = 'v2' | 'legacy'
+
+interface SecretTokenFromStorage {
+  readonly secretToken: string
+  readonly source: SecretTokenSource
+}
+
 export class V2SecretReadFailedAfterBeingWritten extends Schema.TaggedError<V2SecretReadFailedAfterBeingWritten>(
   'V2SecretReadFailedAfterBeingWritten'
 )('V2SecretReadFailedAfterBeingWritten', {
@@ -53,14 +60,35 @@ function mapLegacySecretReadError(
   return loadingError
 }
 
-function getSecretToken({
+function secretTokenFromStorage(
+  source: SecretTokenSource,
+  secretToken: string
+): SecretTokenFromStorage {
+  return {secretToken, source}
+}
+
+function getLegacySecretToken({
+  secretStorageKey,
+}: {
+  secretStorageKey: string
+}): Effect.Effect<
+  SecretTokenFromStorage,
+  StoredSessionSecretUnavailable | ErrorReadingFromSecureStorage
+> {
+  return getItemFromSecretStorage(secretStorageKey).pipe(
+    Effect.mapError(mapLegacySecretReadError),
+    Effect.map((secretToken) => secretTokenFromStorage('legacy', secretToken))
+  )
+}
+
+function getPreferredSecretToken({
   secretStorageKey,
   secretStorageKeyV2,
 }: {
   secretStorageKey: string
   secretStorageKeyV2: string
 }): Effect.Effect<
-  string,
+  SecretTokenFromStorage,
   | StoreEmpty
   | V2SecretReadFailedAfterBeingWritten
   | StoredSessionSecretUnavailable
@@ -68,19 +96,98 @@ function getSecretToken({
 > {
   return getItemFromSecretStorage(secretStorageKeyV2).pipe(
     Effect.mapError(mapV2SecretReadError),
+    Effect.map((secretToken) => secretTokenFromStorage('v2', secretToken)),
     Effect.catchTag('StoreEmpty', () =>
-      getItemFromSecretStorage(secretStorageKey).pipe(
-        Effect.mapError(mapLegacySecretReadError),
-        Effect.tap((secretToken) =>
-          saveItemToSecretStorage(
+      getLegacySecretToken({
+        secretStorageKey,
+      })
+    )
+  )
+}
+
+function backfillV2SecretIfNeeded({
+  secretStorageKeyV2,
+  secretTokenFromStorage,
+}: {
+  secretStorageKeyV2: string
+  secretTokenFromStorage: SecretTokenFromStorage
+}): Effect.Effect<void> {
+  if (secretTokenFromStorage.source === 'v2') return Effect.void
+
+  return saveItemToSecretStorage(
+    secretStorageKeyV2,
+    SECRET_TOKEN_KEY_V2_OPTIONS
+  )(secretTokenFromStorage.secretToken).pipe(
+    Effect.tap(() => Effect.sync(markV2SecretAsWritten)),
+    Effect.ignore
+  )
+}
+
+function decryptAndDecodeSession(
+  encryptedSessionJson: string,
+  secretToken: string
+): Effect.Effect<Session, CryptoError | ParseResult.ParseError> {
+  return aesCTRDecrypt(secretToken)(encryptedSessionJson).pipe(
+    Effect.flatMap(Schema.decode(Schema.parseJson(Session)))
+  )
+}
+
+function decryptWithLegacySecretOrOriginalError({
+  encryptedSessionJson,
+  secretStorageKey,
+  secretStorageKeyV2,
+  originalError,
+}: {
+  encryptedSessionJson: string
+  secretStorageKey: string
+  secretStorageKeyV2: string
+  originalError: CryptoError | ParseResult.ParseError
+}): Effect.Effect<Session, CryptoError | ParseResult.ParseError> {
+  return getLegacySecretToken({secretStorageKey}).pipe(
+    Effect.flatMap((secretTokenFromStorage) =>
+      decryptAndDecodeSession(
+        encryptedSessionJson,
+        secretTokenFromStorage.secretToken
+      ).pipe(
+        Effect.tap(() =>
+          backfillV2SecretIfNeeded({
             secretStorageKeyV2,
-            SECRET_TOKEN_KEY_V2_OPTIONS
-          )(secretToken).pipe(
-            Effect.tap(() => Effect.sync(markV2SecretAsWritten)),
-            Effect.ignore
-          )
+            secretTokenFromStorage,
+          })
         )
       )
+    ),
+    Effect.catchAll(() => Effect.fail(originalError))
+  )
+}
+
+function decryptAndDecodeSessionWithFallback({
+  encryptedSessionJson,
+  secretStorageKey,
+  secretStorageKeyV2,
+  secretTokenFromStorage,
+}: {
+  encryptedSessionJson: string
+  secretStorageKey: string
+  secretStorageKeyV2: string
+  secretTokenFromStorage: SecretTokenFromStorage
+}): Effect.Effect<Session, CryptoError | ParseResult.ParseError> {
+  return decryptAndDecodeSession(
+    encryptedSessionJson,
+    secretTokenFromStorage.secretToken
+  ).pipe(
+    Effect.tap(() =>
+      backfillV2SecretIfNeeded({secretStorageKeyV2, secretTokenFromStorage})
+    ),
+    Effect.catchAll((e) =>
+      secretTokenFromStorage.source === 'v2'
+        ? decryptWithLegacySecretOrOriginalError({
+            encryptedSessionJson,
+            secretStorageKey,
+            secretStorageKeyV2,
+            originalError: e,
+          })
+        : Effect.fail(e)
     )
   )
 }
@@ -107,13 +214,17 @@ export function readSessionFromStorage({
     const encryptedSessionJson = yield* _(
       getItemFromAsyncStorage(asyncStorageKey)
     )
-    const secretToken = yield* _(
-      getSecretToken({secretStorageKey, secretStorageKeyV2})
+    const secretTokenFromStorage = yield* _(
+      getPreferredSecretToken({secretStorageKey, secretStorageKeyV2})
     )
 
     return yield* _(
-      aesCTRDecrypt(secretToken)(encryptedSessionJson),
-      Effect.flatMap(Schema.decode(Schema.parseJson(Session)))
+      decryptAndDecodeSessionWithFallback({
+        encryptedSessionJson,
+        secretStorageKey,
+        secretStorageKeyV2,
+        secretTokenFromStorage,
+      })
     )
   })
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session recovery when a newer stored secret cannot decrypt the session.
  * The app now intelligently falls back to the legacy secret, backfills the newer secret when appropriate, and preserves `loggedIn` state with an upgraded session.
  * Added automated test coverage for this recovery and fallback behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->