### PR TITLE
fix: repeating task layer blocks dependent layers from building

### DIFF
--- a/packages/server-utils/src/repeatingTask.ts
+++ b/packages/server-utils/src/repeatingTask.ts
@@ -44,6 +44,13 @@ export const makeRepeatingTaskLayer = <E1, R1, E2, R2>({
         `Skipping repeating task ${jobName} because another worker holds the lock`
       )
     ),
+    // Defects (thrown exceptions, Effect.die) are not covered by the typed
+    // catches above. Without this they would reject into BullMQ's processor
+    // and vanish as a removed failed job — log them and let the scheduler
+    // fire the next tick.
+    Effect.catchAllDefect((defect) =>
+      Effect.logError(`Repeating task ${jobName} died with a defect`, defect)
+    ),
     Effect.withSpan(`RepeatingTask/${jobName}`)
   )
 
@@ -100,8 +107,8 @@ export const makeRepeatingTaskLayer = <E1, R1, E2, R2>({
       yield* _(
         Effect.acquireRelease(
           Effect.try({
-            try: () =>
-              new Worker(
+            try: () => {
+              const worker = new Worker(
                 queueName,
                 async () => {
                   await Runtime.runPromise(runtime)(taskWithLock)
@@ -111,7 +118,20 @@ export const makeRepeatingTaskLayer = <E1, R1, E2, R2>({
                   prefix,
                   concurrency: 1,
                 }
-              ),
+              )
+              // BullMQ emits 'error' for connection-level problems. An
+              // EventEmitter 'error' event with no listener crashes the
+              // process, so a Redis blip must be logged, not fatal.
+              worker.on('error', (error) => {
+                Runtime.runSync(runtime)(
+                  Effect.logError(
+                    `Worker for repeating task ${jobName} emitted an error`,
+                    error
+                  )
+                )
+              })
+              return worker
+            },
             catch: (e) => e,
           }),
           (worker) =>

--- a/packages/server-utils/src/repeatingTask.ts
+++ b/packages/server-utils/src/repeatingTask.ts
@@ -1,5 +1,5 @@
 import {Queue, Worker} from 'bullmq'
-import {type Duration, Effect, Layer, Stream} from 'effect'
+import {type Duration, Effect, Layer, Runtime} from 'effect'
 import {RedisNamespacePrefixConfig} from './commonConfigs'
 import {RedisConnectionService} from './RedisConnection'
 import {type RedisService, withRedisLock} from './RedisService'
@@ -34,11 +34,20 @@ export const makeRepeatingTaskLayer = <E1, R1, E2, R2>({
   never,
   R1 | R2 | RedisConnectionService | RedisService
 > => {
-  const jobsStream = Stream.asyncScoped<
-    undefined,
-    never,
-    RedisConnectionService | R1
-  >((emit) =>
+  const taskWithLock = task.pipe(
+    Effect.catchAll((e) =>
+      Effect.logError(`Repeating task ${jobName} failed`, e)
+    ),
+    withRedisLock(lockResource, lockDuration),
+    Effect.catchTag('RedisLockError', () =>
+      Effect.logInfo(
+        `Skipping repeating task ${jobName} because another worker holds the lock`
+      )
+    ),
+    Effect.withSpan(`RepeatingTask/${jobName}`)
+  )
+
+  return Layer.scopedDiscard(
     Effect.gen(function* (_) {
       const redisConnection = yield* _(RedisConnectionService)
       const prefix = yield* _(RedisNamespacePrefixConfig)
@@ -81,6 +90,13 @@ export const makeRepeatingTaskLayer = <E1, R1, E2, R2>({
         })
       )
 
+      // The worker callback runs each tick's task through the captured
+      // runtime. This keeps the layer build finite — it completes once the
+      // worker is registered — instead of blocking on an infinite stream,
+      // which would stall every layer depending on this one (e.g. the HTTP
+      // server never binding its port).
+      const runtime = yield* _(Effect.runtime<R2 | RedisService>())
+
       yield* _(
         Effect.acquireRelease(
           Effect.try({
@@ -88,7 +104,7 @@ export const makeRepeatingTaskLayer = <E1, R1, E2, R2>({
               new Worker(
                 queueName,
                 async () => {
-                  await emit.single(undefined)
+                  await Runtime.runPromise(runtime)(taskWithLock)
                 },
                 {
                   connection: redisConnection,
@@ -107,30 +123,15 @@ export const makeRepeatingTaskLayer = <E1, R1, E2, R2>({
     }).pipe(
       // Setup failures (Redis connection, config, Queue/Worker creation,
       // upsertJobScheduler) must not be swallowed: doing so would leave the
-      // stream open but silent, permanently disabling the task while the
-      // service still reports healthy. Log for context, then die so the layer
-      // build fails and the process crashes/restarts under supervision.
-      // Per-tick task failures are handled separately in `taskWithLock` below
-      // and stay non-fatal by design.
+      // task permanently disabled while the service still reports healthy.
+      // Log for context, then die so the layer build fails and the process
+      // crashes/restarts under supervision. Per-tick task failures are
+      // handled separately in `taskWithLock` above and stay non-fatal by
+      // design.
       Effect.tapError((e) =>
         Effect.logError(`Failed to start repeating task ${jobName}`, e)
       ),
       Effect.orDie
     )
   )
-
-  const taskWithLock = task.pipe(
-    Effect.catchAll((e) =>
-      Effect.logError(`Repeating task ${jobName} failed`, e)
-    ),
-    withRedisLock(lockResource, lockDuration),
-    Effect.catchTag('RedisLockError', () =>
-      Effect.logInfo(
-        `Skipping repeating task ${jobName} because another worker holds the lock`
-      )
-    ),
-    Effect.withSpan(`RepeatingTask/${jobName}`)
-  )
-
-  return Layer.effectDiscard(Stream.runForEach(jobsStream, () => taskWithLock))
 }


### PR DESCRIPTION
## Problem

`makeRepeatingTaskLayer` (introduced with the board & notes feature) returns

```ts
Layer.effectDiscard(Stream.runForEach(jobsStream, () => taskWithLock))
```

`Layer.effectDiscard` treats the effect as part of the layer *build*, and `Stream.runForEach` on the BullMQ job stream never completes — so the layer never finishes building.

In offer-service, `HttpServerLive` composes `CleanupWorkersLayer` via a `Layer.provideMerge` chain, which makes it a **dependency** of `ApiServerLive`. The API server therefore waits forever on the never-completing build: the health server comes up, Redis connects, the cleanup tasks even run — but the service never binds port 3003. The mobile app fails with `Transport error (GET .../offers/me/modified/paginated)` against a "healthy" service.

contact-service and notification-service dodge this only by accident: they mount their worker layers as `Layer.mergeAll` siblings of the API server, so nothing awaits the build.

## Fix

Set up the BullMQ queue, job scheduler, and worker directly in a `Layer.scopedDiscard` effect, and run each tick's task from the worker callback through the captured Effect runtime. The layer build now completes once the worker is registered.

Semantics preserved:
- Setup failures (Redis, config, queue/scheduler/worker creation) still log and `orDie`, failing the build so the process crashes and restarts under supervision (per the earlier review-comment change).
- Per-tick task failures remain non-fatal (caught and logged in `taskWithLock`).
- Queue/worker teardown still runs via `acquireRelease` when the layer scope closes.

## Verification

- offer-service now logs `Listening on http://0.0.0.0:3003` and serves requests (previously stalled after the health-server log line in every run).
- With a short `CLEAN_EXPIRED_NOTES_INTERVAL_MS` against fresh Redis + Postgres, the repeating tasks tick on schedule through the new worker path (Redis locks acquired/released each interval).
- `turbo typecheck` on all dependents of server-utils, `format`, and `lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of repeating background tasks by simplifying their scheduling and execution flow.
  * Startup/configuration issues now fail fast, preventing the task runner from staying in a partially initialized state.
  * Per-run failures remain isolated, ensuring one failed execution doesn’t stop subsequent repeats.
  * Added clearer worker-level error logging to avoid unexpected crashes from unhandled worker errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->