### PR TITLE
fix #2557: Donation need to be saved immediately to mmkv before proceeding to detail to avoid state inconsistency

### DIFF
--- a/apps/mobile/src/components/DonationPrompt/atoms/index.ts
+++ b/apps/mobile/src/components/DonationPrompt/atoms/index.ts
@@ -13,6 +13,7 @@ import {DateTime} from 'luxon'
 import {apiAtom} from '../../../api'
 import {
   myDonationsAtom,
+  setMyDonationsAndSaveImmediatelyActionAtom,
   singleDonationAtom,
 } from '../../../state/donations/atom'
 import {type MyDonation} from '../../../state/donations/domain'
@@ -85,22 +86,25 @@ export const createDonationInvoiceRequestActionAtom = atom(
         )
       )
 
-      set(myDonationsAtom, (prev) => [
+      const newDonation: MyDonation = {
+        invoiceId: resp.invoiceId,
+        storeId: resp.storeId,
+        status: resp.status,
+        paymentMethod: resp.paymentMethod,
+        fiatAmount: resp.fiatAmount,
+        btcAmount: resp.btcAmount,
+        currency: resp.currency,
+        exchangeRate: resp.exchangeRate,
+        createdTime: resp.createdTime,
+        expirationTime: resp.expirationTime,
+        paymentLink: resp.paymentLink,
+      }
+      // Persist synchronously so the donation is already in storage when
+      // the details screen mounts the atom and re-reads it from MMKV.
+      set(setMyDonationsAndSaveImmediatelyActionAtom, (prev) => ({
         ...prev,
-        {
-          invoiceId: resp.invoiceId,
-          storeId: resp.storeId,
-          status: resp.status,
-          paymentMethod: resp.paymentMethod,
-          fiatAmount: resp.fiatAmount,
-          btcAmount: resp.btcAmount,
-          currency: resp.currency,
-          exchangeRate: resp.exchangeRate,
-          createdTime: resp.createdTime,
-          expirationTime: resp.expirationTime,
-          paymentLink: resp.paymentLink,
-        },
-      ])
+        data: pipe(prev.data, Array.append(newDonation)),
+      }))
 
       set(
         lastDisplayOfDonationPromptTimestampAtom,
@@ -251,4 +255,19 @@ export const updateAllNonSettledOrExpiredInvoicesStatusTypesActionAtom = atom(
         })
       )
     })
+)
+
+export const myDonationsRefreshingAtom = atom<boolean>(false)
+
+export const refreshMyDonationsActionAtom = atom(null, (get, set) =>
+  Effect.gen(function* (_) {
+    set(myDonationsRefreshingAtom, true)
+    yield* _(set(updateAllNonSettledOrExpiredInvoicesStatusTypesActionAtom))
+  }).pipe(
+    Effect.ensuring(
+      Effect.sync(() => {
+        set(myDonationsRefreshingAtom, false)
+      })
+    )
+  )
 )

--- a/apps/mobile/src/components/DonationsFlow/components/MyDonationsScreen/components/DonationsList.tsx
+++ b/apps/mobile/src/components/DonationsFlow/components/MyDonationsScreen/components/DonationsList.tsx
@@ -4,13 +4,13 @@ import {Array, Effect} from 'effect'
 import {useAtomValue, useSetAtom} from 'jotai'
 import React from 'react'
 import {RefreshControl} from 'react-native-gesture-handler'
-import {
-  myDonationsSortedAtom,
-  myDonationsStateAtom,
-} from '../../../../../state/donations/atom'
+import {myDonationsSortedAtom} from '../../../../../state/donations/atom'
 import {type MyDonation} from '../../../../../state/donations/domain'
 import {useTranslation} from '../../../../../utils/localization/I18nProvider'
-import {updateAllNonSettledOrExpiredInvoicesStatusTypesActionAtom} from '../../../../DonationPrompt/atoms'
+import {
+  myDonationsRefreshingAtom,
+  refreshMyDonationsActionAtom,
+} from '../../../../DonationPrompt/atoms'
 import DonationsListItem from './DonationsListItem'
 import EmptyListPlaceholder from './EmptyListPlaceholder'
 
@@ -30,10 +30,8 @@ function DonationsList({onDonatePress}: Props): React.ReactElement {
   const {t} = useTranslation()
   const theme = useTheme()
   const myDonationsSorted = useAtomValue(myDonationsSortedAtom)
-  const myDonationsLoading = useAtomValue(myDonationsStateAtom) === 'loading'
-  const updateAllNonSettledOrExpiredInvoicesStatusTypes = useSetAtom(
-    updateAllNonSettledOrExpiredInvoicesStatusTypesActionAtom
-  )
+  const myDonationsRefreshing = useAtomValue(myDonationsRefreshingAtom)
+  const refreshMyDonations = useSetAtom(refreshMyDonationsActionAtom)
 
   if (!Array.isNonEmptyArray(myDonationsSorted)) {
     return <EmptyListPlaceholder onDonatePress={onDonatePress} />
@@ -65,10 +63,8 @@ function DonationsList({onDonatePress}: Props): React.ReactElement {
       indicatorStyle="white"
       refreshControl={
         <RefreshControl
-          refreshing={myDonationsLoading ?? false}
-          onRefresh={() =>
-            Effect.runFork(updateAllNonSettledOrExpiredInvoicesStatusTypes())
-          }
+          refreshing={myDonationsRefreshing}
+          onRefresh={() => Effect.runFork(refreshMyDonations())}
           tintColor={theme.foregroundTertiary.get()}
         />
       }

--- a/apps/mobile/src/state/donations/atom.ts
+++ b/apps/mobile/src/state/donations/atom.ts
@@ -3,20 +3,19 @@ import {Schema} from 'effect'
 import {atom} from 'jotai'
 import {focusAtom} from 'jotai-optics'
 import {splitAtom} from 'jotai/utils'
-import {atomWithParsedMmkvStorage} from '../../utils/atomUtils/atomWithParsedMmkvStorage'
+import {atomWithParsedMmkvStorageWithImmediateSaveOption} from '../../utils/atomUtils/atomWithParsedMmkvStorage'
 import {type FocusAtomType} from '../../utils/atomUtils/FocusAtomType'
 import {MyDonation} from './domain'
 
-const myDonationsStorageAtom = atomWithParsedMmkvStorage(
+const myDonationsStorage = atomWithParsedMmkvStorageWithImmediateSaveOption(
   'myDonations',
-  {data: [], state: 'loaded'},
+  {data: []},
   Schema.Struct({
     data: Schema.Array(MyDonation).pipe(Schema.mutable),
-    state: Schema.Literal('loading', 'loaded'),
   })
 )
 
-export const myDonationsAtom = focusAtom(myDonationsStorageAtom, (optic) =>
+export const myDonationsAtom = focusAtom(myDonationsStorage.atom, (optic) =>
   optic.prop('data')
 )
 
@@ -26,10 +25,6 @@ export const myDonationsSortedAtom = atom((get) =>
 
 export const myDonationsAtomsAtom = splitAtom(myDonationsSortedAtom)
 
-export const myDonationsStateAtom = focusAtom(myDonationsStorageAtom, (optic) =>
-  optic.prop('state')
-)
-
 export function singleDonationAtom(
   invoiceid: InvoiceId
 ): FocusAtomType<MyDonation | undefined> {
@@ -37,3 +32,6 @@ export function singleDonationAtom(
     optic.find((myDonation) => myDonation.invoiceId === invoiceid)
   )
 }
+
+export const setMyDonationsAndSaveImmediatelyActionAtom =
+  myDonationsStorage.setAndSaveImmediatelyAtom

--- a/apps/mobile/src/utils/atomUtils/atomWithParsedMmkvStorage.ts
+++ b/apps/mobile/src/utils/atomUtils/atomWithParsedMmkvStorage.ts
@@ -1,5 +1,10 @@
 import {Array, Either, Schema, pipe, type ParseResult} from 'effect'
-import {atom, type PrimitiveAtom, type SetStateAction} from 'jotai'
+import {
+  atom,
+  type PrimitiveAtom,
+  type SetStateAction,
+  type WritableAtom,
+} from 'jotai'
 import {InteractionManager} from 'react-native'
 import {storage} from '../mmkv/effectMmkv'
 import reportError from '../reportError'
@@ -168,6 +173,21 @@ function getInitialValue<A>({
   )
 }
 
+export interface AtomWithParsedMmkvStorageWithImmediateSaveOption<A> {
+  readonly atom: FlushablePrimitiveAtom<A>
+  /**
+   * Sets the atom and persists the new value to MMKV synchronously, instead of
+   * deferring the write with InteractionManager as regular sets do. Use when
+   * the value must be readable from storage right away. Persist errors are
+   * reported, not thrown.
+   */
+  readonly setAndSaveImmediatelyAtom: WritableAtom<
+    null,
+    [update: SetStateAction<A>],
+    void
+  >
+}
+
 /**
  * Creates a primitive atom persisted in MMKV under the given key.
  *
@@ -188,12 +208,15 @@ function getInitialValue<A>({
  * still contain it decode fine — effect Schema structs ignore excess
  * properties by default.
  */
-export function atomWithParsedMmkvStorage<A, I extends object>(
+export function atomWithParsedMmkvStorageWithImmediateSaveOption<
+  A,
+  I extends object,
+>(
   key: string,
   defaultValue: A,
   schema: Schema.Schema<A, I, never>,
   debugLabel?: string
-): FlushablePrimitiveAtom<A> {
+): AtomWithParsedMmkvStorageWithImmediateSaveOption<A> {
   const decodeRawValue = Schema.decodeEither(Schema.parseJson(schema))
   const persistValue = storage.saveVerified(key, schema)
 
@@ -330,8 +353,56 @@ export function atomWithParsedMmkvStorage<A, I extends object>(
     return listener.remove
   }
 
+  const flushableAtom = Object.assign(mmkvAtom, {flushNow: flushPendingWrite})
+
+  const setAndSaveImmediatelyAtom = atom(
+    null,
+    (get, set, update: SetStateAction<A>): void => {
+      const newValue = getValueFromSetStateActionOfAtom(update)(() =>
+        get(coreAtom)
+      )
+      set(coreAtom, newValue)
+
+      pendingWrite = undefined
+
+      isPersistingOwnValue = true
+      try {
+        pipe(
+          persistValue(newValue),
+          Either.getOrElse((l) => {
+            reportError(
+              'warn',
+              new Error(
+                `Error while immediately saving value to storage. Key: ${key}`
+              ),
+              {errorTag: l._tag}
+            )
+          })
+        )
+      } finally {
+        isPersistingOwnValue = false
+      }
+    }
+  )
+
   // `flushPendingWrite` already reads-and-clears the pending write, no-ops when
   // nothing is queued, and drops the write when the clear-generation moved on —
-  // exactly the semantics `flushNow` needs — so expose it directly.
-  return Object.assign(mmkvAtom, {flushNow: flushPendingWrite})
+  // exactly the semantics `flushNow` needs.
+  return {atom: flushableAtom, setAndSaveImmediatelyAtom}
+}
+
+export function atomWithParsedMmkvStorage<A, I extends object>(
+  key: string,
+  defaultValue: A,
+  schema: Schema.Schema<A, I, never>,
+  debugLabel?: string
+): FlushablePrimitiveAtom<A> {
+  const storageAtom = atomWithParsedMmkvStorageWithImmediateSaveOption(
+    key,
+    defaultValue,
+    schema,
+    debugLabel
+  )
+
+  return storageAtom.atom
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Donation entries are now persisted immediately after creation, so they appear in the saved list right away.
  * Added an immediate-save option for mobile MMKV-backed state updates.
* **Bug Fixes**
  * Improved donation persistence by persisting the saved data in a simplified shape and writing updates through the dedicated immediate-save path.
* **Improvements**
  * Updated the donations list pull-to-refresh to use a dedicated refreshing flag and refresh action, with more accurate refreshing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->