### PR TITLE
fix: align EAS Update runtime fingerprints between CI and EAS builds

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -48,7 +48,13 @@ jobs:
         with:
           # Single-quoted on purpose: in a plain YAML scalar the " #" would
           # start a comment and truncate the command mid-string.
-          command: 'eas update --branch pr-${{ github.event.number }} --message "PR #${{ github.event.number }} (${{ github.event.pull_request.head.sha }})" --non-interactive'
+          #
+          # --environment must match the dev-client build profile's
+          # environment (eas.json): it pulls the same EAS env vars (the
+          # react-native-maps API keys) into app config evaluation — they
+          # are part of the runtime fingerprint, so without them the update
+          # would never load in the dev client.
+          command: 'eas update --branch pr-${{ github.event.number }} --environment development --message "PR #${{ github.event.number }} (${{ github.event.pull_request.head.sha }})" --non-interactive'
           working-directory: apps/mobile
         env:
           ENV_PRESET: stage

--- a/.github/workflows/release-over-the-air-update.yaml
+++ b/.github/workflows/release-over-the-air-update.yaml
@@ -85,6 +85,11 @@ jobs:
         # NOT be set here — that flag shifts the fingerprint to the
         # dev-client runtime and the update would target dev clients instead
         # of release apps.
+        #
+        # --environment production matches the store build profiles
+        # (staging and production alike — see eas.json): it pulls the same
+        # EAS env vars (the react-native-maps API keys) into app config
+        # evaluation, which are part of the runtime fingerprint.
         run: |
           {
             echo "## ⚠️ OTA update (${{ inputs.environment }})"
@@ -95,7 +100,7 @@ jobs:
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
           for CHANNEL in "${{ inputs.environment }}" "${{ inputs.environment }}-apk"; do
-            eas update --channel "$CHANNEL" --message "OTA (${REASON}) @ ${GITHUB_SHA::7}" --non-interactive --json > update.json
+            eas update --channel "$CHANNEL" --environment production --message "OTA (${REASON}) @ ${GITHUB_SHA::7}" --non-interactive --json > update.json
             jq -r --arg channel "$CHANNEL" \
               '(if type == "array" then . else [.] end)[] |
                "- channel `\($channel)` / \(.platform) / runtime `\(.runtimeVersion)` → [update group](https://expo.dev/accounts/vexlit/projects/vexl/updates/\(.group))"' \

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -5,6 +5,7 @@
   },
   "build": {
     "staging": {
+      "environment": "production",
       "android": {
         "credentialsSource": "remote",
         "resourceClass": "large"
@@ -19,6 +20,7 @@
       "channel": "staging"
     },
     "development": {
+      "environment": "development",
       "developmentClient": true,
       "distribution": "store",
       "android": {
@@ -37,6 +39,7 @@
       "channel": "development"
     },
     "development-simulator": {
+      "environment": "development",
       "developmentClient": true,
       "distribution": "internal",
       "env": {
@@ -47,6 +50,7 @@
       }
     },
     "stagingApk": {
+      "environment": "production",
       "android": {
         "credentialsSource": "remote",
         "buildType": "apk",
@@ -59,6 +63,7 @@
       "channel": "staging-apk"
     },
     "production": {
+      "environment": "production",
       "android": {
         "credentialsSource": "remote",
         "resourceClass": "large"
@@ -73,6 +78,7 @@
       "channel": "production"
     },
     "productionApk": {
+      "environment": "production",
       "android": {
         "credentialsSource": "remote",
         "buildType": "apk"

--- a/apps/mobile/fingerprint.config.js
+++ b/apps/mobile/fingerprint.config.js
@@ -1,5 +1,14 @@
 /** @type {import('@expo/fingerprint').Config} */
 const config = {
+  ignorePaths: [
+    // eas.json is hashed as a fingerprint source by default, but
+    // build-eas-dev-client.yaml injects a unique IOS_BUILD_NUMBER_SUFFIX
+    // into it on every run — hashing it would give every dev-client build
+    // a runtime version no update can ever match. Settings in eas.json
+    // that really affect the native app (env like ENV_PRESET) still show
+    // up in the fingerprint through the evaluated expo config.
+    'eas.json',
+  ],
   sourceSkips: [
     // `extra` carries commitHash (EAS_BUILD_GIT_COMMIT_HASH), which differs
     // on every build and is unset entirely when publishing updates from CI.


### PR DESCRIPTION
## Problem

The `[Build] Dev client` action failed with a runtime version mismatch — the fingerprint computed by eas-cli on the GitHub runner (`635e6b6c`) differed from the one computed on the EAS builder (`fad579e7`). Since `runtimeVersion: {policy: 'fingerprint'}` is unconditional, the same drift would also orphan every update published from CI (PR previews and last-resort OTA updates would silently never load in any build).

## Root causes

1. **Secret-visibility EAS env vars in the fingerprint.** `ANDROID_MAP_API_KEY` / `IOS_MAP_API_KEY` are read by `app.config.ts` into the `react-native-maps` plugin props, which are part of the fingerprint. They were stored with **secret** visibility, and secrets are only injected on EAS builders — never during local config evaluation — so the runner always hashed a config without them. Verified via the EAS build log: the builder received both keys as "Environment secrets" while the runner had neither.
2. **`eas.json` is a fingerprint source, and CI mutates it per run.** The dev-client workflow jq-injects a unique `IOS_BUILD_NUMBER_SUFFIX` into `eas.json`, so every dev-client build would get a runtime version no published update could ever match (the existing `ExpoConfigVersions` skip only covers the resulting `ios.buildNumber`, not the file hash).

The `android` "bareNativeDir" entry in the reported fingerprint diff was a red herring: EAS fingerprints after prebuild, but that source has `hash: null` and null-hash sources don't contribute to the final hash (`@expo/fingerprint` `Hash.js`).

## Changes

- **Done on EAS (not in this repo):** recreated both map API keys with **sensitive** visibility in the development, preview, and production environments — sensitive vars are available for local config evaluation on any machine with eas-cli project access. (The keys ship inside the app binary anyway; they should be protected by app restrictions in Google Cloud, not secrecy.)
- `apps/mobile/eas.json`: pin each build profile to an explicit EAS `environment` instead of relying on implicit resolution rules.
- `.github/workflows/pr-preview.yaml`: publish with `--environment development` to match the dev-client build profile.
- `.github/workflows/release-over-the-air-update.yaml`: publish with `--environment production` to match the store build profiles.
- `apps/mobile/fingerprint.config.js`: exclude `eas.json` from the fingerprint via `ignorePaths`.

## Verification

Computed fingerprints locally with `expo-updates fingerprint:generate`:
- with keys + clean `eas.json`: `5abcdf42…`
- with keys + jq-suffixed `eas.json`: `5abcdf42…` (identical → CI's eas.json edit no longer rotates the runtime)
- without keys: `1c181cea…` (different → the `--environment` flag is load-bearing)

Also ran prettier, eslint, and tsc for `apps/mobile` — all clean. After merging, re-run the `[Build] Dev client` action; the runner and EAS should now agree on the fingerprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of preview and over-the-air updates by ensuring the correct app environment is used during publishing.
  * Reduced the chance of mismatched builds by making environment settings explicit across build profiles.
  * Prevented fingerprinting issues that could cause incompatible mobile builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->