### PR TITLE
fix: runtime version mismatch breaking iOS dev client builds

### DIFF
--- a/apps/mobile/fingerprint.config.js
+++ b/apps/mobile/fingerprint.config.js
@@ -8,6 +8,18 @@ const config = {
     // that really affect the native app (env like ENV_PRESET) still show
     // up in the fingerprint through the evaluated expo config.
     'eas.json',
+    // react-native-libsodium's postinstall extracts libsodium/build.tgz,
+    // an archive created on macOS that carries AppleDouble metadata. GNU
+    // tar on Linux (CI runners publishing updates) materializes it as
+    // literal `._*` files while bsdtar on macOS (EAS build workers) turns
+    // it into invisible xattrs, so the extracted tree hashes differently
+    // per OS and runtime versions never match. The extracted output is
+    // fully derived from build.tgz, which is still fingerprinted, so
+    // ignoring it loses nothing.
+    '**/node_modules/react-native-libsodium/libsodium/build/**',
+    // ...and the AppleDouble entry for the build dir itself, which GNU tar
+    // materializes as a literal file next to it.
+    '**/node_modules/react-native-libsodium/**/._*',
   ],
   sourceSkips: [
     // `extra` carries commitHash (EAS_BUILD_GIT_COMMIT_HASH), which differs


### PR DESCRIPTION
## Problem

iOS dev client builds fail on EAS with a runtime version mismatch ([failing run](https://github.com/vexl-it/vexl/actions/runs/28801913814)):

- Runtime version calculated on the GH runner (Linux): `9f90a57a…`
- Runtime version calculated on EAS (macOS): `ff1300cc…`

The fingerprint diff pointed at `node_modules/react-native-libsodium` hashing differently on the two machines (the `ios` bareNativeDir entry has `hash: null` and does not contribute to the fingerprint — red herring).

## Root cause

`react-native-libsodium`'s postinstall extracts `libsodium/build.tgz`, an archive created with bsdtar on macOS that carries AppleDouble/xattr metadata for every entry:

- **macOS** (EAS workers): bsdtar restores the metadata as invisible xattrs — no extra files
- **Linux** (GH runners): GNU tar materializes it as ~1900 literal `._*` files

So the package directory content genuinely differs per OS, the fingerprint differs, and any update published from Linux CI (PR previews, OTA) can never match a dev client built on EAS.

## Fix

Ignore the extracted output (`libsodium/build/**` and the stray `._build` AppleDouble file) in `fingerprint.config.js`. The extraction is fully derived from `build.tgz`, which remains part of the fingerprint, so no native change can slip through unnoticed.

## Verification

- Computed the full fingerprint on macOS and inside a `node:24` Linux container over a GNU-tar-extracted libsodium tree: identical hash `53efe9fd2072f8947b654d63026dc61646b1ee06` on both (they differed before the fix).
- `pnpm turbo:typecheck`, `turbo:format`, `turbo:lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update compatibility by excluding generated library build artifacts and hidden Apple metadata from fingerprint checks, preventing mismatches that could occur due to OS- or extraction-dependent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->