### PR TITLE
perf: fix Android slowness hotspots found by on-device profiling

### DIFF
--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -23,6 +23,7 @@ import './src/utils/backgroundTask'
 import * as Sentry from '@sentry/react-native'
 import {registerRootComponent} from 'expo'
 import App from './src/App'
+import {detectMmkvDataLoss} from './src/utils/mmkv/detectMmkvDataLoss'
 
 // polyfill Array.at() function
 if (![].at) {
@@ -37,5 +38,8 @@ if (![].toSorted) {
     return [...this].sort(...arg)
   }
 }
+
+// TODO: Temporary diagnostic for silent MMKV data wipes. Remove with the sentinel.
+detectMmkvDataLoss()
 
 registerRootComponent(Sentry.wrap(App))

--- a/apps/mobile/jest.config.ts
+++ b/apps/mobile/jest.config.ts
@@ -4,7 +4,7 @@ const config: Config.InitialOptions = {
   verbose: true,
   preset: 'jest-expo',
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|i18n-js|msgpackr)',
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|@sentry/react-native|native-base|react-native-svg|i18n-js|msgpackr)',
   ],
   setupFilesAfterEnv: ['./jest.setup.ts'],
   moduleDirectories: ['node_modules', 'utils', 'src'],

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -6,7 +6,7 @@
     "start": "expo start --dev-client",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "//test": "jest",
+    "test": "jest",
     "lint": "eslint src",
     "typecheck": "tsc --noemit",
     "format": "prettier --check \"**/*.{js,mjs,cjs,jsx,ts,tsx,md,json}\"",

--- a/apps/mobile/src/components/AppLogsScreen/utils/storage.ts
+++ b/apps/mobile/src/components/AppLogsScreen/utils/storage.ts
@@ -1,10 +1,24 @@
 /**
- * We don't use atoms here to make it at least somewhat performant. We assume storing 1_000 log lines
+ * We don't use atoms here to make it at least somewhat performant. Logs are
+ * kept as a ring buffer capped at MAX_LOG_LINES lines (cached in memory so we
+ * don't re-read and re-split the whole blob on every stored line).
  */
 import {storage} from '../../../utils/mmkv/effectMmkv'
 
 export const LOGS_KEY = 'logs'
 export const IS_CUSTOM_LOGGKING_ENABLED_KEY = 'logs_enabled'
+
+const MAX_LOG_LINES = 1_000
+
+let cachedLogLines: string[] | undefined
+
+function getLogLines(): string[] {
+  if (cachedLogLines === undefined) {
+    const raw = storage._storage.getString(LOGS_KEY)
+    cachedLogLines = raw ? raw.split('\n') : []
+  }
+  return cachedLogLines
+}
 
 export function setCustomLoggingEnabled(enabled: boolean): void {
   storage._storage.set(IS_CUSTOM_LOGGKING_ENABLED_KEY, enabled)
@@ -15,23 +29,21 @@ export function getCustomLoggingEnabled(): boolean {
 }
 
 export function readLogs(): string[] {
-  return storage._storage.getString(LOGS_KEY)?.split('\n') ?? []
+  return getLogLines()
 }
 
 export function readLogsRaw(): string {
-  return storage._storage.getString(LOGS_KEY) ?? '[[NO LOGS YET]]'
+  const logs = storage._storage.getString(LOGS_KEY)
+  return logs !== undefined && logs !== '' ? logs : '[[NO LOGS YET]]'
 }
 
 export function storeLog(logMessage: string): void {
-  const logsSoFar = storage._storage.getString(LOGS_KEY)
-  if (logsSoFar) {
-    storage._storage.set(LOGS_KEY, logsSoFar + `\n${logMessage}`)
-  } else {
-    storage._storage.set(LOGS_KEY, logMessage)
-  }
+  cachedLogLines = [...getLogLines(), logMessage].slice(-MAX_LOG_LINES)
+  storage._storage.set(LOGS_KEY, cachedLogLines.join('\n'))
 }
 
 export function clearLogs(): void {
+  cachedLogLines = []
   storage._storage.delete(LOGS_KEY)
 }
 

--- a/apps/mobile/src/components/ChatDetailScreen/atoms/index.tsx
+++ b/apps/mobile/src/components/ChatDetailScreen/atoms/index.tsx
@@ -97,6 +97,23 @@ export const ChatScope = createScope<
   WritableAtom<ChatWithMessages, [SetStateAction<ChatWithMessages>], void>
 >(atom<ChatWithMessages>(dummyChatWithMessages))
 
+function areMessagesListItemsEquivalent(
+  prev: MessagesListItem,
+  next: MessagesListItem
+): boolean {
+  if (prev.type === 'message' && next.type === 'message')
+    return prev.message === next.message && prev.isLatest === next.isLatest
+  if (prev.type === 'time' && next.type === 'time')
+    return prev.time.toMillis() === next.time.toMillis()
+  if (prev.type === 'vexlBot' && next.type === 'vexlBot')
+    return prev.data === next.data
+  return prev.type === next.type
+}
+
+const referenceArrayEquivalence = Array.getEquivalence(
+  (a: MessagesListItem, b: MessagesListItem) => a === b
+)
+
 export const chatMolecule = molecule((getMolecule, getScope) => {
   const chatWithMessagesAtom = getScope(ChatScope)
 
@@ -140,13 +157,44 @@ export const chatMolecule = molecule((getMolecule, getScope) => {
       }
     )
 
-  const messagesListDataAtom = atom((get) =>
-    buildMessagesListData(
-      get(messagesAtom),
-      get(hiddenMessagesIdsAtom),
-      get(tradeChecklistAtom)
+  // Reuse previous item objects (matched by their stable `key`) so appending
+  // one message does not change the identity of every other list item. Keeps
+  // the keyed splitAtom below (and FlashList rows) stable across updates.
+  let previousMessagesListData: MessagesListItem[] = []
+
+  const messagesListDataAtom = atom((get) => {
+    const items = pipe(
+      buildMessagesListData(
+        get(messagesAtom),
+        get(hiddenMessagesIdsAtom),
+        get(tradeChecklistAtom)
+      ),
+      (nextItems) => {
+        const previousItemsByKey = new Map(
+          pipe(
+            previousMessagesListData,
+            Array.map((item): [string, MessagesListItem] => [item.key, item])
+          )
+        )
+
+        return pipe(
+          nextItems,
+          Array.map((nextItem) => {
+            const previousItem = previousItemsByKey.get(nextItem.key)
+            return previousItem !== undefined &&
+              areMessagesListItemsEquivalent(previousItem, nextItem)
+              ? previousItem
+              : nextItem
+          })
+        )
+      }
     )
-  )
+
+    if (!referenceArrayEquivalence(items, previousMessagesListData))
+      previousMessagesListData = items
+
+    return previousMessagesListData
+  })
 
   const otherSideDataAtom = selectOtherSideDataAtom(chatAtom)
 
@@ -303,7 +351,12 @@ export const chatMolecule = molecule((getMolecule, getScope) => {
     )?.message.uuid
   })
 
-  const messagesListAtomAtoms = splitAtom(messagesListDataAtom)
+  // Keyed by the stable item key so row atoms (and thus FlashList keys)
+  // survive list updates instead of being regenerated per change.
+  const messagesListAtomAtoms = splitAtom(
+    messagesListDataAtom,
+    (item) => item.key
+  )
 
   const deleteChatAtom = deleteChatActionAtom(chatWithMessagesAtom)
 

--- a/apps/mobile/src/components/ChatDetailScreen/components/MessagesList.tsx
+++ b/apps/mobile/src/components/ChatDetailScreen/components/MessagesList.tsx
@@ -3,11 +3,13 @@ import {type ChatMessageId} from '@vexl-next/domain/src/general/messaging'
 import {tokens, useScreenFooterHeight} from '@vexl-next/ui'
 import {useMolecule} from 'bunshi/dist/react'
 import {useAtomValue, useSetAtom, useStore, type Atom} from 'jotai'
-import React, {useCallback, useEffect, useRef} from 'react'
+import React, {useCallback, useEffect, useMemo, useRef} from 'react'
 import {
   Animated,
   Easing,
+  type LayoutChangeEvent,
   type NativeScrollEvent,
+  type NativeSyntheticEvent,
   type ViewabilityConfig,
 } from 'react-native'
 import {KeyboardEvents} from 'react-native-keyboard-controller'
@@ -351,54 +353,86 @@ function MessagesList({
     }
   }, [animateKeyboardBottomSpacer, scrollToBottom])
 
+  const contentContainerStyle = useMemo(
+    () => ({
+      paddingBottom: footerHeight + tokens.size[4].val,
+    }),
+    [footerHeight]
+  )
+
+  const maintainVisibleContentPosition = useMemo(
+    () => ({
+      autoscrollToBottomThreshold: targetMessageId ? undefined : 0.2,
+      startRenderingFromBottom: !targetMessageId,
+    }),
+    [targetMessageId]
+  )
+
+  const onContentSizeChange = useCallback(
+    (_: number, height: number) => {
+      const wasScrolledToBottom =
+        viewportHeightRef.current !== 0 &&
+        isContentScrolledToBottom(contentHeightRef.current)
+
+      contentHeightRef.current = height
+
+      if (height <= viewportHeightRef.current) {
+        updateScrollRefsToBottom()
+      } else if (!targetMessageId && wasScrolledToBottom) {
+        keepScrolledToBottom(keyboardAnimationActiveRef.current)
+      } else if (
+        !targetMessageId &&
+        viewportBottomAnchorRef.current !== undefined
+      ) {
+        scrollToViewportBottomAnchor(
+          viewportBottomAnchorRef.current,
+          keyboardAnimationActiveRef.current
+        )
+      }
+      tryInitialScrollToBottom()
+    },
+    [
+      isContentScrolledToBottom,
+      keepScrolledToBottom,
+      scrollToViewportBottomAnchor,
+      targetMessageId,
+      tryInitialScrollToBottom,
+      updateScrollRefsToBottom,
+    ]
+  )
+
+  const onLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      preserveBottomVisibleContentOnViewportChange(
+        event.nativeEvent.layout.height
+      )
+      if (contentHeightRef.current <= event.nativeEvent.layout.height) {
+        isScrolledToBottomRef.current = true
+      }
+      tryInitialScrollToBottom()
+    },
+    [preserveBottomVisibleContentOnViewportChange, tryInitialScrollToBottom]
+  )
+
+  const onScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      updateIsScrolledToBottom(event.nativeEvent)
+    },
+    [updateIsScrolledToBottom]
+  )
+
   return (
     <FlashList
       ref={listRef}
       data={dataAtoms}
-      contentContainerStyle={{
-        paddingBottom: footerHeight + tokens.size[4].val,
-      }}
+      contentContainerStyle={contentContainerStyle}
       keyExtractor={atomKeyExtractor}
       ListFooterComponent={renderKeyboardBottomSpacer}
-      maintainVisibleContentPosition={{
-        autoscrollToBottomThreshold: targetMessageId ? undefined : 0.2,
-        startRenderingFromBottom: !targetMessageId,
-      }}
-      onContentSizeChange={(_, height) => {
-        const wasScrolledToBottom =
-          viewportHeightRef.current !== 0 &&
-          isContentScrolledToBottom(contentHeightRef.current)
-
-        contentHeightRef.current = height
-
-        if (height <= viewportHeightRef.current) {
-          updateScrollRefsToBottom()
-        } else if (!targetMessageId && wasScrolledToBottom) {
-          keepScrolledToBottom(keyboardAnimationActiveRef.current)
-        } else if (
-          !targetMessageId &&
-          viewportBottomAnchorRef.current !== undefined
-        ) {
-          scrollToViewportBottomAnchor(
-            viewportBottomAnchorRef.current,
-            keyboardAnimationActiveRef.current
-          )
-        }
-        tryInitialScrollToBottom()
-      }}
-      onLayout={(event) => {
-        preserveBottomVisibleContentOnViewportChange(
-          event.nativeEvent.layout.height
-        )
-        if (contentHeightRef.current <= event.nativeEvent.layout.height) {
-          isScrolledToBottomRef.current = true
-        }
-        tryInitialScrollToBottom()
-      }}
+      maintainVisibleContentPosition={maintainVisibleContentPosition}
+      onContentSizeChange={onContentSizeChange}
+      onLayout={onLayout}
       onLoad={tryInitialScrollToBottom}
-      onScroll={(event) => {
-        updateIsScrolledToBottom(event.nativeEvent)
-      }}
+      onScroll={onScroll}
       renderItem={renderItem}
       scrollEventThrottle={16}
       onViewableItemsChanged={

--- a/apps/mobile/src/components/ClubOffersScreen/index.tsx
+++ b/apps/mobile/src/components/ClubOffersScreen/index.tsx
@@ -1,5 +1,5 @@
 import {ChevronLeft, NavigationBar, Screen, Stack} from '@vexl-next/ui'
-import {Option, pipe} from 'effect'
+import {Effect, Option, pipe} from 'effect'
 import {useAtomValue, useSetAtom} from 'jotai'
 import React from 'react'
 import {type RootStackScreenProps} from '../../navigationTypes'
@@ -46,7 +46,11 @@ export function ClubOffersScreen({route}: Props): React.ReactElement {
       <Stack f={1}>
         <OffersList
           offersAtoms={offersAtom}
-          onRefresh={refreshOffers}
+          onRefresh={() => {
+            Effect.runFork(
+              refreshOffers({forceRemovedOffersReconciliation: true})
+            )
+          }}
           refreshing={loadingOffers}
         />
       </Stack>

--- a/apps/mobile/src/components/DebugScreen/index.tsx
+++ b/apps/mobile/src/components/DebugScreen/index.tsx
@@ -2,6 +2,7 @@ import Clipboard from '@react-native-clipboard/clipboard'
 import {useNavigation} from '@react-navigation/native'
 import {PublicKeyPemBase64} from '@vexl-next/cryptography/src/KeyHolder'
 import {type ClubUuid} from '@vexl-next/domain/src/general/clubs'
+import {E164PhoneNumber} from '@vexl-next/domain/src/general/E164PhoneNumber.brand'
 import {type Inbox} from '@vexl-next/domain/src/general/messaging'
 import {
   type BtcNetwork,
@@ -21,7 +22,10 @@ import {
 import {MINIMAL_DATE} from '@vexl-next/domain/src/utility/IsoDatetimeString.brand'
 import {UnixMilliseconds} from '@vexl-next/domain/src/utility/UnixMilliseconds.brand'
 import {generateUuid} from '@vexl-next/domain/src/utility/Uuid.brand'
-import {effectToTaskEither} from '@vexl-next/resources-utils/src/effect-helpers/TaskEitherConverter'
+import {
+  effectToTaskEither,
+  taskEitherToEffect,
+} from '@vexl-next/resources-utils/src/effect-helpers/TaskEitherConverter'
 import {fetchAndEncryptNotificationToken} from '@vexl-next/resources-utils/src/notifications/fetchAndEncryptNotificationToken'
 import {FeedbackFormId} from '@vexl-next/rest-api/src/services/feedback/contracts'
 import {
@@ -46,21 +50,33 @@ import {getInstallationSource} from 'expo-installation-source'
 import * as Notifications from 'expo-notifications'
 import * as TaskManager from 'expo-task-manager'
 import {isTestFlight} from 'expo-testflight'
+import {pipe} from 'fp-ts/function'
 import * as T from 'fp-ts/Task'
 import * as TE from 'fp-ts/TaskEither'
-import {pipe} from 'fp-ts/function'
-import {useAtomValue, useSetAtom, useStore} from 'jotai'
+import {
+  atom,
+  type PrimitiveAtom,
+  type SetStateAction,
+  useAtomValue,
+  useSetAtom,
+  useStore,
+} from 'jotai'
 import {DateTime} from 'luxon'
 import React from 'react'
 import {Alert, Platform} from 'react-native'
 import {apiAtom, apiEnv} from '../../api'
 import {type RootStackScreenProps} from '../../navigationTypes'
+import acceptMessagingRequestAtom from '../../state/chat/atoms/acceptMessagingRequestAtom'
 import allChatsAtom from '../../state/chat/atoms/allChatsAtom'
 import {sendUpdateNoticeMessageActionAtom} from '../../state/chat/atoms/checkAndReportCurrentVersionToChatsActionAtom'
 import deleteAllInboxesActionAtom from '../../state/chat/atoms/deleteAllInboxesActionAtom'
 import fetchMessagesForAllInboxesAtom from '../../state/chat/atoms/fetchNewMessagesActionAtom'
 import focusChatByInboxKeyAndSenderKey from '../../state/chat/atoms/focusChatByInboxKeyAndSenderKey'
 import messagingStateAtom from '../../state/chat/atoms/messagingStateAtom'
+import {
+  type ChatWithMessages,
+  dummyChatWithMessages,
+} from '../../state/chat/domain'
 import {upsertInboxOnBeAndLocallyActionAtom} from '../../state/chat/hooks/useCreateInbox'
 import {clubsToKeyHolderAtom} from '../../state/clubs/atom/clubsToKeyHolderV2Atom'
 import {clubsWithMembersAtom} from '../../state/clubs/atom/clubsWithMembersAtom'
@@ -73,7 +89,9 @@ import offerToConnectionsAtom, {
   updateAndReencryptAllOffersConnectionsActionAtom,
 } from '../../state/connections/atom/offerToConnectionsAtom'
 import {storedContactsAtom} from '../../state/contacts/atom/contactsStore'
+import {submitContactsActionAtom} from '../../state/contacts/atom/submitContactsActionAtom'
 import {StoredContact} from '../../state/contacts/domain'
+import {hashPhoneNumber} from '../../state/contacts/utils'
 import {btcPriceDataAtom} from '../../state/currentBtcPriceAtoms'
 import {createOfferActionAtom} from '../../state/marketplace/atoms/createOfferActionAtom'
 import {myOffersAtom} from '../../state/marketplace/atoms/myOffers'
@@ -675,6 +693,176 @@ function DebugScreen(): React.ReactElement {
                 clubOffersNextPageParam: {},
               })
               Alert.alert('Done')
+            }}
+          />
+          <Button
+            variant="primary"
+            size="small"
+            text="Seed perf: import 200 fake contacts"
+            onPress={() => {
+              // Matches tooling/dev/seed-perf-data.ts: direct fake users are
+              // +420777000000 + i for i < ceil(N_USERS * 2/3) with N_USERS=300
+              // (the `numbersToImportInApp` list of seed-fake-numbers.json).
+              const numbersToImport = effectPipe(
+                Array.makeBy(200, (i) => `+${420777000000 + i}`),
+                Array.map((number) =>
+                  Schema.decodeSync(E164PhoneNumber)(number)
+                )
+              )
+
+              const existingRawNumbers = new Set(
+                store.get(storedContactsAtom).map((c) => c.info.rawNumber)
+              )
+              const newStoredContacts = effectPipe(
+                numbersToImport,
+                Array.filter((number) => !existingRawNumbers.has(number)),
+                Array.filterMap((number): Option.Option<StoredContact> => {
+                  const hash = hashPhoneNumber(number)
+                  if (hash._tag !== 'Right') return Option.none()
+                  return Option.some({
+                    info: {
+                      name: `Seed user ${number.slice(-3)}`,
+                      label: Option.none(),
+                      nonUniqueContactId: Option.none(),
+                      numberToDisplay: number,
+                      rawNumber: number,
+                    },
+                    computedValues: Option.some({
+                      normalizedNumber: number,
+                      hash: hash.right,
+                    }),
+                    serverHashToClient: Option.none(),
+                    flags: {
+                      seen: true,
+                      imported: false,
+                      importedManually: true,
+                      invalidNumber: 'valid',
+                    },
+                  })
+                })
+              )
+              store.set(storedContactsAtom, (existing) => [
+                ...existing,
+                ...newStoredContacts,
+              ])
+
+              Effect.runFork(
+                store
+                  .set(submitContactsActionAtom, {
+                    normalizeAndImportAll: false,
+                    numbersToImport,
+                    showOfferReencryptionDialog: false,
+                    showContactImportProgressDialog: true,
+                  })
+                  .pipe(
+                    Effect.tap((result) =>
+                      Effect.sync(() => {
+                        Alert.alert('Seed contacts import', result)
+                      })
+                    )
+                  )
+              )
+            }}
+          />
+          <Button
+            variant="primary"
+            size="small"
+            text="Seed perf: approve all chat requests"
+            onPress={() => {
+              const pending = effectPipe(
+                store.get(messagingStateAtom),
+                Array.flatMap((inbox) =>
+                  effectPipe(
+                    inbox.chats,
+                    Array.filterMap((chatWithMessages) => {
+                      const lastMessage = chatWithMessages.messages.at(-1)
+                      return lastMessage?.message.messageType ===
+                        'REQUEST_MESSAGING' && lastMessage.state === 'received'
+                        ? Option.some({
+                            inboxKey: inbox.inbox.privateKey.publicKeyPemBase64,
+                            senderKey:
+                              chatWithMessages.chat.otherSide.publicKey,
+                          })
+                        : Option.none()
+                    })
+                  )
+                )
+              )
+
+              if (!Array.isNonEmptyArray(pending)) {
+                Alert.alert('No pending chat requests found')
+                return
+              }
+              Alert.alert(
+                'Started',
+                `Approving ${pending.length} chat requests. Watch console for progress.`
+              )
+
+              Effect.runFork(
+                effectPipe(
+                  Effect.forEach(
+                    pending,
+                    ({inboxKey, senderKey}, i) =>
+                      Effect.gen(function* (_) {
+                        const focusedChatAtom = focusChatByInboxKeyAndSenderKey(
+                          {
+                            inboxKey,
+                            senderKey,
+                          }
+                        )
+                        const definiteChatAtom: PrimitiveAtom<ChatWithMessages> =
+                          atom(
+                            (get) =>
+                              get(focusedChatAtom) ?? dummyChatWithMessages,
+                            (
+                              get,
+                              set,
+                              update: SetStateAction<ChatWithMessages>
+                            ) => {
+                              const current = get(focusedChatAtom)
+                              if (current === undefined) return
+                              set(
+                                focusedChatAtom,
+                                typeof update === 'function'
+                                  ? update(current)
+                                  : update
+                              )
+                            }
+                          )
+                        yield* _(
+                          taskEitherToEffect(
+                            store.set(acceptMessagingRequestAtom, {
+                              chatAtom: definiteChatAtom,
+                              approve: true,
+                              text: 'Hi! Sure, let us talk.',
+                            })
+                          )
+                        )
+                        console.log(
+                          `Approved chat request ${i + 1}/${pending.length}`
+                        )
+                      }),
+                    {concurrency: 3}
+                  ),
+                  Effect.tap((results) =>
+                    Effect.sync(() => {
+                      Alert.alert(
+                        'Done',
+                        `Approved ${results.length} chat requests`
+                      )
+                    })
+                  ),
+                  Effect.tapError((error) =>
+                    Effect.sync(() => {
+                      console.error('Error approving chat requests', error)
+                      Alert.alert(
+                        'Error approving chat requests',
+                        JSON.stringify(error, null, 2).slice(0, 800)
+                      )
+                    })
+                  )
+                )
+              )
             }}
           />
           <Button

--- a/apps/mobile/src/components/DebugScreen/index.tsx
+++ b/apps/mobile/src/components/DebugScreen/index.tsx
@@ -116,6 +116,7 @@ import {
 import {realUserDataAtom} from '../../state/session/userDataAtoms'
 import {andThenExpectVoidNoErrors} from '../../utils/andThenExpectNoErrors'
 import {
+  apiPreset,
   commitHash,
   enableHiddenFeatures,
   packageName,
@@ -148,6 +149,13 @@ import {
   generateTestContacts,
   NUMBER_OF_TEST_CONTACTS,
 } from './utils/generateTestContacts'
+
+// The perf seed buttons upload fake contact hashes and auto-approve real chat
+// requests against whatever backend the app is pointed at. They are meant only
+// for the local seeding workflow (see tooling/dev/README.md), which runs the
+// app against the `local` env preset, so hard-guard them to that preset to
+// prevent polluting real accounts on staging/production.
+const isLocalEnvPreset = apiPreset === 'localEnv'
 
 const DEBUG_EUROPE_OFFERS_PREFIX = 'debug-europe-offer-'
 const DEBUG_FILTER_TEST_OFFERS_PREFIX = 'debug-filter-test-offer-'
@@ -695,176 +703,189 @@ function DebugScreen(): React.ReactElement {
               Alert.alert('Done')
             }}
           />
-          <Button
-            variant="primary"
-            size="small"
-            text="Seed perf: import 200 fake contacts"
-            onPress={() => {
-              // Matches tooling/dev/seed-perf-data.ts: direct fake users are
-              // +420777000000 + i for i < ceil(N_USERS * 2/3) with N_USERS=300
-              // (the `numbersToImportInApp` list of seed-fake-numbers.json).
-              const numbersToImport = effectPipe(
-                Array.makeBy(200, (i) => `+${420777000000 + i}`),
-                Array.map((number) =>
-                  Schema.decodeSync(E164PhoneNumber)(number)
-                )
-              )
-
-              const existingRawNumbers = new Set(
-                store.get(storedContactsAtom).map((c) => c.info.rawNumber)
-              )
-              const newStoredContacts = effectPipe(
-                numbersToImport,
-                Array.filter((number) => !existingRawNumbers.has(number)),
-                Array.filterMap((number): Option.Option<StoredContact> => {
-                  const hash = hashPhoneNumber(number)
-                  if (hash._tag !== 'Right') return Option.none()
-                  return Option.some({
-                    info: {
-                      name: `Seed user ${number.slice(-3)}`,
-                      label: Option.none(),
-                      nonUniqueContactId: Option.none(),
-                      numberToDisplay: number,
-                      rawNumber: number,
-                    },
-                    computedValues: Option.some({
-                      normalizedNumber: number,
-                      hash: hash.right,
-                    }),
-                    serverHashToClient: Option.none(),
-                    flags: {
-                      seen: true,
-                      imported: false,
-                      importedManually: true,
-                      invalidNumber: 'valid',
-                    },
-                  })
-                })
-              )
-              store.set(storedContactsAtom, (existing) => [
-                ...existing,
-                ...newStoredContacts,
-              ])
-
-              Effect.runFork(
-                store
-                  .set(submitContactsActionAtom, {
-                    normalizeAndImportAll: false,
-                    numbersToImport,
-                    showOfferReencryptionDialog: false,
-                    showContactImportProgressDialog: true,
-                  })
-                  .pipe(
-                    Effect.tap((result) =>
-                      Effect.sync(() => {
-                        Alert.alert('Seed contacts import', result)
-                      })
+          {isLocalEnvPreset ? (
+            <>
+              <Button
+                variant="primary"
+                size="small"
+                text="Seed perf: import 200 fake contacts"
+                onPress={() => {
+                  if (!isLocalEnvPreset) {
+                    Alert.alert('Only available on the local env preset')
+                    return
+                  }
+                  // Matches tooling/dev/seed-perf-data.ts: direct fake users are
+                  // +420777000000 + i for i < ceil(N_USERS * 2/3) with N_USERS=300
+                  // (the `numbersToImportInApp` list of seed-fake-numbers.json).
+                  const numbersToImport = effectPipe(
+                    Array.makeBy(200, (i) => `+${420777000000 + i}`),
+                    Array.map((number) =>
+                      Schema.decodeSync(E164PhoneNumber)(number)
                     )
                   )
-              )
-            }}
-          />
-          <Button
-            variant="primary"
-            size="small"
-            text="Seed perf: approve all chat requests"
-            onPress={() => {
-              const pending = effectPipe(
-                store.get(messagingStateAtom),
-                Array.flatMap((inbox) =>
-                  effectPipe(
-                    inbox.chats,
-                    Array.filterMap((chatWithMessages) => {
-                      const lastMessage = chatWithMessages.messages.at(-1)
-                      return lastMessage?.message.messageType ===
-                        'REQUEST_MESSAGING' && lastMessage.state === 'received'
-                        ? Option.some({
-                            inboxKey: inbox.inbox.privateKey.publicKeyPemBase64,
-                            senderKey:
-                              chatWithMessages.chat.otherSide.publicKey,
+
+                  const existingRawNumbers = new Set(
+                    store.get(storedContactsAtom).map((c) => c.info.rawNumber)
+                  )
+                  const newStoredContacts = effectPipe(
+                    numbersToImport,
+                    Array.filter((number) => !existingRawNumbers.has(number)),
+                    Array.filterMap((number): Option.Option<StoredContact> => {
+                      const hash = hashPhoneNumber(number)
+                      if (hash._tag !== 'Right') return Option.none()
+                      return Option.some({
+                        info: {
+                          name: `Seed user ${number.slice(-3)}`,
+                          label: Option.none(),
+                          nonUniqueContactId: Option.none(),
+                          numberToDisplay: number,
+                          rawNumber: number,
+                        },
+                        computedValues: Option.some({
+                          normalizedNumber: number,
+                          hash: hash.right,
+                        }),
+                        serverHashToClient: Option.none(),
+                        flags: {
+                          seen: true,
+                          imported: false,
+                          importedManually: true,
+                          invalidNumber: 'valid',
+                        },
+                      })
+                    })
+                  )
+                  store.set(storedContactsAtom, (existing) => [
+                    ...existing,
+                    ...newStoredContacts,
+                  ])
+
+                  Effect.runFork(
+                    store
+                      .set(submitContactsActionAtom, {
+                        normalizeAndImportAll: false,
+                        numbersToImport,
+                        showOfferReencryptionDialog: false,
+                        showContactImportProgressDialog: true,
+                      })
+                      .pipe(
+                        Effect.tap((result) =>
+                          Effect.sync(() => {
+                            Alert.alert('Seed contacts import', result)
                           })
-                        : Option.none()
-                    })
-                  )
-                )
-              )
-
-              if (!Array.isNonEmptyArray(pending)) {
-                Alert.alert('No pending chat requests found')
-                return
-              }
-              Alert.alert(
-                'Started',
-                `Approving ${pending.length} chat requests. Watch console for progress.`
-              )
-
-              Effect.runFork(
-                effectPipe(
-                  Effect.forEach(
-                    pending,
-                    ({inboxKey, senderKey}, i) =>
-                      Effect.gen(function* (_) {
-                        const focusedChatAtom = focusChatByInboxKeyAndSenderKey(
-                          {
-                            inboxKey,
-                            senderKey,
-                          }
                         )
-                        const definiteChatAtom: PrimitiveAtom<ChatWithMessages> =
-                          atom(
-                            (get) =>
-                              get(focusedChatAtom) ?? dummyChatWithMessages,
-                            (
-                              get,
-                              set,
-                              update: SetStateAction<ChatWithMessages>
-                            ) => {
-                              const current = get(focusedChatAtom)
-                              if (current === undefined) return
-                              set(
-                                focusedChatAtom,
-                                typeof update === 'function'
-                                  ? update(current)
-                                  : update
+                      )
+                  )
+                }}
+              />
+              <Button
+                variant="primary"
+                size="small"
+                text="Seed perf: approve all chat requests"
+                onPress={() => {
+                  if (!isLocalEnvPreset) {
+                    Alert.alert('Only available on the local env preset')
+                    return
+                  }
+                  const pending = effectPipe(
+                    store.get(messagingStateAtom),
+                    Array.flatMap((inbox) =>
+                      effectPipe(
+                        inbox.chats,
+                        Array.filterMap((chatWithMessages) => {
+                          const lastMessage = chatWithMessages.messages.at(-1)
+                          return lastMessage?.message.messageType ===
+                            'REQUEST_MESSAGING' &&
+                            lastMessage.state === 'received'
+                            ? Option.some({
+                                inboxKey:
+                                  inbox.inbox.privateKey.publicKeyPemBase64,
+                                senderKey:
+                                  chatWithMessages.chat.otherSide.publicKey,
+                              })
+                            : Option.none()
+                        })
+                      )
+                    )
+                  )
+
+                  if (!Array.isNonEmptyArray(pending)) {
+                    Alert.alert('No pending chat requests found')
+                    return
+                  }
+                  Alert.alert(
+                    'Started',
+                    `Approving ${pending.length} chat requests. Watch console for progress.`
+                  )
+
+                  Effect.runFork(
+                    effectPipe(
+                      Effect.forEach(
+                        pending,
+                        ({inboxKey, senderKey}, i) =>
+                          Effect.gen(function* (_) {
+                            const focusedChatAtom =
+                              focusChatByInboxKeyAndSenderKey({
+                                inboxKey,
+                                senderKey,
+                              })
+                            const definiteChatAtom: PrimitiveAtom<ChatWithMessages> =
+                              atom(
+                                (get) =>
+                                  get(focusedChatAtom) ?? dummyChatWithMessages,
+                                (
+                                  get,
+                                  set,
+                                  update: SetStateAction<ChatWithMessages>
+                                ) => {
+                                  const current = get(focusedChatAtom)
+                                  if (current === undefined) return
+                                  set(
+                                    focusedChatAtom,
+                                    typeof update === 'function'
+                                      ? update(current)
+                                      : update
+                                  )
+                                }
                               )
-                            }
+                            yield* _(
+                              taskEitherToEffect(
+                                store.set(acceptMessagingRequestAtom, {
+                                  chatAtom: definiteChatAtom,
+                                  approve: true,
+                                  text: 'Hi! Sure, let us talk.',
+                                })
+                              )
+                            )
+                            console.log(
+                              `Approved chat request ${i + 1}/${pending.length}`
+                            )
+                          }),
+                        {concurrency: 3}
+                      ),
+                      Effect.tap((results) =>
+                        Effect.sync(() => {
+                          Alert.alert(
+                            'Done',
+                            `Approved ${results.length} chat requests`
                           )
-                        yield* _(
-                          taskEitherToEffect(
-                            store.set(acceptMessagingRequestAtom, {
-                              chatAtom: definiteChatAtom,
-                              approve: true,
-                              text: 'Hi! Sure, let us talk.',
-                            })
+                        })
+                      ),
+                      Effect.tapError((error) =>
+                        Effect.sync(() => {
+                          console.error('Error approving chat requests', error)
+                          Alert.alert(
+                            'Error approving chat requests',
+                            JSON.stringify(error, null, 2).slice(0, 800)
                           )
-                        )
-                        console.log(
-                          `Approved chat request ${i + 1}/${pending.length}`
-                        )
-                      }),
-                    {concurrency: 3}
-                  ),
-                  Effect.tap((results) =>
-                    Effect.sync(() => {
-                      Alert.alert(
-                        'Done',
-                        `Approved ${results.length} chat requests`
+                        })
                       )
-                    })
-                  ),
-                  Effect.tapError((error) =>
-                    Effect.sync(() => {
-                      console.error('Error approving chat requests', error)
-                      Alert.alert(
-                        'Error approving chat requests',
-                        JSON.stringify(error, null, 2).slice(0, 800)
-                      )
-                    })
+                    )
                   )
-                )
-              )
-            }}
-          />
+                }}
+              />
+            </>
+          ) : null}
           <Button
             variant="primary"
             size="small"

--- a/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/EmptyList.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/EmptyList.tsx
@@ -19,6 +19,7 @@ import {
 import {importedContactsCountAtom} from '../../../../../state/contacts/atom/contactsStore'
 import {useAreOffersLoading} from '../../../../../state/marketplace'
 import {hasPostedFirstOfferActionStepAtom} from '../../../../../state/marketplace/atoms/myOffers'
+import {areThereAnyStoredOffersAtom} from '../../../../../state/marketplace/atoms/offersState'
 import {refreshOffersActionAtom} from '../../../../../state/marketplace/atoms/refreshOffersActionAtom'
 import {
   newOfferButtonVisibleOnLoadingMarketplaceAtom,
@@ -33,7 +34,11 @@ import {useAppState} from '../../../../../utils/useAppState'
 import useAddContactsFromMarketplaceAction from './useAddContactsFromMarketplaceAction'
 import useEnableNotificationsFromMarketplaceAction from './useEnableNotificationsFromMarketplaceAction'
 
-const EMPTY_MARKETPLACE_REFRESH_INTERVAL_MS = 5000
+// Poll fast at first so genuinely new users pick up their first offers
+// quickly, then back off to avoid burning network + battery indefinitely.
+const EMPTY_MARKETPLACE_REFRESH_BACKOFF_MS: readonly number[] = [
+  5_000, 30_000, 60_000,
+]
 const LOADING_OFFERS_EMPTY_STATE_TIMEOUT_MS = 15_000
 
 interface EmptyListAction {
@@ -193,7 +198,11 @@ function EmptyList(): React.ReactElement {
   const [loadingOffersTimedOut, setLoadingOffersTimedOut] = useState(false)
   const isLoadingOffersVisible =
     shouldShowLoadingOffers && (!loadingOffersTimedOut || loading)
-  const shouldPollEmptyMarketplace = isAppActive && isFocused
+  // Poll only when there are no offers stored at all — not when stored offers
+  // are merely all hidden (mine / expired / reported / no common friends).
+  const areThereAnyStoredOffers = useAtomValue(areThereAnyStoredOffersAtom)
+  const shouldPollEmptyMarketplace =
+    isAppActive && isFocused && !areThereAnyStoredOffers
 
   useEffect(() => {
     loadingRef.current = loading
@@ -210,18 +219,29 @@ function EmptyList(): React.ReactElement {
       return undefined
     }
 
-    if (!loadingRef.current) {
-      Effect.runFork(refreshOffers())
-    }
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    let refreshCount = 0
 
-    const intervalId = setInterval(() => {
+    const refreshAndScheduleNext = (): void => {
       if (!loadingRef.current) {
         Effect.runFork(refreshOffers())
       }
-    }, EMPTY_MARKETPLACE_REFRESH_INTERVAL_MS)
+
+      const delay =
+        EMPTY_MARKETPLACE_REFRESH_BACKOFF_MS[
+          Math.min(
+            refreshCount,
+            EMPTY_MARKETPLACE_REFRESH_BACKOFF_MS.length - 1
+          )
+        ] ?? 60_000
+      refreshCount += 1
+      timeoutId = setTimeout(refreshAndScheduleNext, delay)
+    }
+
+    refreshAndScheduleNext()
 
     return () => {
-      clearInterval(intervalId)
+      if (timeoutId !== undefined) clearTimeout(timeoutId)
     }
   }, [refreshOffers, shouldPollEmptyMarketplace])
 

--- a/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/MarketplaceScreenContent.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/MarketplaceScreenContent.tsx
@@ -128,7 +128,7 @@ function MarketplaceScreenContent({
   )
 
   const handleRefresh = useCallback(() => {
-    Effect.runFork(refreshOffers())
+    Effect.runFork(refreshOffers({forceRemovedOffersReconciliation: true}))
   }, [refreshOffers])
 
   const listHeaderComponent = useMemo(

--- a/apps/mobile/src/components/InsideRouter/components/MessagesScreen/components/ChatsList.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/MessagesScreen/components/ChatsList.tsx
@@ -1,18 +1,17 @@
 import {useNavigation} from '@react-navigation/native'
 import {FlashList} from '@shopify/flash-list'
 import {SearchBar, Typography} from '@vexl-next/ui'
+import {Option, pipe, Array as ReadonlyArray} from 'effect'
 import {useAtomValue, type Atom} from 'jotai'
 import {selectAtom, splitAtom} from 'jotai/utils'
 import React from 'react'
 import Animated from 'react-native-reanimated'
 import {Stack} from 'tamagui'
 import messagingStateAtom from '../../../../../state/chat/atoms/messagingStateAtom'
-import {type ChatWithMessages} from '../../../../../state/chat/domain'
 import compareMessages from '../../../../../state/chat/utils/compareMessages'
 import chatShouldBeVisible from '../../../../../state/chat/utils/isChatActive'
 import atomKeyExtractor from '../../../../../utils/atomUtils/atomKeyExtractor'
 import {useTranslation} from '../../../../../utils/localization/I18nProvider'
-import notEmpty from '../../../../../utils/notEmpty'
 import EmptyListWrapper from '../../../../EmptyListWrapper'
 import usePixelsFromBottomWhereTabsEnd from '../../../utils'
 import {InsideScreenListHeader, useInsideScreenScroll} from '../../InsideScreen'
@@ -21,25 +20,36 @@ import ChatListItem, {type ChatListData} from './ChatListItem'
 const ReanimatedFlashList: React.ComponentType<any> =
   Animated.createAnimatedComponent(FlashList)
 
-const chatIdsAtom = selectAtom(messagingStateAtom, (inboxes): ChatListData[] =>
-  inboxes
-    .reduce<ChatWithMessages[]>((acc, one) => {
-      return acc.concat(one.chats)
-    }, [])
-    .filter(chatShouldBeVisible)
-    .map((one) => {
-      if (one.messages.length === 0) return null
-
-      const lastMessage = one.messages.at(-1)
-      if (!lastMessage) return null
-
-      return {chat: one, lastMessage}
-    })
-    .filter(notEmpty)
-    .sort((a, b) => compareMessages(b.lastMessage, a.lastMessage))
+const chatsListDataEquivalence = ReadonlyArray.getEquivalence<ChatListData>(
+  (a, b) => a.chat === b.chat && a.lastMessage === b.lastMessage
 )
 
-const chatIdAtomsAtom = splitAtom(chatIdsAtom)
+const chatsListDataAtom = selectAtom(
+  messagingStateAtom,
+  (inboxes): ChatListData[] =>
+    pipe(
+      inboxes,
+      ReadonlyArray.flatMap((inbox) => inbox.chats),
+      ReadonlyArray.filter(chatShouldBeVisible),
+      ReadonlyArray.filterMap((chat) =>
+        Option.map(ReadonlyArray.last(chat.messages), (lastMessage) => ({
+          chat,
+          lastMessage,
+        }))
+      ),
+      ReadonlyArray.sort<ChatListData>((a, b) =>
+        compareMessages(b.lastMessage, a.lastMessage)
+      )
+    ),
+  chatsListDataEquivalence
+)
+
+// Keyed by chat id so row atoms (and thus FlashList keys) stay stable
+// when unrelated parts of the messaging state change.
+const chatsListDataAtomsAtom = splitAtom(
+  chatsListDataAtom,
+  (item) => item.chat.chat.id
+)
 
 function renderItem({item}: {item: Atom<ChatListData>}): React.ReactElement {
   return <ChatListItem dataAtom={item} />
@@ -48,7 +58,7 @@ function renderItem({item}: {item: Atom<ChatListData>}): React.ReactElement {
 function ChatsList(): React.ReactElement | null {
   const {t} = useTranslation()
   const navigation = useNavigation()
-  const elementAtoms = useAtomValue(chatIdAtomsAtom)
+  const elementAtoms = useAtomValue(chatsListDataAtomsAtom)
   const tabBarEndsAt = usePixelsFromBottomWhereTabsEnd()
   const {onScroll} = useInsideScreenScroll()
 

--- a/apps/mobile/src/state/chat/atoms/fetchNewMessagesActionAtom.ts
+++ b/apps/mobile/src/state/chat/atoms/fetchNewMessagesActionAtom.ts
@@ -539,12 +539,20 @@ export const fetchAndStoreMessagesForInboxHandleNotificationsActionAtom = atom<
 
 const lastRefreshAtom = atom<UnixMilliseconds>(UnixMilliseconds0)
 
+// Only meant to collapse duplicate triggers firing in a burst (e.g. resume
+// in-app loading task + background task). Must stay short — this sweep is the
+// only way users without push notifications learn about new messages on
+// resume, so a long window would make briefly-backgrounded messages invisible.
+const REFRESH_ALL_INBOXES_THROTTLE_MS = 5_000
+const FETCH_INBOX_CONCURRENCY = 6
+
 const fetchMessagesForAllInboxesAtom = atom(null, (get, set) => {
   return Effect.gen(function* (_) {
     const lastRefresh = get(lastRefreshAtom)
 
-    if (unixMillisecondsNow() - lastRefresh < 120) return 'done' as const
-    console.log(`Last refresh before ${unixMillisecondsNow() - lastRefresh}`)
+    if (unixMillisecondsNow() - lastRefresh < REFRESH_ALL_INBOXES_THROTTLE_MS)
+      return 'done' as const
+    console.log(`Last refresh before ${unixMillisecondsNow() - lastRefresh}ms`)
 
     set(lastRefreshAtom, unixMillisecondsNow())
     const measure = startMeasure('Fetch inboxes')
@@ -557,7 +565,7 @@ const fetchMessagesForAllInboxesAtom = atom(null, (get, set) => {
           key: inbox.inbox.privateKey.publicKeyPemBase64,
         }).pipe(Effect.either)
       ),
-      Effect.allWith({concurrency: 'unbounded'}),
+      Effect.allWith({concurrency: FETCH_INBOX_CONCURRENCY}),
       effectWithEnsuredBenchmark('Fetch all inboxes')
     )
 
@@ -567,7 +575,15 @@ const fetchMessagesForAllInboxesAtom = atom(null, (get, set) => {
 
     measure()
     return 'done' as const
-  })
+  }).pipe(
+    // The throttle timestamp is set before fetching — roll it back when the
+    // sweep does not complete so the next trigger is not silently skipped.
+    Effect.tapErrorCause(() =>
+      Effect.sync(() => {
+        set(lastRefreshAtom, UnixMilliseconds0)
+      })
+    )
+  )
 })
 
 export default fetchMessagesForAllInboxesAtom

--- a/apps/mobile/src/state/chat/atoms/fetchNewMessagesActionAtom.ts
+++ b/apps/mobile/src/state/chat/atoms/fetchNewMessagesActionAtom.ts
@@ -5,11 +5,6 @@ import {
 import {type NewChatMessageNoticeNotificationData} from '@vexl-next/domain/src/general/notifications'
 import {VexlNotificationToken} from '@vexl-next/domain/src/general/notifications/VexlNotificationToken'
 import {type OneOfferInState} from '@vexl-next/domain/src/general/offers'
-import {
-  UnixMilliseconds0,
-  unixMillisecondsNow,
-  type UnixMilliseconds,
-} from '@vexl-next/domain/src/utility/UnixMilliseconds.brand'
 import retrieveMessages, {
   type ApiErrorRetrievingMessages,
   type RetrievedChatMessage,
@@ -20,7 +15,7 @@ import {
   taskToEffect,
 } from '@vexl-next/resources-utils/src/effect-helpers/TaskEitherConverter'
 import {type ChatApi} from '@vexl-next/rest-api/src/services/chat'
-import {Array, Effect, Option, Record, Schema} from 'effect/index'
+import {Array, Effect, Fiber, Option, Record, Schema} from 'effect/index'
 import * as A from 'fp-ts/Array'
 import * as E from 'fp-ts/Either'
 import * as T from 'fp-ts/Task'
@@ -537,53 +532,59 @@ export const fetchAndStoreMessagesForInboxHandleNotificationsActionAtom = atom<
   })
 )
 
-const lastRefreshAtom = atom<UnixMilliseconds>(UnixMilliseconds0)
-
-// Only meant to collapse duplicate triggers firing in a burst (e.g. resume
-// in-app loading task + background task). Must stay short — this sweep is the
-// only way users without push notifications learn about new messages on
-// resume, so a long window would make briefly-backgrounded messages invisible.
-const REFRESH_ALL_INBOXES_THROTTLE_MS = 5_000
+// Holds the currently running full-inbox sweep so that concurrent triggers
+// join it instead of starting a duplicate. This replaces a wall-clock throttle:
+// de-duping only collapses triggers that overlap an in-progress sweep, while a
+// time window would also skip a sweep that follows a recent one. That matters
+// for users without push notifications, for whom the resume sweep is the only
+// way new messages surface — a throttle would drop it and hide messages that
+// arrived during a brief background.
+const inFlightFetchFiberAtom = atom<Fiber.RuntimeFiber<'done'> | null>(null)
 const FETCH_INBOX_CONCURRENCY = 6
 
 const fetchMessagesForAllInboxesAtom = atom(null, (get, set) => {
   return Effect.gen(function* (_) {
-    const lastRefresh = get(lastRefreshAtom)
+    const inFlightFetch = get(inFlightFetchFiberAtom)
+    if (inFlightFetch) return yield* _(Fiber.join(inFlightFetch))
 
-    if (unixMillisecondsNow() - lastRefresh < REFRESH_ALL_INBOXES_THROTTLE_MS)
-      return 'done' as const
-    console.log(`Last refresh before ${unixMillisecondsNow() - lastRefresh}ms`)
-
-    set(lastRefreshAtom, unixMillisecondsNow())
     const measure = startMeasure('Fetch inboxes')
     console.log('Refreshing all inboxes')
 
-    yield* _(
-      get(messagingStateAtom),
-      Array.map((inbox) =>
-        set(fetchAndStoreMessagesForInboxHandleNotificationsActionAtom, {
-          key: inbox.inbox.privateKey.publicKeyPemBase64,
-        }).pipe(Effect.either)
-      ),
-      Effect.allWith({concurrency: FETCH_INBOX_CONCURRENCY}),
-      effectWithEnsuredBenchmark('Fetch all inboxes')
+    // Fork as a daemon so a single sweep runs to completion (and clears the
+    // in-flight marker) even if the trigger that started it is interrupted,
+    // while every joiner still awaits the same real fetch.
+    const fiber = yield* _(
+      Effect.gen(function* (_) {
+        yield* _(
+          get(messagingStateAtom),
+          Array.map((inbox) =>
+            set(fetchAndStoreMessagesForInboxHandleNotificationsActionAtom, {
+              key: inbox.inbox.privateKey.publicKeyPemBase64,
+            }).pipe(Effect.either)
+          ),
+          Effect.allWith({concurrency: FETCH_INBOX_CONCURRENCY}),
+          effectWithEnsuredBenchmark('Fetch all inboxes')
+        )
+
+        if (Platform.OS === 'ios') {
+          void cancelNewChatNotifications()
+        }
+
+        measure()
+        return 'done' as const
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            set(inFlightFetchFiberAtom, null)
+          })
+        ),
+        Effect.forkDaemon
+      )
     )
 
-    if (Platform.OS === 'ios') {
-      void cancelNewChatNotifications()
-    }
-
-    measure()
-    return 'done' as const
-  }).pipe(
-    // The throttle timestamp is set before fetching — roll it back when the
-    // sweep does not complete so the next trigger is not silently skipped.
-    Effect.tapErrorCause(() =>
-      Effect.sync(() => {
-        set(lastRefreshAtom, UnixMilliseconds0)
-      })
-    )
-  )
+    set(inFlightFetchFiberAtom, fiber)
+    return yield* _(Fiber.join(fiber))
+  })
 })
 
 export default fetchMessagesForAllInboxesAtom

--- a/apps/mobile/src/state/chat/checkAndDeleteEmptyInboxesWithoutOfferInAppLoadingTask.ts
+++ b/apps/mobile/src/state/chat/checkAndDeleteEmptyInboxesWithoutOfferInAppLoadingTask.ts
@@ -1,12 +1,21 @@
-import {Array, Effect} from 'effect'
+import {Array, Effect, Either, Schema} from 'effect'
 import {pipe} from 'fp-ts/lib/function'
 import {apiAtom} from '../../api'
 import {registerInAppLoadingTask} from '../../utils/inAppLoadingTasks'
+import {storage} from '../../utils/mmkv/effectMmkv'
 import reportError from '../../utils/reportError'
 import {myOffersAtom} from '../marketplace/atoms/myOffers'
+import {OFFERS_STORAGE_KEY, offersAtom} from '../marketplace/atoms/offersState'
 import {myNotesAtom} from '../notes/atoms/notesState'
 import {sessionDataOrDummyAtom} from '../session'
 import messagingStateAtom from './atoms/messagingStateAtom'
+
+// Lightweight probe used only to tell whether the persisted offers blob holds
+// any offers. It decodes just the `offers` array shape (elements stay
+// `Unknown`), so it avoids the cost of fully validating every stored offer.
+const PersistedOffersProbe = Schema.Struct({
+  offers: Schema.Array(Schema.Unknown),
+})
 
 export const checkAndDeleteEmptyInboxesWithoutOfferInAppLoadingTaskId =
   registerInAppLoadingTask({
@@ -25,6 +34,39 @@ export const checkAndDeleteEmptyInboxesWithoutOfferInAppLoadingTaskId =
           .get(myNotesAtom)
           .map((note) => note.noteInfo.noteId)
         const session = store.get(sessionDataOrDummyAtom)
+
+        // Safety guard: deleting an inbox is destructive and server-visible.
+        // Own-offer inboxes are kept only when their offer is present in the
+        // in-memory offers store. If that store is empty in memory while the
+        // persisted blob still decodes to a non-empty offers list, the
+        // in-memory value is transiently empty / out of sync (this exact
+        // anomaly once deleted every own-offer inbox). Skip this run and let a
+        // future one clean up once the two agree. A genuinely empty offers
+        // store (blob absent, or decoding to an empty list) is not suspicious,
+        // so cleanup still runs for hydrated accounts that have no own offers.
+        const inMemoryOffersEmpty = Array.isEmptyArray(store.get(offersAtom))
+        const anyInboxBelongsToOffer = pipe(
+          store.get(messagingStateAtom),
+          Array.some((one) => !!one.inbox.offerId)
+        )
+        if (inMemoryOffersEmpty && anyInboxBelongsToOffer) {
+          const persistedOffersNonEmpty = pipe(
+            storage.getVerified(OFFERS_STORAGE_KEY, PersistedOffersProbe),
+            Either.map((persisted) =>
+              Array.isNonEmptyReadonlyArray(persisted.offers)
+            ),
+            Either.getOrElse(() => false)
+          )
+          if (persistedOffersNonEmpty) {
+            reportError(
+              'warn',
+              new Error(
+                'Skipping checkAndDeleteEmptyInboxesWithoutOffer. The in-memory offers store is empty while the persisted offers blob still holds offers - offers state is transiently empty / out of sync.'
+              )
+            )
+            return
+          }
+        }
 
         store.set(
           messagingStateAtom,

--- a/apps/mobile/src/state/chat/checkAndDeleteEmptyInboxesWithoutOfferInAppLoadingTask.ts
+++ b/apps/mobile/src/state/chat/checkAndDeleteEmptyInboxesWithoutOfferInAppLoadingTask.ts
@@ -9,6 +9,7 @@ import {OFFERS_STORAGE_KEY, offersAtom} from '../marketplace/atoms/offersState'
 import {myNotesAtom} from '../notes/atoms/notesState'
 import {sessionDataOrDummyAtom} from '../session'
 import messagingStateAtom from './atoms/messagingStateAtom'
+import {fetchMessagesForAllInboxesInAppLoadingTaskId} from './fetchMessagesForAllInboxesInAppLoadingTask'
 
 // Lightweight probe used only to tell whether the persisted offers blob holds
 // any offers. It decodes just the `offers` array shape (elements stay
@@ -24,6 +25,21 @@ export const checkAndDeleteEmptyInboxesWithoutOfferInAppLoadingTaskId =
       requiresUserLoggedIn: true,
       runOn: 'resume',
     },
+    // Deleting an inbox is destructive and server-visible. An inbox with no own
+    // offer/note and no open chats looks deletable, but that "no open chats"
+    // signal is only trustworthy once this session has actually pulled pending
+    // messages from the server - otherwise we could delete an inbox whose first
+    // incoming message is still waiting server-side. Gate cleanup on a
+    // successful full-inbox fetch: onlyIfSucceeds means a failed fetch skips
+    // cleanup entirely (skipping is always safer than deleting early).
+    //
+    // This is correct as long as the fetch task reports completion only after a
+    // real fetch. A throttle that fast-returns a no-op without fetching would
+    // undermine the gate, so the fetch path must await the in-flight fetch
+    // rather than resolve immediately when throttled.
+    dependsOn: [
+      {id: fetchMessagesForAllInboxesInAppLoadingTaskId, onlyIfSucceeds: true},
+    ],
     task: (store) =>
       Effect.gen(function* (_) {
         const api = store.get(apiAtom)

--- a/apps/mobile/src/state/clubs/atom/checkForClubsAdmissionActionAtom.ts
+++ b/apps/mobile/src/state/clubs/atom/checkForClubsAdmissionActionAtom.ts
@@ -3,7 +3,7 @@ import {atom} from 'jotai'
 import {apiAtom} from '../../../api'
 import {addNotificationToCenterActionAtom} from '../../../components/NotificationsScreen/state'
 import {translationAtom} from '../../../utils/localization/I18nProvider'
-import {getNotificationTokenE} from '../../../utils/notifications'
+import {getNotificationTokenWithTimeoutE} from '../../../utils/notifications'
 import {showInternalNotificationForClubAdmission} from '../../../utils/notifications/clubNotifications'
 import {ignoreReportErrors} from '../../../utils/reportError'
 import {effectWithEnsuredBenchmark} from '../../ActionBenchmarks'
@@ -23,12 +23,7 @@ export const checkForClubsAdmissionActionAtom = atom(null, (get, set) => {
     const keysWaitingForAdmission = get(keysWaitingForAdmissionAtom)
     // Time-limited so a hanging push-token fetch can never stall the
     // admission check (same treatment as in syncConnectionsActionAtom).
-    const notificationToken = yield* _(
-      getNotificationTokenE(),
-      Effect.timeout('3 seconds'),
-      Effect.catchTag('TimeoutException', () => Effect.succeed(null)),
-      Effect.map(Option.fromNullable)
-    )
+    const notificationToken = yield* _(getNotificationTokenWithTimeoutE())
 
     yield* _(
       keysWaitingForAdmission,

--- a/apps/mobile/src/state/clubs/atom/checkForClubsAdmissionActionAtom.ts
+++ b/apps/mobile/src/state/clubs/atom/checkForClubsAdmissionActionAtom.ts
@@ -21,8 +21,12 @@ export const checkForClubsAdmissionActionAtom = atom(null, (get, set) => {
     const api = get(apiAtom)
 
     const keysWaitingForAdmission = get(keysWaitingForAdmissionAtom)
+    // Time-limited so a hanging push-token fetch can never stall the
+    // admission check (same treatment as in syncConnectionsActionAtom).
     const notificationToken = yield* _(
       getNotificationTokenE(),
+      Effect.timeout('3 seconds'),
+      Effect.catchTag('TimeoutException', () => Effect.succeed(null)),
       Effect.map(Option.fromNullable)
     )
 

--- a/apps/mobile/src/state/clubs/atom/refreshClubsActionAtom.ts
+++ b/apps/mobile/src/state/clubs/atom/refreshClubsActionAtom.ts
@@ -7,7 +7,7 @@ import {type VexlNotificationToken} from '@vexl-next/domain/src/general/notifica
 import {Array, Effect, Either, Option, pipe, Record} from 'effect'
 import {atom} from 'jotai'
 import {apiAtom} from '../../../api'
-import {getNotificationTokenE} from '../../../utils/notifications'
+import {getNotificationTokenWithTimeoutE} from '../../../utils/notifications'
 import {ignoreReportErrors} from '../../../utils/reportError'
 import {effectWithEnsuredBenchmark} from '../../ActionBenchmarks'
 import {removeClubOffersNextPageParamFromStateActionAtom} from '../../marketplace/atoms/offersState'
@@ -66,12 +66,7 @@ const fetchClubWithMembersHandleStateIfNotFoundActionAtom = atom(
     Effect.gen(function* (_) {
       // Time-limited so a hanging push-token fetch can never stall the club
       // refresh (same treatment as in syncConnectionsActionAtom).
-      const notificationToken = yield* _(
-        getNotificationTokenE(),
-        Effect.timeout('3 seconds'),
-        Effect.catchTag('TimeoutException', () => Effect.succeed(null)),
-        Effect.map(Option.fromNullable)
-      )
+      const notificationToken = yield* _(getNotificationTokenWithTimeoutE())
       const api = get(apiAtom)
       const clubAlreadyInStateStats = get(
         clubsWithMembersStorageAtom

--- a/apps/mobile/src/state/clubs/atom/refreshClubsActionAtom.ts
+++ b/apps/mobile/src/state/clubs/atom/refreshClubsActionAtom.ts
@@ -64,8 +64,12 @@ const fetchClubWithMembersHandleStateIfNotFoundActionAtom = atom(
     }
   ) =>
     Effect.gen(function* (_) {
+      // Time-limited so a hanging push-token fetch can never stall the club
+      // refresh (same treatment as in syncConnectionsActionAtom).
       const notificationToken = yield* _(
         getNotificationTokenE(),
+        Effect.timeout('3 seconds'),
+        Effect.catchTag('TimeoutException', () => Effect.succeed(null)),
         Effect.map(Option.fromNullable)
       )
       const api = get(apiAtom)

--- a/apps/mobile/src/state/connections/atom/connectionStateAtom.ts
+++ b/apps/mobile/src/state/connections/atom/connectionStateAtom.ts
@@ -75,64 +75,79 @@ export const syncConnectionsActionAtom = atom(
       const secondLevel = yield* _(fetchContacts('SECOND', api.contact))
 
       // report difference
+      // Forked and time-limited (like the metrics report below) so a hanging
+      // push-token fetch can never stall the connections sync.
       const connectionState = get(connectionStateAtom)
 
-      if (
-        !!connectionState.lastUpdate &&
-        !!(yield* _(getNotificationTokenE()))
-      ) {
-        const newFirstLevelConnections = Array.difference(firstLevel)(
-          connectionState.firstLevel
-        )
-        const newSecondLevelConnections = Array.difference(secondLevel)(
-          connectionState.secondLevel
-        )
-        const newConnectionsUnique = pipe(
-          newFirstLevelConnections,
-          Array.appendAll(newSecondLevelConnections),
-          Array.dedupe
-        )
+      if (connectionState.lastUpdate) {
+        yield* _(
+          Effect.gen(function* (_) {
+            const notificationToken = yield* _(
+              getNotificationTokenE(),
+              Effect.timeout('3 seconds'),
+              Effect.option
+            )
+            if (
+              Option.isNone(notificationToken) ||
+              notificationToken.value === null
+            )
+              return
 
-        console.log('🦋 New connections:', newConnectionsUnique.length)
+            const newFirstLevelConnections = Array.difference(firstLevel)(
+              connectionState.firstLevel
+            )
+            const newSecondLevelConnections = Array.difference(secondLevel)(
+              connectionState.secondLevel
+            )
+            const newConnectionsUnique = pipe(
+              newFirstLevelConnections,
+              Array.appendAll(newSecondLevelConnections),
+              Array.dedupe
+            )
 
-        // only if notification tracking id has been passed
-        if (notificationTrackingId) {
-          const notificationsEnabled = yield* _(
-            areNotificationsEnabledE(),
-            Effect.option
-          )
+            console.log('🦋 New connections:', newConnectionsUnique.length)
 
-          yield* _(
-            api.metrics
-              .reportNotificationInteraction({
-                count: newConnectionsUnique.length,
-                notificationType: 'Network',
-                ...(Option.isSome(notificationsEnabled)
-                  ? {
-                      notificationsEnabled:
-                        notificationsEnabled.value.notifications,
-                      backgroundTaskEnabled:
-                        notificationsEnabled.value.backgroundTasks,
-                    }
-                  : {}),
-                type: 'NewConnectionsReceived',
-                uuid: generateUuid(),
-                trackingId: notificationTrackingId,
-              })
-              .pipe(
-                Effect.timeout(500),
-                Effect.retry({times: 3}),
-                Effect.tapError((e) =>
-                  reportErrorE(
-                    'warn',
-                    new Error('Error reporting new connections'),
-                    {e}
-                  )
-                ),
-                Effect.forkDaemon
+            // only if notification tracking id has been passed
+            if (notificationTrackingId) {
+              const notificationsEnabled = yield* _(
+                areNotificationsEnabledE(),
+                Effect.option
               )
-          )
-        }
+
+              yield* _(
+                api.metrics
+                  .reportNotificationInteraction({
+                    count: newConnectionsUnique.length,
+                    notificationType: 'Network',
+                    ...(Option.isSome(notificationsEnabled)
+                      ? {
+                          notificationsEnabled:
+                            notificationsEnabled.value.notifications,
+                          backgroundTaskEnabled:
+                            notificationsEnabled.value.backgroundTasks,
+                        }
+                      : {}),
+                    type: 'NewConnectionsReceived',
+                    uuid: generateUuid(),
+                    trackingId: notificationTrackingId,
+                  })
+                  .pipe(
+                    Effect.timeout(500),
+                    Effect.retry({times: 3}),
+                    Effect.tapError((e) =>
+                      reportErrorE(
+                        'warn',
+                        new Error('Error reporting new connections'),
+                        {e}
+                      )
+                    )
+                  )
+              )
+            }
+          }),
+          Effect.ignore,
+          Effect.forkDaemon
+        )
       }
 
       const serverToClientHashesToHashedPhoneNumbersMap = yield* _(

--- a/apps/mobile/src/state/connections/atom/offerToConnectionsAtom.ts
+++ b/apps/mobile/src/state/connections/atom/offerToConnectionsAtom.ts
@@ -517,7 +517,19 @@ export const updateAndReencryptAllOffersConnectionsActionAtom = atom(
           )
         }),
         Effect.all,
-        Effect.ensuring(Effect.sync(persistPendingConnectionUpdates)),
+        Effect.ensuring(
+          Effect.sync(() => {
+            persistPendingConnectionUpdates()
+            // The atom's own MMKV write is deferred behind InteractionManager
+            // and coalesced. By here the server has been mutated for every
+            // processed offer, so a kill before that deferred flush runs would
+            // drop the whole run's local connection records — leaving orphaned
+            // server private parts that the next diff-based sync never removes
+            // (current === target, so nothing is deleted). Force one synchronous
+            // durable write to bound that window to the sync loop itself.
+            offerToConnectionsAtom.flushNow()
+          })
+        ),
         Effect.tap((res) =>
           Effect.sync(() => {
             const timePretty = endUpdateOfferConnectionsMeasure()

--- a/apps/mobile/src/state/connections/atom/offerToConnectionsAtom.ts
+++ b/apps/mobile/src/state/connections/atom/offerToConnectionsAtom.ts
@@ -20,7 +20,6 @@ import {splitAtom} from 'jotai/utils'
 import {apiAtom} from '../../../api'
 import {atomWithParsedMmkvStorage} from '../../../utils/atomUtils/atomWithParsedMmkvStorage'
 import getValueFromSetStateActionOfAtom from '../../../utils/atomUtils/getValueFromSetStateActionOfAtom'
-import notEmpty from '../../../utils/notEmpty'
 import {showDebugNotificationIfEnabled} from '../../../utils/notifications/showDebugNotificationIfEnabled'
 import reportError from '../../../utils/reportError'
 import {startMeasure} from '../../../utils/reportTime'
@@ -152,12 +151,15 @@ export const upsertOfferToConnectionsActionAtom = atom<
 })
 
 export const deleteOrphanRecordsActionAtom = atom(null, (get, set) => {
-  const adminIds = get(offersStateAtom)
-    .offers.map((one) => one.ownershipInfo?.adminId)
-    .filter(notEmpty)
+  const adminIds = new Set(
+    pipe(
+      get(offersStateAtom).offers,
+      Array.filterMap((one) => Option.fromNullable(one.ownershipInfo?.adminId))
+    )
+  )
   set(offerToConnectionsAtom, (old) => ({
-    offerToConnections: old.offerToConnections.filter((one) =>
-      adminIds.includes(one.adminId)
+    offerToConnections: Array.filter(old.offerToConnections, (one) =>
+      adminIds.has(one.adminId)
     ),
   }))
 })
@@ -233,7 +235,21 @@ const processClubConnections = ({
   )
 }
 
-export const updateAndReencryptSingleOfferConnectionActionAtom = atom(
+interface UpdateSingleOfferConnectionParams {
+  adminId: OfferAdminId
+  intendedClubs?: readonly ClubUuid[]
+  intendedConnectionLevel?: IntendedConnectionLevel
+  stopProcessingAfter?: UnixMilliseconds
+  onProgress?: (status: OfferEncryptionProgress) => void
+}
+
+/**
+ * Uploads new/removed private parts for a single offer and returns an updater
+ * that applies the resulting connection changes to the locally stored
+ * `OfferToConnectionsItem`. Persisting the returned update is left to the
+ * caller so batch flows can coalesce all offers into a single storage write.
+ */
+const computeSingleOfferConnectionUpdateActionAtom = atom(
   null,
   (
     get,
@@ -244,13 +260,7 @@ export const updateAndReencryptSingleOfferConnectionActionAtom = atom(
       intendedConnectionLevel,
       stopProcessingAfter,
       onProgress,
-    }: {
-      adminId: OfferAdminId
-      intendedClubs?: readonly ClubUuid[]
-      intendedConnectionLevel?: IntendedConnectionLevel
-      stopProcessingAfter?: UnixMilliseconds
-      onProgress?: (status: OfferEncryptionProgress) => void
-    }
+    }: UpdateSingleOfferConnectionParams
   ) =>
     Effect.gen(function* (_) {
       const offerApi = get(apiAtom).offer
@@ -342,7 +352,7 @@ export const updateAndReencryptSingleOfferConnectionActionAtom = atom(
         )
       }
 
-      set(oneOfferConnectionsAtom, (val) => ({
+      return (val: OfferToConnectionsItem): OfferToConnectionsItem => ({
         ...val,
         connections: {
           firstLevel: subtractArrays(
@@ -365,8 +375,21 @@ export const updateAndReencryptSingleOfferConnectionActionAtom = atom(
             removedConnections,
           }),
         },
-      }))
+      })
     })
+)
+
+export const updateAndReencryptSingleOfferConnectionActionAtom = atom(
+  null,
+  (get, set, params: UpdateSingleOfferConnectionParams) =>
+    set(computeSingleOfferConnectionUpdateActionAtom, params).pipe(
+      Effect.map((applyConnectionsUpdate) => {
+        set(
+          createSingleOfferToConnectionsAtom(params.adminId),
+          applyConnectionsUpdate
+        )
+      })
+    )
 )
 
 export const updateAndReencryptAllOffersConnectionsActionAtom = atom(
@@ -415,11 +438,38 @@ export const updateAndReencryptAllOffersConnectionsActionAtom = atom(
 
       const offerToConnectionsAtoms = get(offerToConnectionsAtomsAtom)
 
+      // Per-offer results are accumulated in memory and persisted in chunks
+      // (each write re-encodes and re-writes the entire storage blob, so
+      // writing once per offer is prohibitively expensive, while a single
+      // end-of-run write would lose every already-uploaded offer's local
+      // record if the process is hard-killed mid-run). The final flush runs
+      // via `Effect.ensuring` so updates that succeeded are persisted even
+      // on partial failure or interruption.
+      const PERSIST_CONNECTION_UPDATES_CHUNK_SIZE = 10
+      const pendingConnectionUpdates = new Map<
+        OfferAdminId,
+        (val: OfferToConnectionsItem) => OfferToConnectionsItem
+      >()
+      const persistPendingConnectionUpdates = (): void => {
+        if (pendingConnectionUpdates.size === 0) return
+        set(offerToConnectionsAtom, (old) => ({
+          ...old,
+          offerToConnections: Array.map(old.offerToConnections, (one) => {
+            const applyConnectionsUpdate = pendingConnectionUpdates.get(
+              one.adminId
+            )
+            return applyConnectionsUpdate ? applyConnectionsUpdate(one) : one
+          }),
+        }))
+        // The updaters are not idempotent — never apply a flushed one again.
+        pendingConnectionUpdates.clear()
+      }
+
       return yield* _(
         offerToConnectionsAtoms,
         Array.map((oneOfferAtom, i) => {
           const adminId = get(oneOfferAtom).adminId
-          return set(updateAndReencryptSingleOfferConnectionActionAtom, {
+          return set(computeSingleOfferConnectionUpdateActionAtom, {
             adminId,
             onProgress: onProgres
               ? (progress) => {
@@ -432,7 +482,15 @@ export const updateAndReencryptAllOffersConnectionsActionAtom = atom(
               : undefined,
             stopProcessingAfter,
           }).pipe(
-            Effect.zipRight(Effect.succeed({adminId, success: true})),
+            Effect.map((applyConnectionsUpdate) => {
+              pendingConnectionUpdates.set(adminId, applyConnectionsUpdate)
+              if (
+                pendingConnectionUpdates.size >=
+                PERSIST_CONNECTION_UPDATES_CHUNK_SIZE
+              )
+                persistPendingConnectionUpdates()
+              return {adminId, success: true}
+            }),
             Effect.catchAll((e) =>
               Effect.sync(() => {
                 if (e._tag === 'SkippedBecauseTimeLimitReached') {
@@ -459,6 +517,7 @@ export const updateAndReencryptAllOffersConnectionsActionAtom = atom(
           )
         }),
         Effect.all,
+        Effect.ensuring(Effect.sync(persistPendingConnectionUpdates)),
         Effect.tap((res) =>
           Effect.sync(() => {
             const timePretty = endUpdateOfferConnectionsMeasure()

--- a/apps/mobile/src/state/contacts/atom/contactsStore.ts
+++ b/apps/mobile/src/state/contacts/atom/contactsStore.ts
@@ -75,17 +75,21 @@ export const resolveAllContactsAsSeenActionAtom = atom(
 
 export const normalizedContactsAtom = atom(
   (get): StoredContactWithComputedValues[] => {
+    // Set-keyed dedupe (keeps the first occurrence, same as dedupeWith)
+    // to avoid O(n²) pairwise comparisons on large contact lists.
+    const seenNormalizedNumbers = new Set<string>()
     return pipe(
       get(storedContactsAtom),
       Array.filterMap((contact) =>
         contact.computedValues.pipe(
+          Option.filter((computedValues) => {
+            if (seenNormalizedNumbers.has(computedValues.normalizedNumber))
+              return false
+            seenNormalizedNumbers.add(computedValues.normalizedNumber)
+            return true
+          }),
           Option.map((computedValues) => ({...contact, computedValues}))
         )
-      ),
-      Array.dedupeWith(
-        (first, second) =>
-          first.computedValues.normalizedNumber ===
-          second.computedValues.normalizedNumber
       )
     )
   }

--- a/apps/mobile/src/state/contacts/atom/createImportedContactsForHashesAtom.ts
+++ b/apps/mobile/src/state/contacts/atom/createImportedContactsForHashesAtom.ts
@@ -7,14 +7,19 @@ import {importedContactsAtom} from './contactsStore'
 export default function createImportedContactsForHashesAtom(
   hashes: readonly HashedPhoneNumber[]
 ): Atom<StoredContactWithComputedValues[]> {
-  return atom((get) =>
-    pipe(
+  const hashesSet = new Set(hashes)
+
+  return atom((get) => {
+    // Single pass keeping the first occurrence per hash (same as dedupeWith)
+    const includedHashes = new Set<HashedPhoneNumber>()
+    return pipe(
       get(importedContactsAtom),
-      Array.filter((contact) => hashes.includes(contact.computedValues.hash)),
-      Array.dedupeWith(
-        (first, second) =>
-          first.computedValues.hash === second.computedValues.hash
-      )
+      Array.filter((contact) => {
+        const hash = contact.computedValues.hash
+        if (!hashesSet.has(hash) || includedHashes.has(hash)) return false
+        includedHashes.add(hash)
+        return true
+      })
     )
-  )
+  })
 }

--- a/apps/mobile/src/state/contacts/atom/loadContactsFromDeviceActionAtom.ts
+++ b/apps/mobile/src/state/contacts/atom/loadContactsFromDeviceActionAtom.ts
@@ -1,25 +1,12 @@
-import {Array, Effect, HashMap, Option, pipe} from 'effect'
+import {Array, Effect, Option, pipe, Schema} from 'effect'
 import {atom} from 'jotai'
 import reportError from '../../../utils/reportError'
 import {effectWithEnsuredBenchmark} from '../../ActionBenchmarks'
-import {type ContactInfo, type StoredContact} from '../domain'
+import {ContactInfoE, type ContactInfo, type StoredContact} from '../domain'
 import {getContactsAndTryToResolveThePermissionsAlongTheWay} from '../utils'
 import {storedContactsAtom} from './contactsStore'
 
-function filterNotStoredContacts(
-  storedContacts: readonly StoredContact[]
-): (contactsFromDevice: ContactInfo[]) => ContactInfo[] {
-  const storedContactsRawNumbersSet = new Set(
-    storedContacts.map((c) => c.info.rawNumber)
-  )
-
-  return (contactsFromDevice: ContactInfo[]) => {
-    return contactsFromDevice.filter(
-      (contactFromDevice) =>
-        !storedContactsRawNumbersSet.has(contactFromDevice.rawNumber)
-    )
-  }
-}
+const contactInfoEquivalence = Schema.equivalence(ContactInfoE)
 
 export const loadingContactsFromDeviceAtom = atom<boolean>(false)
 
@@ -30,28 +17,36 @@ const loadContactsFromDeviceActionAtom = atom(null, (get, set) => {
     )
     const storedContacts = get(storedContactsAtom)
 
-    const contactsFromDeviceHashMap = HashMap.fromIterable(
+    const contactsFromDeviceByRawNumber = new Map<string, ContactInfo>(
       Array.map(contactsFromDevice, (c) => [c.rawNumber, c])
     )
 
-    const updatedStoredContacts = Array.map(
-      storedContacts,
-      (storedContact) =>
-        ({
-          ...storedContact,
-          info: pipe(
-            HashMap.get(
-              contactsFromDeviceHashMap,
-              storedContact.info.rawNumber
-            ),
-            Option.getOrElse(() => storedContact.info)
-          ),
-        }) satisfies StoredContact
-    )
+    // Preserve object identity for unchanged contacts so derived atoms
+    // and the persisted storage blob don't churn on every resume.
+    let someContactChanged = false
+    const updatedStoredContacts = Array.map(storedContacts, (storedContact) => {
+      const infoFromDevice = contactsFromDeviceByRawNumber.get(
+        storedContact.info.rawNumber
+      )
+      if (
+        infoFromDevice === undefined ||
+        contactInfoEquivalence(infoFromDevice, storedContact.info)
+      )
+        return storedContact
 
+      someContactChanged = true
+      return {...storedContact, info: infoFromDevice} satisfies StoredContact
+    })
+
+    const storedContactsRawNumbers = new Set(
+      Array.map(storedContacts, (c) => c.info.rawNumber)
+    )
     const newContactsToStore = pipe(
       contactsFromDevice,
-      filterNotStoredContacts(get(storedContactsAtom)),
+      Array.filter(
+        (contactFromDevice) =>
+          !storedContactsRawNumbers.has(contactFromDevice.rawNumber)
+      ),
       Array.map(
         (newContact) =>
           ({
@@ -68,7 +63,11 @@ const loadContactsFromDeviceActionAtom = atom(null, (get, set) => {
       )
     )
 
-    set(storedContactsAtom, [...updatedStoredContacts, ...newContactsToStore])
+    // Skip the write entirely when device contacts are unchanged to avoid
+    // a full-blob storage rewrite and derived-atom recomputation.
+    if (someContactChanged || Array.isNonEmptyArray(newContactsToStore)) {
+      set(storedContactsAtom, [...updatedStoredContacts, ...newContactsToStore])
+    }
     return 'success' as const
   }).pipe(
     Effect.catchAll((e) => {

--- a/apps/mobile/src/state/contacts/atom/normalizeStoredContactsActionAtom.ts
+++ b/apps/mobile/src/state/contacts/atom/normalizeStoredContactsActionAtom.ts
@@ -12,16 +12,6 @@ import {type ContactComputedValues, type StoredContact} from '../domain'
 import {hashPhoneNumber} from '../utils'
 import {storedContactsAtom} from './contactsStore'
 
-interface ContactsToNormalize {
-  readonly normalized: StoredContact[]
-  readonly toNormalize: StoredContact[]
-}
-
-const emptyContactsToNormalize: ContactsToNormalize = {
-  normalized: [],
-  toNormalize: [],
-}
-
 function markContactInvalid(contact: StoredContact): StoredContact {
   return {
     ...contact,
@@ -91,18 +81,12 @@ const normalizeStoredContactsActionAtom = atom(
     const measure = startMeasure('Normalizing contacts')
     const storedContacts = get(storedContactsAtom)
 
-    const {normalized, toNormalize} = pipe(
+    const [toNormalize, normalized] = pipe(
       storedContacts,
-      Array.reduce(emptyContactsToNormalize, (acc, c) => {
-        if (
-          Option.isSome(c.computedValues) ||
-          c.flags.invalidNumber === 'invalid'
-        ) {
-          return {...acc, normalized: [...acc.normalized, c]}
-        } else {
-          return {...acc, toNormalize: [...acc.toNormalize, c]}
-        }
-      })
+      Array.partition(
+        (c) =>
+          Option.isSome(c.computedValues) || c.flags.invalidNumber === 'invalid'
+      )
     )
 
     if (Array.isEmptyArray(toNormalize)) return Effect.void
@@ -111,7 +95,6 @@ const normalizeStoredContactsActionAtom = atom(
 
     return pipe(
       toNormalize,
-      Array.filter((c) => Option.isNone(c.computedValues)),
       Array.map(flow(normalizeContact, effectToTask)),
       sequenceTasksWithAnimationFrames(100, (percentage) => {
         onProgress({total: storedContacts.length, percentDone: percentage})

--- a/apps/mobile/src/state/marketplace/atoms/ensureMyOffersHaveOwnershipInfoUploadedInPrivatepayloadForOwner.ts
+++ b/apps/mobile/src/state/marketplace/atoms/ensureMyOffersHaveOwnershipInfoUploadedInPrivatepayloadForOwner.ts
@@ -1,37 +1,36 @@
-import updateOwnerPrivatePayload from '@vexl-next/resources-utils/src/offers/updateOwnerPrivatePayload'
 import {Array, Effect, pipe} from 'effect'
 import {atom} from 'jotai'
-import {apiAtom} from '../../../api'
 import {reportErrorE} from '../../../utils/reportError'
-import {sessionDataOrDummyAtom} from '../../session'
-import {myOffersAtom} from './myOffers'
+import {myOffersAtom, updateMyOfferPrivatePayloadActionAtom} from './myOffers'
 
 export const ensureMyOffersHaveOwnershipInfoUploadedInPrivatepayloadForOwner =
-  atom(null, (get, set) =>
-    pipe(
+  atom(null, (get, set) => {
+    const offersToUpdate = pipe(
       get(myOffersAtom),
       Array.filter(
         (one) =>
           !one.offerInfo.privatePart.adminId ||
           !one.offerInfo.privatePart.intendedConnectionLevel
-      ),
-      (offersToUpdate) => {
-        console.log(
-          `Updating offers to include owner info in owner's private payload. Count: ${offersToUpdate.length}`
-        )
-        return offersToUpdate
-      },
-      Array.map((one) =>
-        pipe(
-          updateOwnerPrivatePayload({
-            api: get(apiAtom).offer,
-            ownerCredentials: get(sessionDataOrDummyAtom).privateKey,
-            ownerKeyPairV2: get(sessionDataOrDummyAtom).keyPairV2,
-            symmetricKey: one.offerInfo.privatePart.symmetricKey,
-            adminId: one.ownershipInfo.adminId,
-            intendedConnectionLevel: one.ownershipInfo.intendedConnectionLevel,
-            intendedClubs: one.ownershipInfo.intendedClubs ?? [],
-          }),
+      )
+    )
+
+    if (!Array.isNonEmptyArray(offersToUpdate)) return Effect.void
+
+    console.log(
+      `Updating offers to include owner info in owner's private payload. Count: ${offersToUpdate.length}`
+    )
+
+    // updateMyOfferPrivatePayloadActionAtom re-encrypts + uploads the owner
+    // private payload AND persists the uploaded payload into local offer state,
+    // so this step converges instead of repeating on every refresh.
+    return Effect.forEach(
+      offersToUpdate,
+      (one) =>
+        set(updateMyOfferPrivatePayloadActionAtom, {
+          adminId: one.ownershipInfo.adminId,
+          intendedConnectionLevel: one.ownershipInfo.intendedConnectionLevel,
+          intendedClubs: [...(one.ownershipInfo.intendedClubs ?? [])],
+        }).pipe(
           Effect.tapError((e) =>
             reportErrorE(
               'warn',
@@ -40,8 +39,7 @@ export const ensureMyOffersHaveOwnershipInfoUploadedInPrivatepayloadForOwner =
             )
           ),
           Effect.ignore
-        )
-      ),
-      Effect.all
+        ),
+      {discard: true}
     )
-  )
+  })

--- a/apps/mobile/src/state/marketplace/atoms/filteredOffers.ts
+++ b/apps/mobile/src/state/marketplace/atoms/filteredOffers.ts
@@ -42,6 +42,7 @@ export const filteredOffersIgnoreLocationAtom = atom((get) => {
     text: textFilter,
     offers: filtered,
     importedContacts: get(importedContactsAtom),
+    importedContactsHashes: get(importedContactsHashesAtom),
   })
   const sort = filter.sort ?? 'NEWEST_OFFER'
 

--- a/apps/mobile/src/state/marketplace/atoms/offersState.ts
+++ b/apps/mobile/src/state/marketplace/atoms/offersState.ts
@@ -19,8 +19,10 @@ import {OffersState} from '../domain'
 import {isProductOfferMissingCategory} from '../utils/isProductOfferMissingCategory'
 import {offerWithoutSourceOrNone} from '../utils/offerWithoutSourceOrNone'
 
+export const OFFERS_STORAGE_KEY = 'offers'
+
 export const offersStateAtom = atomWithParsedMmkvStorage(
-  'offers',
+  OFFERS_STORAGE_KEY,
   {
     contactOffersNextPageParam: undefined,
     clubOffersNextPageParam: {},
@@ -31,6 +33,10 @@ export const offersStateAtom = atomWithParsedMmkvStorage(
 )
 export const offersAtom = focusAtom(offersStateAtom, (optic) =>
   optic.prop('offers')
+)
+
+export const areThereAnyStoredOffersAtom = atom((get) =>
+  Array.isNonEmptyReadonlyArray(get(offersAtom))
 )
 
 export const offersIdsAtom = focusAtom(offersAtom, (optic) =>

--- a/apps/mobile/src/state/marketplace/atoms/offersToSeeInMarketplace.ts
+++ b/apps/mobile/src/state/marketplace/atoms/offersToSeeInMarketplace.ts
@@ -50,27 +50,29 @@ export const offersToSeeInMarketplaceAtom = atom((get) => {
   const isDeveloper = get(isDeveloperAtom)
 
   const offers = get(offersAtom)
-  alertAndReportInPersonOffersWithoutLocation(
-    offers.map((one) => one.offerInfo)
-  )
 
   return pipe(
     offers,
     Array.filter((oneOffer) => {
+      // Cheap checks first, common-friends derivation only when still needed
+      if (
+        // only active offers
+        !oneOffer.offerInfo.publicPart.active ||
+        // only not expired offers
+        isOfferExpired(oneOffer.offerInfo.publicPart.expirationDate) ||
+        // Not mine offers
+        !!oneOffer.ownershipInfo ||
+        // Not reported offers
+        oneOffer.flags.reported
+      )
+        return false
+
       const visibleCommonFriends = deriveVisibleCommonFriendsForOffer({
         offerInfo: oneOffer.offerInfo,
         importedContactsHashes,
       })
 
       return (
-        // only active offers
-        oneOffer.offerInfo.publicPart.active &&
-        // only not expired offers
-        !isOfferExpired(oneOffer.offerInfo.publicPart.expirationDate) &&
-        // Not mine offers
-        !oneOffer.ownershipInfo &&
-        // Not reported offers
-        !oneOffer.flags.reported &&
         // Offers that has at least one visible common contact or are first degree
         (Array.isNonEmptyReadonlyArray(visibleCommonFriends.commonFriends) ||
           pipe(

--- a/apps/mobile/src/state/marketplace/atoms/refreshOffersActionAtom/index.ts
+++ b/apps/mobile/src/state/marketplace/atoms/refreshOffersActionAtom/index.ts
@@ -1,4 +1,5 @@
-import {isoNow} from '@vexl-next/domain/src/utility/IsoDatetimeString.brand'
+import {type ClubUuid} from '@vexl-next/domain/src/general/clubs'
+import {type OfferId} from '@vexl-next/domain/src/general/offers'
 import {Array, Effect, Record, pipe} from 'effect'
 import {atom} from 'jotai'
 import {AppState} from 'react-native'
@@ -13,10 +14,25 @@ import {ensureMyOffersHaveOwnershipInfoUploadedInPrivatepayloadForOwner} from '.
 import {loadingStateAtom} from '../loadingState'
 import {anyMarketplaceSuggestionDismissedInThisSessionAtom} from '../offerSuggestionVisible'
 import {offersAtom, offersStateAtom} from '../offersState'
+import {reportOffersWithoutLocationActionAtom} from '../offersToSeeInMarketplace'
 import {combineIncomingOffers} from './utils/combineIncomingOffers'
 import {fetchOffersReportErrorsActionAtom} from './utils/fetchOffersReportErrorsActionAtom'
 import {getRemovedOffersIds} from './utils/getRemovedOffersIds'
 import {mergeIncomingOffersToState} from './utils/mergeIncomingOffersToState'
+
+// Reconciling removed offers POSTs every stored offer id to the server, so it
+// is throttled instead of running on every refresh (refreshes can be as
+// frequent as every few seconds on an empty marketplace).
+const REMOVED_OFFERS_RECONCILIATION_INTERVAL_MS = 10 * 60 * 1000
+const lastRemovedOffersReconciliationAtAtom = atom(0)
+
+const NO_REMOVED_OFFERS: {
+  removedContactOfferIds: readonly OfferId[]
+  removedClubsOfferIdsToClubUuid: ReadonlyArray<{
+    clubUuid: ClubUuid
+    removedIds: readonly OfferId[]
+  }>
+} = {removedContactOfferIds: [], removedClubsOfferIdsToClubUuid: []}
 
 export const refreshOffersActionAtom = atom(null, (get, set) =>
   Effect.gen(function* (_) {
@@ -26,7 +42,6 @@ export const refreshOffersActionAtom = atom(null, (get, set) =>
 
     const endBenchmark = startBenchmark('Refresh offers')
 
-    const updateStartedAt = isoNow()
     const storedOffers = get(offersAtom)
 
     set(loadingStateAtom, {state: 'inProgress'})
@@ -42,14 +57,33 @@ export const refreshOffersActionAtom = atom(null, (get, set) =>
       })
     )
 
-    set(updateOffersIdsForClubStateActionAtom, {newOffers: newClubsOffers})
+    // With no new club offers the update is a no-op that would only rewrite
+    // the persisted clubs state, so skip it entirely.
+    if (Array.isNonEmptyReadonlyArray(newClubsOffers))
+      set(updateOffersIdsForClubStateActionAtom, {newOffers: newClubsOffers})
+
+    const shouldReconcileRemovedOffers =
+      Date.now() - get(lastRemovedOffersReconciliationAtAtom) >=
+      REMOVED_OFFERS_RECONCILIATION_INTERVAL_MS
 
     const {removedClubsOfferIdsToClubUuid, removedContactOfferIds} = yield* _(
-      getRemovedOffersIds({
-        offersApi: api.offer,
-        storedOffers,
-        storedClubs: myStoredClubs,
-      })
+      shouldReconcileRemovedOffers
+        ? getRemovedOffersIds({
+            offersApi: api.offer,
+            storedOffers,
+            storedClubs: myStoredClubs,
+          }).pipe(
+            Effect.tap((result) =>
+              Effect.sync(() => {
+                // Only throttle when the reconciliation actually succeeded, so a
+                // transient failure retries on the next refresh instead of
+                // leaving removed offers visible for the full interval.
+                if (result.succeeded)
+                  set(lastRemovedOffersReconciliationAtAtom, Date.now())
+              })
+            )
+          )
+        : Effect.succeed(NO_REMOVED_OFFERS)
     )
 
     const incomingOffers = pipe(
@@ -59,19 +93,24 @@ export const refreshOffersActionAtom = atom(null, (get, set) =>
       Array.filterMap(combineIncomingOffers)
     )
 
-    // Update with callback to ensure no offers from state are lost
-    set(offersStateAtom, (old) => ({
-      ...old,
-      offers: mergeIncomingOffersToState({
-        incomingOffers,
-        storedOffers: old.offers,
-        removedOffersIds: {
-          clubs: removedClubsOfferIdsToClubUuid,
-          contacts: removedContactOfferIds,
-        },
-      }),
-      lastUpdatedAt2: updateStartedAt,
-    }))
+    // Read fresh state right before merging to ensure no offers
+    // written while fetching are lost.
+    const offersBeforeMerge = get(offersAtom)
+    const mergedOffers = mergeIncomingOffersToState({
+      incomingOffers,
+      storedOffers: offersBeforeMerge,
+      removedOffersIds: {
+        clubs: removedClubsOfferIdsToClubUuid,
+        contacts: removedContactOfferIds,
+      },
+    })
+
+    // Skip the state write (and the full persisted-blob rewrite + derived-atom
+    // invalidation it causes) when the refresh changed nothing.
+    if (mergedOffers !== offersBeforeMerge) {
+      set(offersStateAtom, (old) => ({...old, offers: mergedOffers}))
+      set(reportOffersWithoutLocationActionAtom)
+    }
     set(anyMarketplaceSuggestionDismissedInThisSessionAtom, false)
 
     yield* _(

--- a/apps/mobile/src/state/marketplace/atoms/refreshOffersActionAtom/index.ts
+++ b/apps/mobile/src/state/marketplace/atoms/refreshOffersActionAtom/index.ts
@@ -34,107 +34,113 @@ const NO_REMOVED_OFFERS: {
   }>
 } = {removedContactOfferIds: [], removedClubsOfferIdsToClubUuid: []}
 
-export const refreshOffersActionAtom = atom(null, (get, set) =>
-  Effect.gen(function* (_) {
-    const api = get(apiAtom)
-    const session = get(sessionDataOrDummyAtom)
-    const myStoredClubs = get(clubsToKeyHolderAtom)
+export const refreshOffersActionAtom = atom(
+  null,
+  (get, set, options?: {readonly forceRemovedOffersReconciliation?: boolean}) =>
+    Effect.gen(function* (_) {
+      const api = get(apiAtom)
+      const session = get(sessionDataOrDummyAtom)
+      const myStoredClubs = get(clubsToKeyHolderAtom)
 
-    const endBenchmark = startBenchmark('Refresh offers')
+      const endBenchmark = startBenchmark('Refresh offers')
 
-    const storedOffers = get(offersAtom)
+      const storedOffers = get(offersAtom)
 
-    set(loadingStateAtom, {state: 'inProgress'})
+      set(loadingStateAtom, {state: 'inProgress'})
 
-    console.log('🦋 Refreshing offers')
+      console.log('🦋 Refreshing offers')
 
-    const {clubs: newClubsOffers, contact: newContactOffers} = yield* _(
-      set(fetchOffersReportErrorsActionAtom, {
-        offersApi: api.offer,
-        contactNetworkKeyPair: session.privateKey,
-        contactNetworkKeyPairV2: session.keyPairV2,
-        clubs: myStoredClubs,
-      })
-    )
+      const {clubs: newClubsOffers, contact: newContactOffers} = yield* _(
+        set(fetchOffersReportErrorsActionAtom, {
+          offersApi: api.offer,
+          contactNetworkKeyPair: session.privateKey,
+          contactNetworkKeyPairV2: session.keyPairV2,
+          clubs: myStoredClubs,
+        })
+      )
 
-    // With no new club offers the update is a no-op that would only rewrite
-    // the persisted clubs state, so skip it entirely.
-    if (Array.isNonEmptyReadonlyArray(newClubsOffers))
-      set(updateOffersIdsForClubStateActionAtom, {newOffers: newClubsOffers})
+      // With no new club offers the update is a no-op that would only rewrite
+      // the persisted clubs state, so skip it entirely.
+      if (Array.isNonEmptyReadonlyArray(newClubsOffers))
+        set(updateOffersIdsForClubStateActionAtom, {newOffers: newClubsOffers})
 
-    const shouldReconcileRemovedOffers =
-      Date.now() - get(lastRemovedOffersReconciliationAtAtom) >=
-      REMOVED_OFFERS_RECONCILIATION_INTERVAL_MS
+      // A user-initiated refresh (pull-to-refresh) bypasses the throttle so
+      // offers deleted/unshared on the server disappear immediately instead of
+      // lingering until the interval expires.
+      const shouldReconcileRemovedOffers =
+        options?.forceRemovedOffersReconciliation === true ||
+        Date.now() - get(lastRemovedOffersReconciliationAtAtom) >=
+          REMOVED_OFFERS_RECONCILIATION_INTERVAL_MS
 
-    const {removedClubsOfferIdsToClubUuid, removedContactOfferIds} = yield* _(
-      shouldReconcileRemovedOffers
-        ? getRemovedOffersIds({
-            offersApi: api.offer,
-            storedOffers,
-            storedClubs: myStoredClubs,
-          }).pipe(
-            Effect.tap((result) =>
-              Effect.sync(() => {
-                // Only throttle when the reconciliation actually succeeded, so a
-                // transient failure retries on the next refresh instead of
-                // leaving removed offers visible for the full interval.
-                if (result.succeeded)
-                  set(lastRemovedOffersReconciliationAtAtom, Date.now())
-              })
+      const {removedClubsOfferIdsToClubUuid, removedContactOfferIds} = yield* _(
+        shouldReconcileRemovedOffers
+          ? getRemovedOffersIds({
+              offersApi: api.offer,
+              storedOffers,
+              storedClubs: myStoredClubs,
+            }).pipe(
+              Effect.tap((result) =>
+                Effect.sync(() => {
+                  // Only throttle when the reconciliation actually succeeded, so a
+                  // transient failure retries on the next refresh instead of
+                  // leaving removed offers visible for the full interval.
+                  if (result.succeeded)
+                    set(lastRemovedOffersReconciliationAtAtom, Date.now())
+                })
+              )
             )
-          )
-        : Effect.succeed(NO_REMOVED_OFFERS)
-    )
+          : Effect.succeed(NO_REMOVED_OFFERS)
+      )
 
-    const incomingOffers = pipe(
-      [...newContactOffers, ...newClubsOffers],
-      Array.groupBy((one) => one.offerId),
-      Record.values,
-      Array.filterMap(combineIncomingOffers)
-    )
+      const incomingOffers = pipe(
+        [...newContactOffers, ...newClubsOffers],
+        Array.groupBy((one) => one.offerId),
+        Record.values,
+        Array.filterMap(combineIncomingOffers)
+      )
 
-    // Read fresh state right before merging to ensure no offers
-    // written while fetching are lost.
-    const offersBeforeMerge = get(offersAtom)
-    const mergedOffers = mergeIncomingOffersToState({
-      incomingOffers,
-      storedOffers: offersBeforeMerge,
-      removedOffersIds: {
-        clubs: removedClubsOfferIdsToClubUuid,
-        contacts: removedContactOfferIds,
-      },
-    })
-
-    // Skip the state write (and the full persisted-blob rewrite + derived-atom
-    // invalidation it causes) when the refresh changed nothing.
-    if (mergedOffers !== offersBeforeMerge) {
-      set(offersStateAtom, (old) => ({...old, offers: mergedOffers}))
-      set(reportOffersWithoutLocationActionAtom)
-    }
-    set(anyMarketplaceSuggestionDismissedInThisSessionAtom, false)
-
-    yield* _(
-      set(ensureMyOffersHaveOwnershipInfoUploadedInPrivatepayloadForOwner)
-    )
-
-    if (AppState.currentState === 'active') {
-      set(refreshLastSeenOffersActionAtom)
-    }
-
-    endBenchmark(
-      `Incoming offers: ${incomingOffers.length}. Removed offers: ${removedClubsOfferIdsToClubUuid.length + removedContactOfferIds.length}`
-    )
-  }).pipe(
-    Effect.catchAll((e) => {
-      reportError('error', new Error('Error fetching offers'), {e})
-      set(loadingStateAtom, {state: 'error', error: e})
-
-      return Effect.void
-    }),
-    Effect.zipLeft(
-      Effect.sync(() => {
-        set(loadingStateAtom, {state: 'success'})
+      // Read fresh state right before merging to ensure no offers
+      // written while fetching are lost.
+      const offersBeforeMerge = get(offersAtom)
+      const mergedOffers = mergeIncomingOffersToState({
+        incomingOffers,
+        storedOffers: offersBeforeMerge,
+        removedOffersIds: {
+          clubs: removedClubsOfferIdsToClubUuid,
+          contacts: removedContactOfferIds,
+        },
       })
+
+      // Skip the state write (and the full persisted-blob rewrite + derived-atom
+      // invalidation it causes) when the refresh changed nothing.
+      if (mergedOffers !== offersBeforeMerge) {
+        set(offersStateAtom, (old) => ({...old, offers: mergedOffers}))
+        set(reportOffersWithoutLocationActionAtom)
+      }
+      set(anyMarketplaceSuggestionDismissedInThisSessionAtom, false)
+
+      yield* _(
+        set(ensureMyOffersHaveOwnershipInfoUploadedInPrivatepayloadForOwner)
+      )
+
+      if (AppState.currentState === 'active') {
+        set(refreshLastSeenOffersActionAtom)
+      }
+
+      endBenchmark(
+        `Incoming offers: ${incomingOffers.length}. Removed offers: ${removedClubsOfferIdsToClubUuid.length + removedContactOfferIds.length}`
+      )
+    }).pipe(
+      Effect.catchAll((e) => {
+        reportError('error', new Error('Error fetching offers'), {e})
+        set(loadingStateAtom, {state: 'error', error: e})
+
+        return Effect.void
+      }),
+      Effect.zipLeft(
+        Effect.sync(() => {
+          set(loadingStateAtom, {state: 'success'})
+        })
+      )
     )
-  )
 )

--- a/apps/mobile/src/state/marketplace/atoms/refreshOffersActionAtom/utils/getRemovedOffersIds.ts
+++ b/apps/mobile/src/state/marketplace/atoms/refreshOffersActionAtom/utils/getRemovedOffersIds.ts
@@ -22,6 +22,9 @@ export const getRemovedOffersIds = ({
     clubUuid: ClubUuid
     removedIds: readonly OfferId[]
   }>
+  // False when any removed-offer check failed and was swallowed, so callers can
+  // avoid recording a failed reconciliation as successful.
+  succeeded: boolean
 }> => {
   const savedContactOffersIds = pipe(
     Array.filter(
@@ -55,41 +58,54 @@ export const getRemovedOffersIds = ({
     })
   )
 
-  return Effect.all({
-    removedContactOfferIds: pipe(
-      savedContactOffersIds.length > 0
-        ? offersApi
-            .getRemovedOffers({offerIds: savedContactOffersIds})
-            .pipe(Effect.map((one) => one.offerIds))
-        : Effect.succeed([] as readonly OfferId[]),
-      Effect.catchAll((e) => {
-        reportError('error', new Error('Error fetching removed offers'), {
-          e,
-        })
-
-        return Effect.succeed([] as readonly OfferId[])
+  // Each check is turned into an Option: None marks a swallowed failure so the
+  // overall `succeeded` flag can tell an empty-because-successful result apart
+  // from an empty-because-failed one.
+  const removedContactOffers = pipe(
+    Array.isNonEmptyArray(savedContactOffersIds)
+      ? offersApi
+          .getRemovedOffers({offerIds: savedContactOffersIds})
+          .pipe(Effect.map((one) => one.offerIds))
+      : Effect.succeed<readonly OfferId[]>([]),
+    Effect.tapError((e) =>
+      Effect.sync(() => {
+        reportError('error', new Error('Error fetching removed offers'), {e})
       })
     ),
+    Effect.option
+  )
 
-    removedClubsOfferIdsToClubUuid: pipe(
-      clubOffersIds,
-      Array.map(({clubKey, clubUuid, offersIds}) =>
-        offersApi
-          .getRemovedClubOffers({
-            offerIds: offersIds,
-            keyPair: clubKey.oldKeyPair,
-            keyPairV2: clubKey.keyPair,
-          })
-          .pipe(
-            Effect.map((removedIds) => ({
-              clubUuid,
-              removedIds: removedIds.offerIds,
-            })),
-            Effect.option
-          )
-      ),
-      Effect.all,
-      Effect.map(Array.getSomes)
+  const removedClubsOffers = pipe(
+    clubOffersIds,
+    Array.map(({clubKey, clubUuid, offersIds}) =>
+      offersApi
+        .getRemovedClubOffers({
+          offerIds: offersIds,
+          keyPair: clubKey.oldKeyPair,
+          keyPairV2: clubKey.keyPair,
+        })
+        .pipe(
+          Effect.map((removedIds) => ({
+            clubUuid,
+            removedIds: removedIds.offerIds,
+          })),
+          Effect.option
+        )
     ),
-  })
+    Effect.all
+  )
+
+  return Effect.all({
+    contact: removedContactOffers,
+    clubs: removedClubsOffers,
+  }).pipe(
+    Effect.map(({contact, clubs}) => ({
+      removedContactOfferIds: Option.getOrElse(
+        contact,
+        (): readonly OfferId[] => []
+      ),
+      removedClubsOfferIdsToClubUuid: Array.getSomes(clubs),
+      succeeded: Option.isSome(contact) && Array.every(clubs, Option.isSome),
+    }))
+  )
 }

--- a/apps/mobile/src/state/marketplace/atoms/refreshOffersActionAtom/utils/mergeIncomingOffersToState.ts
+++ b/apps/mobile/src/state/marketplace/atoms/refreshOffersActionAtom/utils/mergeIncomingOffersToState.ts
@@ -5,103 +5,134 @@ import {
   type OneOfferInState,
 } from '@vexl-next/domain/src/general/offers'
 import extractOwnerInfoFromOwnerPrivatePayload from '@vexl-next/resources-utils/src/offers/extractOwnerInfoFromOwnerPrivatePayload'
-import {Array, Option} from 'effect'
-import {pipe} from 'fp-ts/lib/function'
+import {Array, Option, pipe} from 'effect'
 import {offerWithoutSourceOrNone} from '../../../utils/offerWithoutSourceOrNone'
 
+// Process offers that have adminId in private part but do not have ownershipInfo.
+// Returns the same reference when there is nothing to extract, and None when
+// the private part has adminId but ownership info can not be extracted (data
+// written by older clients) — such offers are dropped from state so they do
+// not linger forever as ghost "foreign" offers.
+const addOwnershipInfoFromPrivatePayloadIfMissing = (
+  offer: OneOfferInState
+): Option.Option<OneOfferInState> => {
+  if (!offer.ownershipInfo && !!offer.offerInfo.privatePart.adminId) {
+    // TODO handle offerToConnections
+    return pipe(
+      extractOwnerInfoFromOwnerPrivatePayload(offer.offerInfo.privatePart),
+      Option.map((ownershipInfo) => ({...offer, ownershipInfo}))
+    )
+  }
+  return Option.some(offer)
+}
+
+/**
+ * Merges incoming offers into the stored offers in O(stored + incoming).
+ *
+ * When the refresh changes nothing, the SAME `storedOffers` array reference is
+ * returned (and unchanged offers keep their object identity), so callers can
+ * skip persisting and downstream derived atoms are not invalidated.
+ */
 export const mergeIncomingOffersToState = ({
   incomingOffers,
   storedOffers,
   removedOffersIds,
 }: {
   incomingOffers: readonly OfferInfo[]
-  storedOffers: readonly OneOfferInState[]
+  storedOffers: OneOfferInState[]
   removedOffersIds: {
     clubs: ReadonlyArray<{clubUuid: ClubUuid; removedIds: readonly OfferId[]}>
     contacts: readonly OfferId[]
   }
-}): OneOfferInState[] =>
-  pipe(
-    Array.union(
-      Array.map(incomingOffers, (one) => one.offerId),
-      Array.map(storedOffers, (one) => one.offerInfo.offerId)
-    ),
-    // Process new offers
-    Array.filterMap((offerId) => {
-      const newOfferO = Array.findFirst(
-        incomingOffers,
-        (o) => o.offerId === offerId
-      )
-      const offerInStateO = pipe(
-        storedOffers,
-        Array.findFirst((one) => one.offerInfo.offerId === offerId)
-      )
+}): OneOfferInState[] => {
+  const incomingOffersById = new Map(
+    Array.map(incomingOffers, (one): [OfferId, OfferInfo] => [one.offerId, one])
+  )
+  const storedOffersIds = new Set(
+    Array.map(storedOffers, (one) => one.offerInfo.offerId)
+  )
+  const removedContactsOfferIds = new Set(removedOffersIds.contacts)
+  const removedClubUuidsByOfferId = new Map<OfferId, ClubUuid[]>()
+  for (const {clubUuid, removedIds} of removedOffersIds.clubs) {
+    for (const offerId of removedIds) {
+      const clubsForOffer = removedClubUuidsByOfferId.get(offerId)
+      if (clubsForOffer !== undefined) clubsForOffer.push(clubUuid)
+      else removedClubUuidsByOfferId.set(offerId, [clubUuid])
+    }
+  }
 
-      if (
-        offerInStateO.pipe(
-          Option.flatMapNullable((o) => o?.ownershipInfo?.adminId),
-          Option.isSome
-        )
-      ) {
-        // Do not update offers that are owned by current user.
-        return offerInStateO
-      }
+  // Returns the same reference when the offer was not removed from any source
+  // and is already normalized.
+  const withoutRemovedSourcesOrNone = (
+    offer: OneOfferInState
+  ): Option.Option<OneOfferInState> => {
+    const removedFromClubs =
+      removedClubUuidsByOfferId.get(offer.offerInfo.offerId) ?? []
+    const removedFromContacts = removedContactsOfferIds.has(
+      offer.offerInfo.offerId
+    )
+    if (Array.isEmptyArray(removedFromClubs) && !removedFromContacts) {
+      // Nothing was removed, but keep normalizing degenerate offers (no
+      // friend level left, or CLUB friend level with no clubs) the same way
+      // the removal path does, so they do not survive in state forever.
+      const {clubIds, friendLevel} = offer.offerInfo.privatePart
+      const isNormalized =
+        Array.isNonEmptyReadonlyArray(friendLevel) &&
+        (!Array.contains(friendLevel, 'CLUB') ||
+          Array.isNonEmptyReadonlyArray(clubIds))
+      if (isNormalized) return Option.some(offer)
+    }
+    return offerWithoutSourceOrNone(
+      offer,
+      removedFromClubs,
+      removedFromContacts
+    )
+  }
 
-      if (Option.isSome(offerInStateO) && Option.isSome(newOfferO)) {
-        return Option.some({
-          ...offerInStateO.value,
-          offerInfo: newOfferO.value,
-        } satisfies OneOfferInState)
-      }
+  const mergedStoredOffers = Array.filterMap(storedOffers, (storedOffer) => {
+    // Do not update or remove offers that are owned by current user.
+    // They can be re-uploaded.
+    if (storedOffer.ownershipInfo?.adminId) return Option.some(storedOffer)
 
-      if (Option.isSome(newOfferO)) {
-        return Option.some({
-          offerInfo: newOfferO.value,
+    const incomingOffer = incomingOffersById.get(storedOffer.offerInfo.offerId)
+    const updatedOffer =
+      incomingOffer !== undefined
+        ? ({
+            ...storedOffer,
+            offerInfo: incomingOffer,
+          } satisfies OneOfferInState)
+        : storedOffer
+
+    return pipe(
+      withoutRemovedSourcesOrNone(updatedOffer),
+      Option.flatMap(addOwnershipInfoFromPrivatePayloadIfMissing)
+    )
+  })
+
+  const newOffers = pipe(
+    incomingOffers,
+    Array.filter((one) => !storedOffersIds.has(one.offerId)),
+    Array.filterMap((offerInfo) =>
+      pipe(
+        withoutRemovedSourcesOrNone({
+          offerInfo,
           flags: {
             reported: false,
           },
-        } satisfies OneOfferInState)
-      }
-
-      return offerInStateO
-    }),
-    // Process removed offers
-    Array.filterMap((one) => {
-      // Do NOT remove offers that are owned by current user.
-      // They can be re-uploaded
-      if (one.ownershipInfo?.adminId) return Option.some(one)
-
-      const removedFromClubs = pipe(
-        removedOffersIds.clubs,
-        Array.filter(({removedIds}) =>
-          Array.contains(removedIds, one.offerInfo.offerId)
-        ),
-        Array.map((one) => one.clubUuid)
+        } satisfies OneOfferInState),
+        Option.flatMap(addOwnershipInfoFromPrivatePayloadIfMissing)
       )
-      const removedFromContacts = Array.contains(
-        removedOffersIds.contacts,
-        one.offerInfo.offerId
-      )
-      return offerWithoutSourceOrNone(
-        one,
-        removedFromClubs,
-        removedFromContacts
-      )
-    }),
-    // Process offers that have adminId in private part but do not have ownershipInfo
-    Array.filterMap((oneOffer) => {
-      if (!oneOffer.ownershipInfo && !!oneOffer.offerInfo.privatePart.adminId) {
-        // TODO handle offerToConnections
-        return pipe(
-          extractOwnerInfoFromOwnerPrivatePayload(
-            oneOffer.offerInfo.privatePart
-          ),
-          Option.map((ownershipInfo) => ({
-            ...oneOffer,
-            ownershipInfo,
-          }))
-        )
-      }
-      return Option.some(oneOffer)
-    })
+    )
   )
+
+  // No-op refresh: keep the original array reference so nothing downstream
+  // invalidates and the persisted store is not rewritten.
+  if (
+    Array.isEmptyArray(newOffers) &&
+    mergedStoredOffers.length === storedOffers.length &&
+    Array.every(mergedStoredOffers, (one, i) => one === storedOffers[i])
+  )
+    return storedOffers
+
+  return [...mergedStoredOffers, ...newOffers]
+}

--- a/apps/mobile/src/state/marketplace/hooks/useVisibleCommonFriendsForOffer.ts
+++ b/apps/mobile/src/state/marketplace/hooks/useVisibleCommonFriendsForOffer.ts
@@ -1,6 +1,5 @@
 import {type OfferInfo} from '@vexl-next/domain/src/general/offers'
 import {useAtomValue} from 'jotai'
-import {useMemo} from 'react'
 import {importedContactsHashesAtom} from '../../contacts/atom/contactsStore'
 import {
   deriveVisibleCommonFriendsForOffer,
@@ -12,12 +11,10 @@ export function useVisibleCommonFriendsForOffer(
 ): VisibleCommonFriends {
   const importedContactsHashes = useAtomValue(importedContactsHashesAtom)
 
-  return useMemo(
-    () =>
-      deriveVisibleCommonFriendsForOffer({
-        offerInfo,
-        importedContactsHashes,
-      }),
-    [importedContactsHashes, offerInfo]
-  )
+  // deriveVisibleCommonFriendsForOffer is memoized per offer + contacts change
+  // and returns a stable reference, so no useMemo is needed here.
+  return deriveVisibleCommonFriendsForOffer({
+    offerInfo,
+    importedContactsHashes,
+  })
 }

--- a/apps/mobile/src/state/marketplace/utils/filterMarketplaceOffers.ts
+++ b/apps/mobile/src/state/marketplace/utils/filterMarketplaceOffers.ts
@@ -1,3 +1,4 @@
+import {type HashedPhoneNumber} from '@vexl-next/domain/src/general/HashedPhoneNumber.brand'
 import {
   type OfferLocation,
   type OfferType,
@@ -279,10 +280,12 @@ export function filterOffersByTextSearch({
   offers,
   text,
   importedContacts,
+  importedContactsHashes,
 }: {
   offers: OneOfferInState[]
   text: string | undefined
   importedContacts: StoredContactWithComputedValues[]
+  importedContactsHashes: readonly HashedPhoneNumber[]
 }): OneOfferInState[] {
   if (!text) return offers
 
@@ -290,6 +293,7 @@ export function filterOffersByTextSearch({
     text,
     offers,
     importedContacts,
+    importedContactsHashes,
   })
 }
 

--- a/apps/mobile/src/state/marketplace/utils/filterOffersByText.ts
+++ b/apps/mobile/src/state/marketplace/utils/filterOffersByText.ts
@@ -1,3 +1,4 @@
+import {type HashedPhoneNumber} from '@vexl-next/domain/src/general/HashedPhoneNumber.brand'
 import {type OneOfferInState} from '@vexl-next/domain/src/general/offers'
 import {Array, Option, pipe} from 'effect'
 
@@ -9,20 +10,18 @@ export default function filterOffersByText({
   text,
   offers,
   importedContacts,
+  importedContactsHashes,
 }: {
   text: string
   offers: OneOfferInState[]
   importedContacts: StoredContactWithComputedValues[]
+  importedContactsHashes: readonly HashedPhoneNumber[]
 }): OneOfferInState[] {
   // TODO - better search. This is just a placeholder
 
   const wordsToSearchFor = pipe(
     text.toUpperCase().trim().split(' '),
     Array.filter(Boolean)
-  )
-  const importedContactsHashes = pipe(
-    importedContacts,
-    Array.map((contact) => contact.computedValues.hash)
   )
   const contactsByHash = new Map<
     StoredContactWithComputedValues['computedValues']['hash'],

--- a/apps/mobile/src/state/marketplace/utils/visibleCommonFriends.ts
+++ b/apps/mobile/src/state/marketplace/utils/visibleCommonFriends.ts
@@ -1,10 +1,29 @@
 import {type HashedPhoneNumber} from '@vexl-next/domain/src/general/HashedPhoneNumber.brand'
 import {type OfferInfo} from '@vexl-next/domain/src/general/offers'
-import {Array} from 'effect'
+import {Array, pipe} from 'effect'
 
 export interface VisibleCommonFriends {
   readonly commonFriends: readonly HashedPhoneNumber[]
   readonly verifiedCommonFriends: readonly HashedPhoneNumber[]
+}
+
+// Builds the imported-contacts-hashes lookup Set once per hashes-array
+// identity (i.e. once per contacts change) instead of scanning the array with
+// Equal.equals for every friend of every offer.
+const hashesSetForArrayCache = new WeakMap<
+  readonly HashedPhoneNumber[],
+  ReadonlySet<HashedPhoneNumber>
+>()
+
+function toHashesSet(
+  hashes: readonly HashedPhoneNumber[]
+): ReadonlySet<HashedPhoneNumber> {
+  const cachedSet = hashesSetForArrayCache.get(hashes)
+  if (cachedSet !== undefined) return cachedSet
+
+  const hashesSet: ReadonlySet<HashedPhoneNumber> = new Set(hashes)
+  hashesSetForArrayCache.set(hashes, hashesSet)
+  return hashesSet
 }
 
 export function deriveVisibleCommonFriendsFromHashes({
@@ -16,19 +35,32 @@ export function deriveVisibleCommonFriendsFromHashes({
   readonly verifiedCommonFriends?: readonly HashedPhoneNumber[]
   readonly importedContactsHashes: readonly HashedPhoneNumber[]
 }): VisibleCommonFriends {
-  const visibleCommonFriends = Array.intersection(
-    Array.union(commonFriends, verifiedCommonFriends),
-    importedContactsHashes
-  )
+  const importedContactsHashesSet = toHashesSet(importedContactsHashes)
 
   return {
-    commonFriends: visibleCommonFriends,
-    verifiedCommonFriends: Array.intersection(
-      verifiedCommonFriends,
-      importedContactsHashes
+    commonFriends: pipe(
+      Array.appendAll(commonFriends, verifiedCommonFriends),
+      Array.filter((one) => importedContactsHashesSet.has(one)),
+      // dedupe while preserving first-occurrence order
+      (visibleHashes) => Array.fromIterable(new Set(visibleHashes))
+    ),
+    verifiedCommonFriends: Array.filter(verifiedCommonFriends, (one) =>
+      importedContactsHashesSet.has(one)
     ),
   }
 }
+
+// Visible common friends for an offer only change when the offer or the
+// imported contacts change, but they are read from multiple places (marketplace
+// filter, sorting, text search, offer cards). Memoize per offerInfo identity so
+// the work happens once per offer per input change.
+const visibleCommonFriendsForOfferCache = new WeakMap<
+  OfferInfo,
+  {
+    importedContactsHashesSet: ReadonlySet<HashedPhoneNumber>
+    visibleCommonFriends: VisibleCommonFriends
+  }
+>()
 
 export function deriveVisibleCommonFriendsForOffer({
   offerInfo,
@@ -37,11 +69,21 @@ export function deriveVisibleCommonFriendsForOffer({
   readonly offerInfo: OfferInfo
   readonly importedContactsHashes: readonly HashedPhoneNumber[]
 }): VisibleCommonFriends {
-  return deriveVisibleCommonFriendsFromHashes({
+  const importedContactsHashesSet = toHashesSet(importedContactsHashes)
+  const cached = visibleCommonFriendsForOfferCache.get(offerInfo)
+  if (cached?.importedContactsHashesSet === importedContactsHashesSet)
+    return cached.visibleCommonFriends
+
+  const visibleCommonFriends = deriveVisibleCommonFriendsFromHashes({
     commonFriends: offerInfo.privatePart.commonFriends,
     verifiedCommonFriends: offerInfo.privatePart.verifiedCommonFriends,
     importedContactsHashes,
   })
+  visibleCommonFriendsForOfferCache.set(offerInfo, {
+    importedContactsHashesSet,
+    visibleCommonFriends,
+  })
+  return visibleCommonFriends
 }
 
 export function deriveVisibleCommonFriendsForChat({

--- a/apps/mobile/src/utils/atomUtils/atomWithParsedMmkvStorage.test.ts
+++ b/apps/mobile/src/utils/atomUtils/atomWithParsedMmkvStorage.test.ts
@@ -5,6 +5,7 @@ import {storage} from '../mmkv/effectMmkv'
 import {
   CLEAR_STORAGE_KEY,
   atomWithParsedMmkvStorage,
+  invalidateScheduledMmkvWrites,
 } from './atomWithParsedMmkvStorage'
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
@@ -246,6 +247,132 @@ describe('atomWithParsedMmkvStorage', () => {
 
     storage._storage.set(CLEAR_STORAGE_KEY, Date.now().toString())
 
+    expect(store.get(testAtom)).toEqual(defaultValue)
+    unsub()
+  })
+
+  it('drops a write scheduled before a storage clear so it cannot resurrect cleared data', () => {
+    const key = 'test-clear-invalidates-pending-write'
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+    const unsub = store.sub(testAtom, () => {})
+
+    // a sensitive value is written but its deferred flush has not run yet
+    store.set(testAtom, {name: 'sensitive', count: 42})
+    expect(storage._storage.getString(key)).toBeUndefined()
+
+    // logout / wipe happens before the flush runs — mirrors the sequence in
+    // clearMmkvStorageAndEmptyAtoms: signal clear, invalidate pending writes,
+    // then wipe storage
+    storage._storage.set(CLEAR_STORAGE_KEY, Date.now().toString())
+    invalidateScheduledMmkvWrites()
+    storage._storage.clearAll()
+
+    // the deferred flush now runs — it must NOT write the old value back
+    flushInteractions()
+
+    expect(storage._storage.getString(key)).toBeUndefined()
+    expect(store.get(testAtom)).toEqual(defaultValue)
+    unsub()
+  })
+
+  it('still persists writes scheduled after a storage clear', () => {
+    const key = 'test-write-after-clear'
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+    const unsub = store.sub(testAtom, () => {})
+
+    storage._storage.set(CLEAR_STORAGE_KEY, Date.now().toString())
+    invalidateScheduledMmkvWrites()
+    storage._storage.clearAll()
+
+    // a write made after the clear must persist normally
+    store.set(testAtom, {name: 'after', count: 1})
+    flushInteractions()
+
+    expect(JSON.parse(storage._storage.getString(key) ?? '')).toEqual({
+      name: 'after',
+      count: 1,
+    })
+    unsub()
+  })
+
+  it('flushNow persists the pending value synchronously, before the deferred flush', () => {
+    const key = 'test-flush-now'
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+
+    const setSpy = jest.spyOn(storage._storage, 'set')
+
+    store.set(testAtom, {name: 'flushed', count: 3})
+    // not persisted yet — the deferred flush has not run
+    expect(storage._storage.getString(key)).toBeUndefined()
+
+    testAtom.flushNow()
+
+    // written immediately, without waiting for interactions
+    expect(JSON.parse(storage._storage.getString(key) ?? '')).toEqual({
+      name: 'flushed',
+      count: 3,
+    })
+    expect(setSpy).toHaveBeenCalledTimes(1)
+
+    // the already-scheduled deferred flush is now a no-op (nothing pending)
+    flushInteractions()
+    expect(setSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('flushNow is a no-op when there is nothing pending', () => {
+    const key = 'test-flush-now-nothing-pending'
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    createStore()
+
+    const setSpy = jest.spyOn(storage._storage, 'set')
+
+    testAtom.flushNow()
+
+    expect(setSpy).not.toHaveBeenCalled()
+    expect(storage._storage.getString(key)).toBeUndefined()
+  })
+
+  it('flushNow does not write a value that was invalidated by a storage clear', () => {
+    const key = 'test-flush-now-after-clear'
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+    const unsub = store.sub(testAtom, () => {})
+
+    // a sensitive value is written but its flush has not run yet
+    store.set(testAtom, {name: 'sensitive', count: 42})
+
+    // logout / wipe happens before the flush
+    storage._storage.set(CLEAR_STORAGE_KEY, Date.now().toString())
+    invalidateScheduledMmkvWrites()
+    storage._storage.clearAll()
+
+    // forcing a synchronous flush must NOT resurrect the cleared value
+    testAtom.flushNow()
+
+    expect(storage._storage.getString(key)).toBeUndefined()
     expect(store.get(testAtom)).toEqual(defaultValue)
     unsub()
   })

--- a/apps/mobile/src/utils/atomUtils/atomWithParsedMmkvStorage.test.ts
+++ b/apps/mobile/src/utils/atomUtils/atomWithParsedMmkvStorage.test.ts
@@ -1,0 +1,288 @@
+import {Schema} from 'effect'
+import {createStore} from 'jotai'
+import {InteractionManager} from 'react-native'
+import {storage} from '../mmkv/effectMmkv'
+import {
+  CLEAR_STORAGE_KEY,
+  atomWithParsedMmkvStorage,
+} from './atomWithParsedMmkvStorage'
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => undefined),
+    removeItem: jest.fn(async () => undefined),
+  },
+}))
+
+jest.mock('../reportError', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+const TestValueSchema = Schema.Struct({
+  name: Schema.String,
+  count: Schema.Number,
+})
+type TestValue = typeof TestValueSchema.Type
+
+const defaultValue: TestValue = {name: 'default', count: 0}
+
+let interactionQueue: Array<() => void> = []
+
+function flushInteractions(): void {
+  while (interactionQueue.length > 0) {
+    const callback = interactionQueue.shift()
+    if (callback) callback()
+  }
+}
+
+beforeEach(() => {
+  interactionQueue = []
+  jest
+    .spyOn(InteractionManager, 'runAfterInteractions')
+    .mockImplementation((task) => {
+      if (typeof task === 'function') {
+        interactionQueue.push(() => {
+          void task()
+        })
+      }
+      return Object.assign(Promise.resolve(), {
+        done: () => {},
+        cancel: () => {},
+      })
+    })
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('atomWithParsedMmkvStorage', () => {
+  it('initializes from the value stored in mmkv', () => {
+    const key = 'test-init-from-storage'
+    storage._storage.set(key, JSON.stringify({name: 'stored', count: 1}))
+
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+
+    expect(store.get(testAtom)).toEqual({name: 'stored', count: 1})
+  })
+
+  it('initializes with the default value when nothing is stored', () => {
+    const key = 'test-init-default'
+
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+
+    expect(store.get(testAtom)).toEqual(defaultValue)
+  })
+
+  it('initializes with the default value when the stored value does not parse', () => {
+    const key = 'test-init-parse-error'
+    storage._storage.set(key, 'not json at all')
+
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+
+    expect(store.get(testAtom)).toEqual(defaultValue)
+  })
+
+  it('still reads blobs written by the old format (embedded ___author_id)', () => {
+    const key = 'test-legacy-author-id'
+    storage._storage.set(
+      key,
+      JSON.stringify({name: 'legacy', count: 2, ___author_id: 'atom123'})
+    )
+
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+
+    expect(store.get(testAtom)).toEqual({name: 'legacy', count: 2})
+  })
+
+  it('persists writes after interactions and coalesces queued writes to the newest value', () => {
+    const key = 'test-coalesce-writes'
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+
+    const setSpy = jest.spyOn(storage._storage, 'set')
+
+    store.set(testAtom, {name: 'v1', count: 1})
+    store.set(testAtom, {name: 'v2', count: 2})
+    store.set(testAtom, {name: 'v3', count: 3})
+
+    // nothing persisted before the deferred flush ran
+    expect(storage._storage.getString(key)).toBeUndefined()
+    expect(store.get(testAtom)).toEqual({name: 'v3', count: 3})
+
+    flushInteractions()
+
+    // last-write-wins: only the newest value was written, exactly once
+    expect(setSpy).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(storage._storage.getString(key) ?? '')).toEqual({
+      name: 'v3',
+      count: 3,
+    })
+  })
+
+  it('does not write the ___author_id field anymore', () => {
+    const key = 'test-no-author-id'
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+
+    store.set(testAtom, {name: 'clean', count: 1})
+    flushInteractions()
+
+    expect(JSON.parse(storage._storage.getString(key) ?? '')).toEqual({
+      name: 'clean',
+      count: 1,
+    })
+  })
+
+  it('does not feed its own write back through the change listener', () => {
+    const key = 'test-own-write-ignored'
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+    const unsub = store.sub(testAtom, () => {})
+
+    const written: TestValue = {name: 'own', count: 5}
+    store.set(testAtom, written)
+    flushInteractions()
+
+    // identity preserved — the listener did not re-decode & set the value
+    expect(store.get(testAtom)).toBe(written)
+    unsub()
+  })
+
+  it('picks up foreign writes from another atom for the same key', () => {
+    const key = 'test-foreign-atom-write'
+    const atomA = atomWithParsedMmkvStorage(key, defaultValue, TestValueSchema)
+    const atomB = atomWithParsedMmkvStorage(key, defaultValue, TestValueSchema)
+    const store = createStore()
+    const unsub = store.sub(atomA, () => {})
+
+    store.set(atomB, {name: 'fromB', count: 7})
+    flushInteractions()
+
+    expect(store.get(atomA)).toEqual({name: 'fromB', count: 7})
+    unsub()
+  })
+
+  it('picks up direct storage writes while mounted', () => {
+    const key = 'test-direct-storage-write'
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+    const unsub = store.sub(testAtom, () => {})
+
+    storage._storage.set(key, JSON.stringify({name: 'direct', count: 9}))
+    flushInteractions()
+
+    expect(store.get(testAtom)).toEqual({name: 'direct', count: 9})
+    unsub()
+  })
+
+  it('resets to the default value when the key is deleted', () => {
+    const key = 'test-delete-key'
+    storage._storage.set(key, JSON.stringify({name: 'stored', count: 1}))
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+    const unsub = store.sub(testAtom, () => {})
+
+    storage._storage.delete(key)
+    flushInteractions()
+
+    expect(store.get(testAtom)).toEqual(defaultValue)
+    unsub()
+  })
+
+  it('resets to the default value when the clear-storage key is written', () => {
+    const key = 'test-clear-storage'
+    storage._storage.set(key, JSON.stringify({name: 'stored', count: 1}))
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+    const unsub = store.sub(testAtom, () => {})
+
+    storage._storage.set(CLEAR_STORAGE_KEY, Date.now().toString())
+
+    expect(store.get(testAtom)).toEqual(defaultValue)
+    unsub()
+  })
+
+  it('does not re-decode on mount when the stored value has not changed', () => {
+    const key = 'test-mount-no-redecode'
+    storage._storage.set(key, JSON.stringify({name: 'stored', count: 1}))
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    const store = createStore()
+
+    const initialValue = store.get(testAtom)
+    const unsub = store.sub(testAtom, () => {})
+
+    // identity preserved — mount skipped the redundant decode + setAtom
+    expect(store.get(testAtom)).toBe(initialValue)
+    unsub()
+  })
+
+  it('re-reads on mount when the stored value changed before mounting', () => {
+    const key = 'test-mount-redecode'
+    storage._storage.set(key, JSON.stringify({name: 'stored', count: 1}))
+    const testAtom = atomWithParsedMmkvStorage(
+      key,
+      defaultValue,
+      TestValueSchema
+    )
+    // no listener yet — atom was created but never mounted
+    storage._storage.set(key, JSON.stringify({name: 'changed', count: 2}))
+
+    const store = createStore()
+    const unsub = store.sub(testAtom, () => {})
+
+    expect(store.get(testAtom)).toEqual({name: 'changed', count: 2})
+    unsub()
+  })
+})

--- a/apps/mobile/src/utils/atomUtils/atomWithParsedMmkvStorage.ts
+++ b/apps/mobile/src/utils/atomUtils/atomWithParsedMmkvStorage.ts
@@ -7,6 +7,24 @@ import getValueFromSetStateActionOfAtom from './getValueFromSetStateActionOfAtom
 
 export const CLEAR_STORAGE_KEY = '__clear_storage'
 
+// Incremented every time persisted storage is wiped (logout / clear). Writes
+// scheduled behind the deferred flush capture the generation at schedule time;
+// if it no longer matches when the flush finally runs, a wipe happened in
+// between and the write is dropped so just-cleared (sensitive) data cannot be
+// resurrected. Shared across all atoms, so it also invalidates pending writes
+// of atoms that are not currently mounted (their change listener never fires).
+let clearGeneration = 0
+
+/**
+ * Invalidates every MMKV write currently scheduled behind the deferred
+ * InteractionManager flush. MUST be called before wiping storage on logout so
+ * an in-flight write cannot persist — and thereby resurrect — data after the
+ * wipe. See `clearMmkvStorageAndEmptyAtoms`.
+ */
+export function invalidateScheduledMmkvWrites(): void {
+  clearGeneration += 1
+}
+
 // TODO: Temporary diagnostic to track atom initialization results on startup.
 // Remove once the root cause of user data loss is identified.
 type InitResult = 'loaded' | 'valueNotSet' | 'parseError'
@@ -53,6 +71,26 @@ interface StoredRead<A> {
    * stored value changed between atom creation and mount without re-decoding.
    */
   raw: string | undefined
+}
+
+/**
+ * A persisted MMKV atom that additionally exposes {@link
+ * FlushablePrimitiveAtom.flushNow}. Assignable to `PrimitiveAtom<A>`, so
+ * callers that do not need the flush handle can treat it as an ordinary atom.
+ */
+export interface FlushablePrimitiveAtom<A> extends PrimitiveAtom<A> {
+  /**
+   * Synchronously persists the value currently waiting behind the deferred,
+   * coalesced InteractionManager flush, then clears it. No-op when nothing is
+   * pending. Honors the clear-generation guard: a write queued before a storage
+   * wipe is dropped rather than resurrecting just-cleared data (see
+   * `invalidateScheduledMmkvWrites`).
+   *
+   * Use after a batch of writes whose durability must not wait for the deferred
+   * flush — e.g. local state the server was just mutated to match, where a
+   * process kill before the flush would otherwise leave storage stale.
+   */
+  flushNow: () => void
 }
 
 function isValidJson(raw: string): boolean {
@@ -137,7 +175,8 @@ function getInitialValue<A>({
  * - Writes are deferred behind `InteractionManager.runAfterInteractions` and
  *   coalesced: when several writes happen before the deferred flush runs, only
  *   the newest value is encoded and persisted (last-write-wins; intermediate
- *   values are never written to storage).
+ *   values are never written to storage). Callers that need the pending value
+ *   on disk immediately can force a synchronous write via `flushNow`.
  * - Writes to the same key made by anyone else (another atom for the same key,
  *   direct storage writes) are picked up via the MMKV change listener while
  *   the atom is mounted.
@@ -154,7 +193,7 @@ export function atomWithParsedMmkvStorage<A, I extends object>(
   defaultValue: A,
   schema: Schema.Schema<A, I, never>,
   debugLabel?: string
-): PrimitiveAtom<A> {
+): FlushablePrimitiveAtom<A> {
   const decodeRawValue = Schema.decodeEither(Schema.parseJson(schema))
   const persistValue = storage.saveVerified(key, schema)
 
@@ -166,14 +205,19 @@ export function atomWithParsedMmkvStorage<A, I extends object>(
   // blob.
   let isPersistingOwnValue = false
 
-  // Value waiting to be persisted by the scheduled deferred flush.
-  // `undefined` means no flush is scheduled.
-  let pendingWrite: {value: A} | undefined
+  // Value waiting to be persisted by the scheduled deferred flush, together
+  // with the `clearGeneration` captured when it was queued. `undefined` means
+  // no flush is scheduled.
+  let pendingWrite: {value: A; generation: number} | undefined
 
   const flushPendingWrite = (): void => {
     const toPersist = pendingWrite
     pendingWrite = undefined
     if (toPersist === undefined) return
+
+    // Storage was wiped after this write was scheduled — persisting it now
+    // would resurrect just-cleared data. Drop it. See `clearGeneration`.
+    if (toPersist.generation !== clearGeneration) return
 
     isPersistingOwnValue = true
     try {
@@ -212,7 +256,7 @@ export function atomWithParsedMmkvStorage<A, I extends object>(
       set(coreAtom, newValue)
 
       const flushAlreadyScheduled = pendingWrite !== undefined
-      pendingWrite = {value: newValue}
+      pendingWrite = {value: newValue, generation: clearGeneration}
       if (!flushAlreadyScheduled) {
         void InteractionManager.runAfterInteractions(flushPendingWrite)
       }
@@ -286,5 +330,8 @@ export function atomWithParsedMmkvStorage<A, I extends object>(
     return listener.remove
   }
 
-  return mmkvAtom
+  // `flushPendingWrite` already reads-and-clears the pending write, no-ops when
+  // nothing is queued, and drops the write when the clear-generation moved on —
+  // exactly the semantics `flushNow` needs — so expose it directly.
+  return Object.assign(mmkvAtom, {flushNow: flushPendingWrite})
 }

--- a/apps/mobile/src/utils/atomUtils/atomWithParsedMmkvStorage.ts
+++ b/apps/mobile/src/utils/atomUtils/atomWithParsedMmkvStorage.ts
@@ -1,12 +1,10 @@
 import {Array, Either, Schema, pipe, type ParseResult} from 'effect'
-import {atom, type PrimitiveAtom} from 'jotai'
+import {atom, type PrimitiveAtom, type SetStateAction} from 'jotai'
 import {InteractionManager} from 'react-native'
-import {type WritingToStoreError} from '../mmkv/domain'
 import {storage} from '../mmkv/effectMmkv'
 import reportError from '../reportError'
 import getValueFromSetStateActionOfAtom from './getValueFromSetStateActionOfAtom'
 
-const AUTHOR_ID_KEY = '___author_id' as const
 export const CLEAR_STORAGE_KEY = '__clear_storage'
 
 // TODO: Temporary diagnostic to track atom initialization results on startup.
@@ -32,10 +30,10 @@ function scheduleStartupReport(): void {
       const parseErrorKeys = keysWithResult('parseError')
       const loadedKeys = keysWithResult('loaded')
 
-      if (
-        Array.isNonEmptyArray(parseErrorKeys) ||
-        Array.isNonEmptyArray(valueNotSetKeys)
-      ) {
+      // Only report parse errors. Keys that were simply never written
+      // (`valueNotSet`) are expected on every startup, so reporting them
+      // unconditionally would fire the summary on every single app start.
+      if (Array.isNonEmptyArray(parseErrorKeys)) {
         reportError('warn', new Error('MMKV atom initialization summary'), {
           loaded: loadedKeys,
           valueNotSet: valueNotSetKeys,
@@ -47,133 +45,179 @@ function scheduleStartupReport(): void {
   }, 5000)
 }
 
-const AuthorKeySchema = Schema.Struct({
-  [AUTHOR_ID_KEY]: Schema.String,
-})
-
-const saveWithAuthorKey = <A, I extends object>({
-  schema,
-  authorKey,
-  value,
-  key,
-}: {
-  schema: Schema.Schema<A, I, never>
-  authorKey: string
+interface StoredRead<A> {
   value: A
-  key: string
-}): Either.Either<void, WritingToStoreError | ParseResult.ParseError> => {
-  const schemaWithAuthorKey = Schema.extend(AuthorKeySchema)(schema)
+  /**
+   * The raw string the value was decoded from. `undefined` when the key was
+   * not set or could not be read at all. Used to cheaply detect whether the
+   * stored value changed between atom creation and mount without re-decoding.
+   */
+  raw: string | undefined
+}
 
-  const valueToSave: typeof schemaWithAuthorKey.Type = {
-    ...value,
-    [AUTHOR_ID_KEY]: authorKey,
+function isValidJson(raw: string): boolean {
+  try {
+    JSON.parse(raw)
+    return true
+  } catch {
+    return false
   }
-
-  return storage.saveVerified(key, schemaWithAuthorKey)(valueToSave)
 }
 
-function toShadowStorageAtom<A, I extends object>(
-  key: string,
-  schema: Schema.Schema<A, I, never>
-): (baseAtom: PrimitiveAtom<A>) => PrimitiveAtom<A> {
-  return (baseAtom) =>
-    atom(
-      (get) => get(baseAtom),
-      (get, set, update): void => {
-        const newValue = getValueFromSetStateActionOfAtom(update)(() =>
-          get(baseAtom)
-        )
-        set(baseAtom, newValue)
-
-        void InteractionManager.runAfterInteractions(() => {
-          pipe(
-            saveWithAuthorKey({
-              schema,
-              authorKey: baseAtom.toString(),
-              value: newValue,
-              key,
-            }),
-            Either.getOrElse((l) => {
-              reportError(
-                'warn',
-                new Error(`Error while saving value to storage. Key: ${key}`),
-                {errorTag: l._tag}
-              )
-            })
-          )
-        })
-      }
-    )
+function readRawString(key: string): string | undefined {
+  try {
+    return storage._storage.getString(key) ?? undefined
+  } catch {
+    return undefined
+  }
 }
 
-function getInitialValue<A, I extends object>({
+function getInitialValue<A>({
   key,
-  schema,
+  decodeRawValue,
   defaultValue,
 }: {
-  schema: Schema.Schema<A, I, never>
   key: string
+  decodeRawValue: (raw: string) => Either.Either<A, ParseResult.ParseError>
   defaultValue: A
-}): A {
+}): StoredRead<A> {
   scheduleStartupReport()
 
   return pipe(
-    storage.getVerified(key, schema),
+    storage.get(key),
     Either.match({
-      onRight: (value) => {
-        atomInitResults.set(key, 'loaded')
-        return value
-      },
-      onLeft: (l) => {
+      onLeft: (l): StoredRead<A> => {
         if (l._tag === 'ValueNotSet') {
           atomInitResults.set(key, 'valueNotSet')
         } else {
           atomInitResults.set(key, 'parseError')
-          try {
-            const rawValue = storage._storage.getString(key)
-            reportError(
-              'warn',
-              new Error(
-                `Error while parsing stored value. Using provided default. Key: ${key}`
-              ),
-              {
-                errorTag: l._tag,
-                rawValueLength: rawValue?.length ?? 0,
-                rawValueIsValidJson: (() => {
-                  if (!rawValue) return false
-                  try {
-                    JSON.parse(rawValue)
-                    return true
-                  } catch {
-                    return false
-                  }
-                })(),
-              }
-            )
-          } catch {
-            reportError(
-              'warn',
-              new Error(
-                `Error while parsing stored value. Using provided default. Key: ${key}`
-              ),
-              {errorTag: l._tag}
-            )
-          }
+          reportError(
+            'warn',
+            new Error(
+              `Error while parsing stored value. Using provided default. Key: ${key}`
+            ),
+            {errorTag: l._tag}
+          )
         }
-        return defaultValue
+        return {value: defaultValue, raw: undefined}
       },
+      onRight: (raw): StoredRead<A> =>
+        pipe(
+          decodeRawValue(raw),
+          Either.match({
+            onLeft: (e): StoredRead<A> => {
+              atomInitResults.set(key, 'parseError')
+              reportError(
+                'warn',
+                new Error(
+                  `Error while parsing stored value. Using provided default. Key: ${key}`
+                ),
+                {
+                  errorTag: e._tag,
+                  rawValueLength: raw.length,
+                  rawValueIsValidJson: isValidJson(raw),
+                }
+              )
+              return {value: defaultValue, raw}
+            },
+            onRight: (value): StoredRead<A> => {
+              atomInitResults.set(key, 'loaded')
+              return {value, raw}
+            },
+          })
+        ),
     })
   )
 }
 
+/**
+ * Creates a primitive atom persisted in MMKV under the given key.
+ *
+ * - The stored value is validated with the given schema on every read.
+ * - Writes are deferred behind `InteractionManager.runAfterInteractions` and
+ *   coalesced: when several writes happen before the deferred flush runs, only
+ *   the newest value is encoded and persisted (last-write-wins; intermediate
+ *   values are never written to storage).
+ * - Writes to the same key made by anyone else (another atom for the same key,
+ *   direct storage writes) are picked up via the MMKV change listener while
+ *   the atom is mounted.
+ *
+ * Note on backward compatibility: older app versions embedded an
+ * `___author_id` field into the persisted blob to tell own writes apart from
+ * foreign ones. Own writes are now detected with an in-memory flag (see
+ * `isPersistingOwnValue` below), so the field is no longer written. Blobs that
+ * still contain it decode fine — effect Schema structs ignore excess
+ * properties by default.
+ */
 export function atomWithParsedMmkvStorage<A, I extends object>(
   key: string,
   defaultValue: A,
   schema: Schema.Schema<A, I, never>,
   debugLabel?: string
 ): PrimitiveAtom<A> {
-  const coreAtom = atom(getInitialValue({key, schema, defaultValue}))
-  const mmkvAtom = pipe(coreAtom, toShadowStorageAtom(key, schema))
+  const decodeRawValue = Schema.decodeEither(Schema.parseJson(schema))
+  const persistValue = storage.saveVerified(key, schema)
+
+  // True only for the synchronous duration of this atom's own storage.set
+  // call. react-native-mmkv dispatches change listeners synchronously from
+  // `set()` (see MMKV.set -> onValuesChanged in the library's JS wrapper), so
+  // the mount listener below can use this flag to tell this atom's own writes
+  // apart from foreign ones in O(1), without reading & parsing the stored
+  // blob.
+  let isPersistingOwnValue = false
+
+  // Value waiting to be persisted by the scheduled deferred flush.
+  // `undefined` means no flush is scheduled.
+  let pendingWrite: {value: A} | undefined
+
+  const flushPendingWrite = (): void => {
+    const toPersist = pendingWrite
+    pendingWrite = undefined
+    if (toPersist === undefined) return
+
+    isPersistingOwnValue = true
+    try {
+      pipe(
+        persistValue(toPersist.value),
+        Either.getOrElse((l) => {
+          reportError(
+            'warn',
+            new Error(`Error while saving value to storage. Key: ${key}`),
+            {errorTag: l._tag}
+          )
+        })
+      )
+    } finally {
+      isPersistingOwnValue = false
+    }
+  }
+
+  // Cached module-eval read. Consumed (and freed, so the potentially large
+  // raw string can be GCed) on first mount to avoid decoding the same blob
+  // twice on startup.
+  let initialRead: StoredRead<A> | undefined = getInitialValue({
+    key,
+    decodeRawValue,
+    defaultValue,
+  })
+
+  const coreAtom = atom(initialRead.value)
+
+  const mmkvAtom: PrimitiveAtom<A> = atom(
+    (get) => get(coreAtom),
+    (get, set, update: SetStateAction<A>): void => {
+      const newValue = getValueFromSetStateActionOfAtom(update)(() =>
+        get(coreAtom)
+      )
+      set(coreAtom, newValue)
+
+      const flushAlreadyScheduled = pendingWrite !== undefined
+      pendingWrite = {value: newValue}
+      if (!flushAlreadyScheduled) {
+        void InteractionManager.runAfterInteractions(flushPendingWrite)
+      }
+    }
+  )
 
   mmkvAtom.debugLabel = `${
     debugLabel ?? ''
@@ -183,12 +227,20 @@ export function atomWithParsedMmkvStorage<A, I extends object>(
   }MMKV core atom for key ${key} ${coreAtom.toString()}`
 
   coreAtom.onMount = (setAtom) => {
-    // Important to get the value from storage again.
-    // If the value has changed from when the atom was created,
-    // atom won't be updated, because it was not mounted yet and thus
-    // not listening for changes
-    setAtom(getInitialValue({key, schema, defaultValue}))
-    const decodeValue = Schema.decodeUnknownEither(schema)
+    // The value in storage might have changed between atom creation and mount
+    // (the atom was not listening for changes yet). Re-decode only when the
+    // raw stored string actually differs from the one already decoded at
+    // creation time — on a normal startup it is identical and the second
+    // decode is skipped entirely.
+    const cachedInitialRead = initialRead
+    initialRead = undefined
+
+    if (
+      cachedInitialRead === undefined ||
+      readRawString(key) !== cachedInitialRead.raw
+    ) {
+      setAtom(getInitialValue({key, decodeRawValue, defaultValue}).value)
+    }
 
     const listener = storage._storage.addOnValueChangedListener(
       (changedKey) => {
@@ -200,23 +252,15 @@ export function atomWithParsedMmkvStorage<A, I extends object>(
 
         if (changedKey !== key) return
 
+        // Own write — the atom already holds this value. Must be checked
+        // synchronously (the listener runs inside our storage.set call).
+        if (isPersistingOwnValue) return
+
         void InteractionManager.runAfterInteractions(() => {
           pipe(
-            storage.getVerified(key, AuthorKeySchema),
-            Either.filterOrLeft(
-              (value) => value[AUTHOR_ID_KEY] !== coreAtom.toString(),
-              () =>
-                ({
-                  _tag: 'authoredByThisAtom',
-                }) as const
-            ),
-            Either.flatMap(() => storage.getVerified(key, schema)),
-            Either.flatMap(decodeValue),
+            storage.getVerified(key, schema),
             Either.match({
               onLeft: (e) => {
-                if (e._tag === 'authoredByThisAtom') {
-                  return
-                }
                 if (e._tag === 'ValueNotSet') {
                   console.info(
                     `MMKV value for key '${key}' was deleted. Setting atom to default value`

--- a/apps/mobile/src/utils/clearMmkvStorageAndEmptyAtoms.ts
+++ b/apps/mobile/src/utils/clearMmkvStorageAndEmptyAtoms.ts
@@ -1,7 +1,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import {CLEAR_STORAGE_KEY} from './atomUtils/atomWithParsedMmkvStorage'
 // TODO: ASYNC_SENTINEL_KEY import is part of temporary MMKV data loss diagnostic. Remove together with the sentinel.
-import {ASYNC_SENTINEL_KEY, storage} from './mmkv/effectMmkv'
+import {ASYNC_SENTINEL_KEY} from './mmkv/detectMmkvDataLoss'
+import {storage} from './mmkv/effectMmkv'
 
 export default function clearMmkvStorageAndEmptyAtoms(): void {
   // set all atoms to defaultValue

--- a/apps/mobile/src/utils/clearMmkvStorageAndEmptyAtoms.ts
+++ b/apps/mobile/src/utils/clearMmkvStorageAndEmptyAtoms.ts
@@ -1,5 +1,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import {CLEAR_STORAGE_KEY} from './atomUtils/atomWithParsedMmkvStorage'
+import {
+  CLEAR_STORAGE_KEY,
+  invalidateScheduledMmkvWrites,
+} from './atomUtils/atomWithParsedMmkvStorage'
 // TODO: ASYNC_SENTINEL_KEY import is part of temporary MMKV data loss diagnostic. Remove together with the sentinel.
 import {ASYNC_SENTINEL_KEY} from './mmkv/detectMmkvDataLoss'
 import {storage} from './mmkv/effectMmkv'
@@ -7,6 +10,10 @@ import {storage} from './mmkv/effectMmkv'
 export default function clearMmkvStorageAndEmptyAtoms(): void {
   // set all atoms to defaultValue
   storage._storage.set(CLEAR_STORAGE_KEY, Date.now().toString())
+
+  // Invalidate any writes already scheduled behind the deferred flush so a
+  // pending write cannot resurrect just-cleared data after clearAll() runs.
+  invalidateScheduledMmkvWrites()
 
   void AsyncStorage.removeItem(ASYNC_SENTINEL_KEY).catch(() => {})
   storage._storage.clearAll()

--- a/apps/mobile/src/utils/inAppLoadingTasks/atoms.ts
+++ b/apps/mobile/src/utils/inAppLoadingTasks/atoms.ts
@@ -7,6 +7,7 @@ import {preferencesAtom} from '../preferences'
 import {reportErrorE} from '../reportError'
 import {
   type InAppLoadingTask,
+  type InAppLoadingTaskDependency,
   type InAppLoadingTaskId,
   type InAppLoadingTaskStatus,
   InAppLoadingTaskError,
@@ -156,56 +157,95 @@ export const executeTasksWithDependencies = (
       HashMap.fromIterable
     )
 
-    // Build dependency graph using HashMap
+    // Build dependency graph using HashMap, preserving onlyIfSucceeds so a
+    // dependent can require its dependency to have completed *successfully*
+    // (not merely to have run).
     const dependencyMap = pipe(
       Array.fromIterable(tasksToExecute),
-      Array.map(([taskId, task]) => {
-        const deps = pipe(
-          task.dependsOn ?? [],
-          Array.map((d) => d.id)
-        )
-        return [taskId, deps] as const
-      }),
+      Array.map(([taskId, task]) => [taskId, task.dependsOn ?? []] as const),
       HashMap.fromIterable
     )
 
-    // Track completed and pending tasks using HashSet
-    let completed = HashSet.empty<InAppLoadingTaskId>()
+    const emptyDeps: readonly InAppLoadingTaskDependency[] = []
+    const depsOf = (
+      taskId: InAppLoadingTaskId
+    ): readonly InAppLoadingTaskDependency[] =>
+      Option.getOrElse(HashMap.get(dependencyMap, taskId), () => emptyDeps)
+
+    // resolved: task finished executing OR was skipped (so plain dependents may
+    // proceed). succeeded: task finished executing with a 'completed' status
+    // (so onlyIfSucceeds dependents may proceed).
+    let resolved = HashSet.empty<InAppLoadingTaskId>()
+    let succeeded = HashSet.empty<InAppLoadingTaskId>()
     let pending = HashSet.fromIterable(taskIds)
 
     // Execute tasks in waves based on dependencies
     while (HashSet.size(pending) > 0) {
-      // Find tasks that can run now (all dependencies completed or no dependencies)
+      const pendingArray = Array.fromIterable(pending)
+
+      // A task can never satisfy its preconditions once one of its
+      // onlyIfSucceeds dependencies has resolved without succeeding - skip it
+      // (and transitively its own dependents) rather than run it against an
+      // unmet precondition.
+      const skipTasks = pipe(
+        pendingArray,
+        Array.filter((taskId) =>
+          pipe(
+            depsOf(taskId),
+            Array.some(
+              (dep) =>
+                dep.onlyIfSucceeds === true &&
+                HashSet.has(resolved, dep.id) &&
+                !HashSet.has(succeeded, dep.id)
+            )
+          )
+        )
+      )
+      const skipSet = HashSet.fromIterable(skipTasks)
+
+      // Find tasks that can run now (all dependencies satisfied). A plain
+      // dependency is satisfied once resolved; an onlyIfSucceeds dependency is
+      // satisfied only once succeeded.
       const readyTasks = pipe(
-        Array.fromIterable(pending),
+        pendingArray,
         Array.filterMap((taskId) => {
+          if (HashSet.has(skipSet, taskId)) return Option.none()
+
+          const allDepsSatisfied = pipe(
+            depsOf(taskId),
+            Array.every((dep) =>
+              dep.onlyIfSucceeds === true
+                ? HashSet.has(succeeded, dep.id)
+                : HashSet.has(resolved, dep.id)
+            )
+          )
+
           const taskOption = HashMap.get(tasksToExecute, taskId)
-          const depsOption = HashMap.get(dependencyMap, taskId)
-          const deps = Option.getOrElse(
-            depsOption,
-            () => [] as InAppLoadingTaskId[]
-          )
-
-          // Check if all dependencies are completed
-          const allDepsCompleted = pipe(
-            deps,
-            Array.every((depId) => HashSet.has(completed, depId))
-          )
-
-          return allDepsCompleted && Option.isSome(taskOption)
+          return allDepsSatisfied && Option.isSome(taskOption)
             ? Option.some({id: taskId, task: taskOption.value})
             : Option.none()
         })
       )
 
-      // If no tasks are ready but we still have pending tasks, we have a circular dependency
-      if (readyTasks.length === 0 && HashSet.size(pending) > 0) {
+      // If nothing can be skipped or run yet we have a circular/missing
+      // dependency; bail out rather than loop forever.
+      if (skipTasks.length === 0 && readyTasks.length === 0) {
         console.error(
           'InAppLoadingTasks',
           '❌ Circular dependency detected or missing dependencies:',
-          Array.fromIterable(pending)
+          pendingArray
         )
         break
+      }
+
+      // Mark skipped tasks resolved-but-not-succeeded and drop them.
+      for (const taskId of skipTasks) {
+        console.warn(
+          'InAppLoadingTasks',
+          `⏭️ Skipping task, a required dependency did not succeed: ${taskId}`
+        )
+        resolved = HashSet.add(resolved, taskId)
+        pending = HashSet.remove(pending, taskId)
       }
 
       // Execute ready tasks
@@ -218,10 +258,19 @@ export const executeTasksWithDependencies = (
         Effect.all(taskEffects, {concurrency: runInParallel ? 'unbounded' : 1})
       )
 
-      // Mark tasks as completed and remove from pending
+      // Record execution outcomes so dependents resolve correctly.
+      const registryAfterWave = store.get(taskRegistryAtom)
       for (const {id} of readyTasks) {
-        completed = HashSet.add(completed, id)
+        resolved = HashSet.add(resolved, id)
         pending = HashSet.remove(pending, id)
+        const didSucceed = pipe(
+          HashMap.get(registryAfterWave, id),
+          Option.map((task) => task.status._tag === 'completed'),
+          Option.getOrElse(() => false)
+        )
+        if (didSucceed) {
+          succeeded = HashSet.add(succeeded, id)
+        }
       }
     }
     console.log('InAppLoadingTasks', 'All tasks executed', {taskIds})

--- a/apps/mobile/src/utils/inAppLoadingTasks/domain.ts
+++ b/apps/mobile/src/utils/inAppLoadingTasks/domain.ts
@@ -38,10 +38,20 @@ export interface InAppLoadingTasksRequirements {
   runOn: 'resume' | 'start'
 }
 
+export interface InAppLoadingTaskDependency {
+  id: InAppLoadingTaskId
+  // When true the dependent runs only if this dependency completed
+  // successfully. If the dependency failed (or was itself skipped) the
+  // dependent is skipped instead of run. Use it when running the dependent
+  // against a failed prerequisite would be unsafe (e.g. deleting data based on
+  // state a failed fetch never refreshed).
+  onlyIfSucceeds?: boolean
+}
+
 export interface InAppLoadingTask {
   name: string
   status: InAppLoadingTaskStatus
   task: (store: Store) => Effect.Effect<void, InAppLoadingTaskError>
   requirements: InAppLoadingTasksRequirements
-  dependsOn?: Array<{id: InAppLoadingTaskId; onlyIfSucceeds?: boolean}>
+  dependsOn?: InAppLoadingTaskDependency[]
 }

--- a/apps/mobile/src/utils/mmkv/detectMmkvDataLoss.ts
+++ b/apps/mobile/src/utils/mmkv/detectMmkvDataLoss.ts
@@ -1,0 +1,69 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import {File, Paths} from 'expo-file-system'
+import {AppState} from 'react-native'
+import reportError from '../reportError'
+import {storage} from './effectMmkv'
+
+// TODO: Temporary diagnostic to detect silent MMKV data wipes (OnErrorDiscard).
+// Remove once the root cause of user data loss is identified.
+//
+// Kept out of effectMmkv.ts on purpose: effectMmkv is a low-level storage util
+// and must not import reportError (which pulls in session state and would
+// create a require cycle back to effectMmkv).
+const MMKV_SENTINEL_KEY = '__mmkv_data_exists'
+export const ASYNC_SENTINEL_KEY = '__mmkv_was_populated'
+
+function getMmkvFilesDiagnostics(): Record<string, unknown> {
+  const docDir = Paths.document
+  if (!docDir) return {error: 'no document directory'}
+
+  const dataFile = new File(docDir, 'mmkv/mmkv.default')
+  const crcFile = new File(docDir, 'mmkv/mmkv.default.crc')
+
+  return {
+    dataFileExists: dataFile.exists,
+    dataFileSize: dataFile.exists ? dataFile.size : null,
+    crcFileExists: crcFile.exists,
+    crcFileSize: crcFile.exists ? crcFile.size : null,
+  }
+}
+
+export function detectMmkvDataLoss(): void {
+  const mmkvInstance = storage._storage
+  try {
+    const mmkvSentinel = mmkvInstance.getString(MMKV_SENTINEL_KEY)
+
+    void AsyncStorage.getItem(ASYNC_SENTINEL_KEY)
+      .then((asyncSentinel) => {
+        try {
+          if (!mmkvSentinel && asyncSentinel) {
+            const remainingKeyCount = mmkvInstance.getAllKeys().length
+            const fileDiagnostics = getMmkvFilesDiagnostics()
+
+            reportError(
+              'error',
+              new Error(
+                'MMKV data loss detected: data was previously stored but MMKV is now empty'
+              ),
+              {
+                lastPopulatedAt: asyncSentinel,
+                remainingKeyCount,
+                appState: AppState.currentState,
+                ...fileDiagnostics,
+              }
+            )
+          }
+        } catch {
+          // Detection fired but gathering diagnostics or reporting threw.
+          // Leave the sentinels unstamped so this one-shot data-loss signal
+          // is re-detected and re-reported on the next launch instead of
+          // being silently consumed.
+          return
+        }
+
+        mmkvInstance.set(MMKV_SENTINEL_KEY, Date.now().toString())
+        return AsyncStorage.setItem(ASYNC_SENTINEL_KEY, Date.now().toString())
+      })
+      .catch(() => {})
+  } catch {}
+}

--- a/apps/mobile/src/utils/mmkv/effectMmkv.ts
+++ b/apps/mobile/src/utils/mmkv/effectMmkv.ts
@@ -1,10 +1,6 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import {Either, flow, Schema, type ParseResult} from 'effect'
-import {File, Paths} from 'expo-file-system'
-import {AppState} from 'react-native'
 import {MMKV} from 'react-native-mmkv'
 import {JsonParseError, JsonStringifyError} from '../fpUtils'
-import reportError from '../reportError'
 import {ReadingFromStoreError, ValueNotSet, WritingToStoreError} from './domain'
 
 export interface EffectMmkv {
@@ -116,61 +112,7 @@ function createEffectMmkv(storage: MMKV): EffectMmkv {
   }
 }
 
-// TODO: Temporary diagnostic to detect silent MMKV data wipes (OnErrorDiscard).
-// Remove once the root cause of user data loss is identified.
-const MMKV_SENTINEL_KEY = '__mmkv_data_exists'
-export const ASYNC_SENTINEL_KEY = '__mmkv_was_populated'
-
-function getMmkvFilesDiagnostics(): Record<string, unknown> {
-  const docDir = Paths.document
-  if (!docDir) return {error: 'no document directory'}
-
-  const dataFile = new File(docDir, 'mmkv/mmkv.default')
-  const crcFile = new File(docDir, 'mmkv/mmkv.default.crc')
-
-  return {
-    dataFileExists: dataFile.exists,
-    dataFileSize: dataFile.exists ? dataFile.size : null,
-    crcFileExists: crcFile.exists,
-    crcFileSize: crcFile.exists ? crcFile.size : null,
-  }
-}
-
-function detectMmkvDataLoss(mmkvInstance: MMKV): void {
-  try {
-    const mmkvSentinel = mmkvInstance.getString(MMKV_SENTINEL_KEY)
-
-    void AsyncStorage.getItem(ASYNC_SENTINEL_KEY)
-      .then((asyncSentinel) => {
-        try {
-          if (!mmkvSentinel && asyncSentinel) {
-            const remainingKeyCount = mmkvInstance.getAllKeys().length
-            const fileDiagnostics = getMmkvFilesDiagnostics()
-
-            reportError(
-              'error',
-              new Error(
-                'MMKV data loss detected: data was previously stored but MMKV is now empty'
-              ),
-              {
-                lastPopulatedAt: asyncSentinel,
-                remainingKeyCount,
-                appState: AppState.currentState,
-                ...fileDiagnostics,
-              }
-            )
-          }
-        } catch {}
-
-        mmkvInstance.set(MMKV_SENTINEL_KEY, Date.now().toString())
-        return AsyncStorage.setItem(ASYNC_SENTINEL_KEY, Date.now().toString())
-      })
-      .catch(() => {})
-  } catch {}
-}
-
 const mmkv = new MMKV()
-detectMmkvDataLoss(mmkv)
 if (__DEV__) {
   // @ts-expect-error for debugging purposes
   window.__mmkv = mmkv

--- a/apps/mobile/src/utils/newOffersNotificationBackgroundTask/store.ts
+++ b/apps/mobile/src/utils/newOffersNotificationBackgroundTask/store.ts
@@ -3,8 +3,7 @@ import {
   UnixMilliseconds,
   UnixMilliseconds0,
 } from '@vexl-next/domain/src/utility/UnixMilliseconds.brand'
-import {Array, Schema} from 'effect'
-import {pipe} from 'fp-ts/lib/function'
+import {Array, Schema, pipe} from 'effect'
 import {atom} from 'jotai'
 import {filteredOffersIncludingLocationFilterAtom} from '../../state/marketplace/atoms/filteredOffers'
 import {atomWithParsedMmkvStorage} from '../atomUtils/atomWithParsedMmkvStorage'
@@ -26,6 +25,16 @@ export const refreshLastSeenOffersActionAtom = atom(null, (get, set) => {
     get(filteredOffersIncludingLocationFilterAtom),
     Array.map((offer) => offer.offerInfo.offerId)
   )
+  // Skip the write (a full persisted-store rewrite + derived-atom
+  // invalidation) when the ids did not change — the common case on no-op
+  // refreshes.
+  const {lastSeenOffers} = get(newOfferNotificationsPreferencesStore)
+  if (
+    lastSeenOffers.length === currentOfferIds.length &&
+    Array.every(lastSeenOffers, (id, i) => id === currentOfferIds[i])
+  )
+    return
+
   set(newOfferNotificationsPreferencesStore, (prev) => ({
     ...prev,
     lastSeenOffers: currentOfferIds,

--- a/apps/mobile/src/utils/notifications/index.ts
+++ b/apps/mobile/src/utils/notifications/index.ts
@@ -1,6 +1,6 @@
 import {ExpoNotificationToken} from '@vexl-next/domain/src/utility/ExpoNotificationToken.brand'
 import {effectToTask} from '@vexl-next/resources-utils/src/effect-helpers/TaskEitherConverter'
-import {Effect, Schema} from 'effect'
+import {Effect, Option, Schema} from 'effect'
 import {BackgroundTaskStatus, getStatusAsync} from 'expo-background-task'
 import * as Device from 'expo-device'
 import * as Notifications from 'expo-notifications'
@@ -12,6 +12,7 @@ import {useEffect, useState} from 'react'
 import {Alert, Platform} from 'react-native'
 import NotificationSetting from 'react-native-open-notification'
 import {useTranslation} from '../localization/I18nProvider'
+import {storage} from '../mmkv/effectMmkv'
 import reportError from '../reportError'
 import {areNotificationsEnabledAtom} from './areNotificaitonsEnabledAtom'
 
@@ -113,6 +114,42 @@ export function getNotificationTokenE(): Effect.Effect<ExpoNotificationToken | n
 
 export function getNotificationToken(): T.Task<ExpoNotificationToken | null> {
   return effectToTask(getNotificationTokenE())
+}
+
+// todo #2124: remove after migrating to vexl notification token
+export const NOTIFICATION_TOKEN_CACHE_KEY = 'notificationToken'
+
+const getCachedNotificationTokenE: Effect.Effect<
+  Option.Option<ExpoNotificationToken>
+> = Effect.suspend(() =>
+  Option.match(
+    Option.fromNullable(
+      storage._storage.getString(NOTIFICATION_TOKEN_CACHE_KEY)
+    ),
+    {
+      onNone: () => Effect.succeedNone,
+      onSome: (cached) =>
+        Schema.decodeUnknown(ExpoNotificationToken)(cached).pipe(
+          Effect.map(Option.some),
+          Effect.orElseSucceed(() => Option.none<ExpoNotificationToken>())
+        ),
+    }
+  )
+)
+
+// Fetches the Expo push token but never blocks a caller for more than 3s so a
+// hanging fetch can not stall club refresh / admission checks. On timeout we
+// fall back to the last-known cached token (see refreshNotificationTokenOnResume)
+// instead of `null` - otherwise a transient hang would clear the token stored on
+// the server and disable legacy club notifications until the next refresh.
+export function getNotificationTokenWithTimeoutE(): Effect.Effect<
+  Option.Option<ExpoNotificationToken>
+> {
+  return getNotificationTokenE().pipe(
+    Effect.timeout('3 seconds'),
+    Effect.map(Option.fromNullable),
+    Effect.catchTag('TimeoutException', () => getCachedNotificationTokenE)
+  )
 }
 
 export interface NotificationsEnabledSettings {

--- a/apps/mobile/src/utils/notifications/refreshNotificationTokenOnResumeTask.ts
+++ b/apps/mobile/src/utils/notifications/refreshNotificationTokenOnResumeTask.ts
@@ -7,9 +7,7 @@ import {
   InAppLoadingTaskError,
   registerInAppLoadingTask,
 } from '../inAppLoadingTasks'
-import {getNotificationTokenE} from './index'
-
-const NOTIFICATION_TOKEN_CACHE_KEY = 'notificationToken'
+import {getNotificationTokenE, NOTIFICATION_TOKEN_CACHE_KEY} from './index'
 
 // todo #2124: remove after migrating to vexl notification token
 export const refreshNotificationTaskId = registerInAppLoadingTask({

--- a/apps/mobile/src/utils/notifications/useConsumeNotificationStream.ts
+++ b/apps/mobile/src/utils/notifications/useConsumeNotificationStream.ts
@@ -56,7 +56,10 @@ import {useAppState} from '../useAppState'
 import {displayLocalNotification} from './displayLocalNotification'
 import {getDefaultChannel} from './notificationChannels'
 import {processVexlProductNotificationActionAtom} from './processVexlProductNotification'
-import {showDebugNotificationIfEnabled} from './showDebugNotificationIfEnabled'
+import {
+  getShowDebugNotifications,
+  showDebugNotificationIfEnabled,
+} from './showDebugNotificationIfEnabled'
 
 const WebSocketConstructorLive = Layer.succeed(
   Socket.WebSocketConstructor,
@@ -315,17 +318,19 @@ const processNewStreamNotificationActionAtom = atom(
         return
       }
 
-      void showDebugNotificationIfEnabled({
-        title: `Notification ${message._tag}`,
-        subtitle: 'processNewStreamNotificationActionAtom',
-        body: JSON.stringify(
-          {
-            data: message,
-          },
-          null,
-          2
-        ),
-      })
+      // Only pay for the pretty stringify when debug notifications are on.
+      if (getShowDebugNotifications())
+        void showDebugNotificationIfEnabled({
+          title: `Notification ${message._tag}`,
+          subtitle: 'processNewStreamNotificationActionAtom',
+          body: JSON.stringify(
+            {
+              data: message,
+            },
+            null,
+            2
+          ),
+        })
 
       yield* _(
         Match.value(message).pipe(
@@ -377,7 +382,7 @@ const processNewStreamNotificationActionAtom = atom(
         if (e._tag === 'Success')
           return Console.log(
             '✅ Processed notification stream message',
-            JSON.stringify(message, null, 2)
+            message._tag
           )
         return reportErrorE(
           'error',

--- a/apps/mobile/src/utils/notifications/useConsumeNotificationStream.ts
+++ b/apps/mobile/src/utils/notifications/useConsumeNotificationStream.ts
@@ -375,7 +375,9 @@ const processNewStreamNotificationActionAtom = atom(
         )
       )
 
-      yield* _(Console.log('Received notification stream message', message))
+      yield* _(
+        Console.log('Received notification stream message', message._tag)
+      )
     }).pipe(
       Effect.exit,
       Effect.tap((e) => {

--- a/docs/performance_findings_2026_07.md
+++ b/docs/performance_findings_2026_07.md
@@ -1,0 +1,184 @@
+# Android Performance Investigation (July 2026)
+
+> How this report was produced: the app (staging dev build) was profiled on an Android
+> emulator against a locally running backend, first with an empty account, then with a
+> seeded realistic account (200 imported contacts, 700 offers — 600 incoming from 300
+> registered fake users + 100 own — and 30 chats × 40 messages). Measurements came from
+> `adb dumpsys gfxinfo`, `am start -W`, React DevTools render profiles, and the app's own
+> task-timing logs. Every measured regression was traced to code before being reported.
+> Data seeding is reproducible with `tooling/dev/seed-perf-data.ts` (see script header).
+
+# Vexl Android Performance Investigation — Synthesis Report
+
+## Methodology
+
+- **Device/build:** Android emulator (emulator-5554), staging dev build (`it.vexl.nextstaging`, Metro on :8081, Hermes, `dev=true`). Absolute numbers are inflated by dev overhead; **only baseline-vs-loaded deltas and component-level evidence are meaningful**.
+- **Baseline:** near-empty account (0 contacts, 0 offers, 0 chats).
+- **Loaded:** seeded realistic account — 200 imported contacts, 600 incoming offers (400 visible), 100 own offers, 30 chats × 40 messages (backed by 300 registered fake users).
+- **Mirrored scenarios:** 3× cold start (`am start -W` + JS InAppLoadingTask log timings), 60s foregrounded idle (gfxinfo + JS logs), tab navigation (react-devtools profile, identical tap coordinates, screenshot-verified), marketplace scroll (gfxinfo, identical swipe script). Loaded run added: offer-refresh cost sampling, marketplace-scroll render profile, chat-open profile.
+- **Cross-referencing:** every measured regression was traced to code (file:line); static findings without measurement corroboration are marked _plausible_.
+- Profile exports and raw logs: `<local artifacts dir>/` (`baseline-tabs.json`, `loaded-tabs.json`, `loaded-chatopen.json`, `loaded-coldstart-run{1,2,3}-logs.txt`, gfxinfo dumps, screenshots).
+
+## Baseline vs Loaded
+
+| Metric                                          | Baseline (empty)     | Loaded (200 contacts / 700 offers / 30 chats)                 | Delta                                                                                  |
+| ----------------------------------------------- | -------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Native cold-start TTI (median)                  | 1618 ms              | 1537 ms                                                       | **unchanged** — launch itself is not data-driven                                       |
+| JS task: syncConnections                        | 43.4 s               | 60.4 s (all 3 runs ±0.1s)                                     | **+17 s**, of which ~15 s is a silent stall after the 100 per-offer connection updates |
+| JS task: fetchMessagesForAllInboxes             | 79 ms                | 5.4 s steady (19.4 s first run)                               | **~68×**                                                                               |
+| JS task: refreshOffersAndEnsureInboxes          | 36 ms                | 4.3 s                                                         | **~120×**                                                                              |
+| JS task: loadContactsFromDevice                 | 2.8 s                | 5.0 s                                                         | +2.2 s                                                                                 |
+| JS tasks: loadNews / refreshNotes / refreshUser | ~250 ms              | ~4.3 s each                                                   | pure JS-thread queueing behind the offer refresh                                       |
+| Startup first two offer refreshes               | 993 / 960 ms         | 4.3 / 2.3 s                                                   | ~4×                                                                                    |
+| Offer refresh, steady state (no new offers)     | 40 ms                | 149–217 ms                                                    | ~5× (modest)                                                                           |
+| Ingesting 700 offers (one refresh)              | —                    | 4.78 s                                                        | JS-thread block                                                                        |
+| Idle 60 s: refresh firings                      | 12 (every 5 s)       | **0**                                                         | 5s poll is an **empty-marketplace artifact**                                           |
+| Idle 30 s: native frames rendered               | 0                    | 0                                                             | idle is clean in both                                                                  |
+| Tab switch (BaseNavigationContainer render)     | avg 196 / max 297 ms | avg 432 / max 1007 ms (Chats tab)                             | 2.2× avg / 3.4× max                                                                    |
+| Tab-nav profile total commit time               | 1133 ms / 36 commits | 2163 ms / 24 commits                                          | +91%                                                                                   |
+| Marketplace scroll janky frames                 | 5.26%, p99 81 ms     | 5.63%, p99 40 ms                                              | **unchanged** — scroll is healthy                                                      |
+| Chat open → full history visible                | —                    | ~2–3.3 s (shell at 1.4 s, message area blank ≥0.3–1.5 s more) |                                                                                        |
+
+**Headline:** native startup and list scrolling are fine. The slowness lives in (a) the post-launch/resume JS task batch — dominated by syncConnections, the offer refresh pipeline, and per-inbox message fetching — which saturates the JS thread for tens of seconds every time the app is foregrounded, and (b) navigation-time render cost on the Chats tab and chat-open, driven by identity-churning jotai selectors and FlashList prop instability.
+
+---
+
+## Ranked Findings
+
+### 1. syncConnections runs on **every app foreground** and ends in an O(offers²) MMKV-rewrite stall (~15 s with 100 own offers) — CONFIRMED, high
+
+**User impact:** for the first minute after opening the app, the JS thread is busy — taps feel laggy, other startup tasks queue behind it (measured: three trivial ~250 ms tasks inflate to ~4.3 s). This is the single biggest "the app is slow" contributor for users with own offers, and it repeats on every resume (`runOn: 'resume'`, `apps/mobile/src/state/connections/syncConnectionsInAppLoadingTask.ts:13`).
+
+**Root cause (measured 60.3–60.5 s, stable across runs):**
+
+- The final phase, `updateAndReencryptAllOffersConnectionsActionAtom` (`apps/mobile/src/state/connections/atom/offerToConnectionsAtom.ts:372`), logs 100 per-offer updates at 1–19 ms each, then goes silent ~15 s before task completion. Explanation found in code: each per-offer update calls `set(oneOfferConnectionsAtom, ...)` (`offerToConnectionsAtom.ts:345`) which writes through `createSingleOfferToConnectionsAtom` into the **whole** `offer-to-connections` persisted atom (`offerToConnectionsAtom.ts:38`). Each write queues an `InteractionManager.runAfterInteractions` full effect-Schema encode + `JSON.stringify` + MMKV write of **all** offers' connection lists (`atomWithParsedMmkvStorage.ts:88–104`), and each MMKV write fires the change listener which re-`JSON.parse`s the entire blob just to check authorship (`atomWithParsedMmkvStorage.ts:203–207`). With 100 offers × ~200 connections each, that's 100 × (full encode + full parse) of a multi-MB blob executed back-to-back after the loop — the ~15 s stall, reproduced on all 3 runs.
+- Also: `deleteOrphanRecordsActionAtom` uses `adminIds.includes` inside a filter — O(offers²) (`offerToConnectionsAtom.ts:154–163`).
+- The inner "Sync connections" step (45.7 s loaded, 43 s at baseline) blocks inline on `getNotificationTokenE()` with **no timeout** (`apps/mobile/src/state/connections/atom/connectionStateAtom.ts:80–83`); on this emulator the Expo token fetch hangs on DNS (test noise), but the same untimed network dependency will stall syncConnections on flaky mobile networks in production.
+
+**Fix sketch:** accumulate connection updates in memory and write `offerToConnectionsAtom` **once** after the loop (or debounce/coalesce shadow-storage persists per key); replace `includes` with a `Set`; wrap `getNotificationTokenE()` in `Effect.timeout` (it only gates optional metrics reporting — fork it like the metrics call already is).
+**Status (this PR):** the client-side fixes landed — batched connection write + `Set`-based orphan check, and a 3s `Effect.timeout` around `getNotificationTokenE()` in `apps/mobile/src/state/connections/atom/connectionStateAtom.ts:87` (the same guard was also added to the clubs token fetches, `refreshClubsActionAtom.ts:71` and `checkForClubsAdmissionActionAtom.ts:28`).
+**Effort:** medium. **Risk:** the connection-update flow feeds private-part re-encryption — batching the _state write_ is safe, but do not change what gets encrypted/uploaded; verify offers still receive connection updates after backgrounding mid-run.
+
+### 2. Systemic: monolithic MMKV persisted atoms — full-blob Schema encode on every write, full re-parse in the change listener, and double decode at startup — CONFIRMED, high
+
+**User impact:** amplifies _every_ hot path: one chat message received, one offer flag toggled, one contact marked seen → re-encode + rewrite of the entire chats/offers/contacts blob, followed by a redundant full parse. Startup pays two full decodes per big blob. This is the shared mechanism behind findings 1, 3, 4, 7 and all four static analysis dimensions independently converged on it.
+
+**Root cause:** `apps/mobile/src/utils/atomUtils/atomWithParsedMmkvStorage.ts` —
+
+- write path (lines 88–104): full `Schema.encode` + `JSON.stringify` + synchronous MMKV set per write; `saveWithAuthorKey` also rebuilds the extended schema (`Schema.extend`) on every write (line 65);
+- change listener (lines 203–214): `getVerified(key, AuthorKeySchema)` JSON.parses the whole blob just to read the author id; for foreign writes it then decodes **twice** (`getVerified(key, schema)` followed by redundant `Either.flatMap(decodeValue)` on the already-decoded value — also a latent correctness bug, since the second decode receives `Option` instances, not the encoded shape);
+- startup (lines 175 + 190): `getInitialValue` runs a synchronous full JSON.parse + Schema decode at **module import time**, then `onMount` unconditionally repeats the identical decode.
+- Affected single-key stores: `messagingState` (ALL chats+messages, `state/chat/atoms/messagingStateAtom.ts:7`), `offers` (`state/marketplace/atoms/offersState.ts:22`), `storedContacts` (`state/contacts/atom/contactsStore.ts:10`), `offer-to-connections`, `connectionsStateV2`, ~30 call sites total.
+
+**Fix sketch:** (a) store the author id in a separate tiny MMKV key (or in-memory last-write flag) so the listener check is O(1); (b) delete the redundant `decodeValue` pass; (c) memoize the extended schema per key; (d) cache the initial decode and skip the onMount re-read unless the raw string changed; (e) longer term, shard hot collections (per-inbox/per-chat keys, offers pages) and debounce persists.
+**Effort:** (a)–(d) small–medium and high-leverage; (e) large. **Risk:** persistence-format changes need a migration path; keep schema validation on read (data integrity matters in an E2E app). No crypto flows touched.
+
+### 3. Offer refresh pipeline: O(N²) merge + O(offers × commonFriends × contacts) filtering + unconditional full-state writes → 4.3 s JS block on every app foreground — CONFIRMED, high
+
+**User impact:** every foreground/marketplace visit blocks the JS thread for seconds (measured 36 ms → 4.3 s first refresh, ×2 per launch; 4.78 s when 700 offers actually arrive; three unrelated startup tasks measured queueing ~4 s behind it). Explains "app feels frozen right after opening".
+
+**Root cause:**
+
+- `mergeIncomingOffersToState` (`state/marketplace/atoms/refreshOffersActionAtom/utils/mergeIncomingOffersToState.ts:25–38`): `Array.union` (O(n²) `dedupeWith` with `Equal.equals`) plus two linear `findFirst` scans per id → quadratic over all stored+incoming offers, every refresh.
+- `offersToSeeInMarketplaceAtom` (`state/marketplace/atoms/offersToSeeInMarketplace.ts:53–60`): per offer, `deriveVisibleCommonFriendsForOffer` does `Array.intersection(Array.union(commonFriends, verifiedCommonFriends), importedContactsHashes)` — effect's intersection is a nested linear scan with `Equal.equals` per pair → O(offers × friends × contacts). Recomputes on every offers/contacts change; also re-invoked in `sortOffers.ts:23`, `filterOffersByText.ts:46`, and per card in `useVisibleCommonFriendsForOffer`. It also runs a Sentry-reporting side effect + O(N) map inside the atom getter.
+- The refresh always bumps `lastUpdatedAt2` and builds a fresh array (`refreshOffersActionAtom/index.ts:63–74`), so even a no-op refresh triggers the full-blob MMKV rewrite (finding 2) and invalidates the entire derived-atom chain. `getRemovedOffersIds.ts:58–93` additionally POSTs every stored offer id per refresh.
+
+**Fix sketch:** Map/Set-based merge (O(N)); short-circuit and return the same array reference when nothing came in; derive `importedContactsHashesSet` once and use `set.has()` in common-friends derivation; move `lastUpdatedAt2` and the Sentry report out of the offers blob/getter; throttle the removed-offers reconciliation to app-foreground/N-minutes cadence.
+**Effort:** medium. **Risk:** merge semantics for owned offers are intertwined with finding 9 — fix together; no crypto changes.
+
+### 4. fetchMessagesForAllInboxes: one HTTP roundtrip per inbox, and every own offer owns an inbox → 100+ requests per resume (79 ms → 5.4 s) — CONFIRMED, high
+
+**User impact:** adds ~5.4 s of JS/network work per app-open for a user with 100 own offers even when there are **zero** new messages (measured: "Fetch inboxes took 5.405s" + 100× "No new messages in inbox"); scales linearly with own offers.
+
+**Root cause:** `fetchMessagesForAllInboxesAtom` (`state/chat/atoms/fetchNewMessagesActionAtom.ts:542–571`) maps every inbox in `messagingStateAtom` to `fetchAndStoreMessagesForInboxHandleNotificationsActionAtom` — one `retrieveMessages` API call per inbox (unbounded concurrency, but each is a full roundtrip + per-inbox handling). Task runs on every resume (`fetchMessagesForAllInboxesInAppLoadingTask.ts`). The throttle guard is 120 **milliseconds** (`fetchNewMessagesActionAtom.ts:546`) — effectively none; the log text suggests seconds were intended. Each inbox that does have messages triggers a full messagingState persist (finding 2).
+
+**Fix sketch:** short term: raise the throttle to an intentional value, and skip inboxes with no expected activity. Proper fix: a batched server endpoint ("which of these inboxes have messages") so one roundtrip covers all inboxes.
+**Effort:** medium (client) / large (server endpoint). **Risk — privacy flag:** a batch endpoint would let the server correlate all of a user's inboxes in a single request; today they're already sent from the same connection in a burst, but the API design should be reviewed against the linkability model before building it.
+
+### 5. Chats tab switch costs up to ~1 s: ChatsList selector rebuilds every row's identity on any messaging-state change — CONFIRMED, medium-high
+
+**User impact:** tab switch to Chats measured at max 1007 ms render (vs 297 ms baseline); 20 `Memo(ChatListItem)` × 37 ms + `Swipeable` × 28.5 ms all mount fresh. Also means **every incoming message remounts every chat row**.
+
+**Root cause:** `components/InsideRouter/components/MessagesScreen/components/ChatsList.tsx:24–42` — `selectAtom(messagingStateAtom, ...)` has no equality function and wraps each chat in a new `{chat, lastMessage}` object per evaluation; `splitAtom` then regenerates all row atoms and `keyExtractor={atomKeyExtractor}` keys rows by atom instance, so FlashList sees all-new items — defeating both `React.memo(ChatListItem)` and recycling.
+
+**Fix sketch:** give `selectAtom` an equality fn / select stable identities (chat ids), pass `splitAtom` a keyExtractor on `chat.id`, and key FlashList rows by chat id.
+**Effort:** small. **Risk:** low; verify unread/last-message updates still propagate.
+
+### 6. Chat open shows a blank message area for 1–2 s: chat FlashList re-keyed per message + unstable list props — CONFIRMED, medium
+
+**User impact:** chat shell appears ~1.4 s after tap but history renders only at ~2–3.3 s (screenshots `loaded-chat-open-*.png`); profile shows the chat FlashList's ViewHolderCollection re-rendering 81× (total 812 ms, max 635 ms) and FlashList itself 42× during scroll. One chat also opened scrolled to mid-history (#7–#15) instead of the newest message.
+
+**Root cause:** `components/ChatDetailScreen/atoms/index.tsx:143–149, 306` — `buildMessagesListData` rebuilds every item object per change and `splitAtom` + `atomKeyExtractor` (MessagesList.tsx:361) key rows by atom instance instead of the stable `item.key` the builder already computes → each appended message re-keys all rows. Contributing library-level issue: `@shopify/flash-list`'s ViewHolderCollection receives 5 freshly-created function props on every render (seen in all profiles: getLayout, getAdjustmentMargin, onCommitLayoutEffect, onCommitEffect, getChildContainerLayout), plus fresh `contentContainerStyle`/`onScroll`/`onContentSizeChange` passed to the list. `MessageItem` itself is correctly memoized (renders once).
+
+**Fix sketch:** key `splitAtom` and FlashList rows by `item.key`; memoize items by message uuid; hoist/stabilize the list props we control; check the mid-history scroll against `maintainVisibleContentPosition`/initial-scroll-index logic; consider a FlashList upgrade/patch for the function-prop churn.
+**Effort:** small–medium. **Risk:** low.
+
+### 7. Contacts pipeline: full device-contacts reload + wholesale store rewrite on every resume, plus O(n²) dedupe — CONFIRMED (measured 2.8 s → 5.0 s), medium
+
+**User impact:** +2.2 s of resume work at only 200 contacts; scales quadratically — real users with 2–5k contacts pay far more, and the identity churn invalidates the marketplace derived-atom chain (multiplying finding 3).
+
+**Root cause:** `state/contacts/atom/loadContactsFromDeviceActionAtom.ts:37–71` runs on every resume and unconditionally `set(storedContactsAtom, ...)` with all-new object identities (no diff), triggering the full-blob MMKV rewrite (finding 2) and recomputation of `normalizedContactsAtom`, which dedupes with `Array.dedupeWith` — O(n²), ~14M comparisons at 5300 contacts (`contactsStore.ts:85–89`). `normalizeStoredContactsActionAtom.ts:96–105` also does a spread-in-reduce O(n²) partition on every screen focus before its early exit. (Good news confirmed statically: libphonenumber parsing and HMAC hashing are cached in `computedValues` and NOT redone per start.)
+
+**Fix sketch:** diff before set (skip write when device contacts unchanged, preserve object identity for unchanged entries); Map-based dedupe; `Array.partition` instead of spread-reduce; Set-based `createImportedContactsForHashesAtom`.
+**Effort:** small–medium. **Risk:** contact hashes feed offer visibility — behavior must stay identical; pure data-structure changes, no crypto.
+
+### 8. Empty-marketplace 5 s poll runs the FULL refresh pipeline indefinitely — CONFIRMED (baseline: 12 firings/60 s; loaded: 0), medium
+
+**User impact:** new users, and any user whose stored offers are all hidden (mine/expired/reported/no common friends — the gate is "nothing _visible_", not "nothing stored"), burn network + battery + JS time every 5 s while on the marketplace: 2+2×clubs requests per tick including POSTing all stored offer ids, O(N²) merge, and 2–3 full MMKV blob rewrites per tick.
+
+**Root cause:** `components/InsideRouter/components/MarketplaceScreen/components/EmptyList.tsx:36, 217–221` (`EMPTY_MARKETPLACE_REFRESH_INTERVAL_MS = 5000`, `setInterval` → full `refreshOffersActionAtom`), mounted whenever `areThereOffersToSeeInMarketplaceWithoutFiltersAtom` is false. Confirmed by idle measurements: exactly-5 s cadence at baseline, zero firings with data.
+
+**Fix sketch:** backoff (5 s → 30 s → 60 s), poll only when the store is truly empty, and skip the merge/state-write/removed-offers/owner-ensure steps when nothing was fetched.
+**Effort:** small. **Risk:** low; keep the fast first-offer pickup for genuinely new users.
+
+### 9. Self-sustaining owner-private-payload loop: re-encrypt + re-upload + re-download owned offers on every refresh — PLAUSIBLE, medium-high
+
+**User impact:** for affected users (offers missing local `adminId`/`intendedConnectionLevel`), every refresh does per-offer ECIES encryption + a server write + re-download + re-decrypt — repeated crypto and network work that never converges, feeding the refresh costs in finding 3.
+
+**Root cause (static, not directly measured):** `state/marketplace/atoms/ensureMyOffersHaveOwnershipInfoUploadedInPrivatepayloadForOwner.ts:13–42` uploads via `updateOwnerPrivatePayload` but discards the result (`Effect.ignore`) and never persists locally, while `mergeIncomingOffersToState.ts:46–47` explicitly refuses to update owned offers from the server — so the missing fields stay missing forever and the cycle repeats each refresh.
+
+**Fix sketch:** persist the returned private payload into local state after a successful upload (or allow the merge to update owned offers' privatePart); skip the step when the filtered list is empty.
+**Effort:** small. **Risk — crypto flag:** touches offer private-payload encryption/upload; verify the re-encrypted payload is byte-compatible with what other clients decrypt, and test with offers created by older app versions.
+
+### 10. Per-message chat decryption is strictly sequential with a heavyweight legacy KDF (2× PBKDF2-2000 per message) — PLAUSIBLE (consistent with run-1 19.4 s message pull), medium
+
+**User impact:** returning from offline with N pending messages costs N sequential ECDH + 2×PBKDF2 + HMAC + AES operations on the JS scheduling path — slow first sync and slow catch-up after inactivity.
+
+**Root cause:** `packages/resources-utils/src/chat/retrieveMessages.ts:48–62` combines per-message decrypts with bare `Effect.all` (concurrency 1); each decrypt runs `eciesLegacyDecrypt` with two PBKDF2 derivations at 2000 iterations (`packages/cryptography/src/operations/eciesLegacy.ts:130–155`) plus ~4 JSON parse/Schema passes per plaintext (`decryptOffer`-style layering in `messageIO.ts`/`chatCrypto.ts`).
+
+**Fix sketch:** pass `{concurrency: 4–8}` to `Effect.all`; cache derived keys per (privateKey, epk) pair; collapse redundant Schema passes. Longer term migrate the legacy KDF to HKDF.
+**Effort:** small (concurrency) / large (KDF migration). **Risk — crypto flag:** any change beyond the concurrency option touches E2E message crypto; concurrency itself is safe (independent messages) but key-caching and KDF changes need cryptographic review and cross-version compatibility testing.
+
+### 11. Startup fixed costs: all 14 locales (~3.4 MB) eagerly parsed, 17 side-effect imports pull the whole state graph (with double blob decodes) into bundle eval, first render gated behind session-load + ~1 s splash bounce — PLAUSIBLE, low-medium
+
+**Root cause:** `packages/localization/src/translations.ts:1–73` (16 `unflatten` passes at module scope, imported by every screen via I18nProvider); `utils/inAppLoadingTasks/useInAppLoadingTasks.ts:9–25` bare side-effect imports defeating inline-requires; `AnimatedSplashScreen.tsx:161, 250, 257` (session load starts in useEffect, `BounceOut.duration(1000)` gates content). Measured native TTI was unchanged by data (as expected — these are constants), and dev-build absolute startup numbers are unreliable, hence the lower rank.
+
+**Fix sketch:** lazy-load non-device locales; start `loadSession` at module scope; shorten/overlap the splash exit animation.
+**Effort:** medium. **Risk:** low.
+
+---
+
+## Measurement caveats (dev/emulator noise — excluded from rankings)
+
+- **exp.host unreachable on the emulator:** `refreshNotificationTokenOnResume` at 23–25 s in both runs, and most of the _constant_ ~43–45 s inner "Sync connections" step, are Expo-push-token DNS-failure timeouts — test-setup noise. The production-relevant residue is captured in finding 1 (no timeout around an inline token fetch).
+- **Dev build overhead:** Metro, Hermes dev mode, react-devtools profiling, and verbose logging (per-task InAppLoadingTasks logs incl. full result serialization, `⏲️` benchmark logs, 1 s notification-stream retry logs) inflate all absolute numbers. Production strips `console` entirely (`setupAppLogs.ts:57–63`).
+- **Production-relevant logging exceptions (kept in findings/backlog):** the AppLogs storage rewrites the entire accumulated log string per line with unbounded growth (`components/AppLogsScreen/utils/storage.ts:26–33`) — active whenever a user enables in-app logs in production; and `useConsumeNotificationStream.ts:318–328` eagerly pretty-JSON.stringifies every stream event before the debug-enabled check. Both are small fixes worth bundling.
+- The baseline "5 s marketplace poll" is real code (finding 8) but only manifests for empty/all-hidden marketplaces.
+- 400 of 600 seeded incoming offers visible (second-degree-only authors filtered) — plausibly intended marketplace behavior, not investigated further.
+
+## Fix status
+
+### Shipped in this PR (originally planned as PRs 1–5)
+
+- ✅ **Connections sync (finding 1):** batched offer-to-connections write in syncConnections + Set for `deleteOrphanRecords` + timeout on `getNotificationTokenE`; fixed the 120 ms inbox throttle (finding 4); empty-marketplace poll backoff + no-op short-circuit (finding 8).
+- ✅ **Storage helper (finding 2 a–d):** O(1) own-write detection, dropped redundant decode, no per-write schema rebuild, single startup decode + write coalescing in `atomWithParsedMmkvStorage`. Benefits every store at once.
+- ✅ **Offers pipeline (findings 3, 9):** Map/Set merge, no-op refresh short-circuit, Set-based common-friends, Sentry report moved out of the getter; owner-private-payload loop fixed (crypto-reviewed).
+- ✅ **Lists (findings 5, 6):** stable keys/identities for ChatsList and chat-detail list.
+- ✅ **Contacts (finding 7):** resume-time diff, Map-based dedupe/partition.
+
+### Remaining follow-up (larger / needs design)
+
+- **Batched inbox-check endpoint** (finding 4 — needs privacy/linkability review).
+- **Decrypt concurrency landed; KDF review/migration remains** (finding 10).
+- **Sharded persistence** (finding 2e).
+- **Startup locale/splash work** (finding 11).

--- a/packages/resources-utils/src/chat/retrieveMessages.ts
+++ b/packages/resources-utils/src/chat/retrieveMessages.ts
@@ -59,7 +59,9 @@ export default function retrieveMessages({
           )
         ),
         Array.map(Effect.either),
-        Effect.all,
+        // Messages are decrypted independently — bounded concurrency instead
+        // of processing them strictly one by one.
+        Effect.allWith({concurrency: 6}),
         Effect.map((eithers) => ({
           errors: pipe(Array.filterMap(eithers, Either.getLeft)),
           messages: pipe(Array.filterMap(eithers, Either.getRight)),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2015,12 +2015,33 @@ importers:
 
   tooling/dev:
     devDependencies:
+      '@effect/platform':
+        specifier: ^0.93.6
+        version: 0.93.8(effect@3.21.4)
+      '@vexl-next/cryptography':
+        specifier: 0.0.0
+        version: link:../../packages/cryptography
+      '@vexl-next/domain':
+        specifier: 0.0.0
+        version: link:../../packages/domain
       '@vexl-next/eslint-config':
         specifier: 0.0.0
         version: link:../eslint
+      '@vexl-next/generic-utils':
+        specifier: 0.0.0
+        version: link:../../packages/generic-utils
       '@vexl-next/prettier-config':
         specifier: 0.0.0
         version: link:../prettier
+      '@vexl-next/resources-utils':
+        specifier: 0.0.0
+        version: link:../../packages/resources-utils
+      '@vexl-next/rest-api':
+        specifier: 0.0.0
+        version: link:../../packages/rest-api
+      effect:
+        specifier: ^3.20.0
+        version: 3.21.4
       eslint:
         specifier: ^9.20.0
         version: 9.39.4(jiti@2.7.0)

--- a/tooling/dev/README.md
+++ b/tooling/dev/README.md
@@ -1,0 +1,72 @@
+# @vexl-next/dev
+
+Scripts for running the local dev stack (`dev-backend.ts`, `dev-infra.ts`, `dev-mobile.ts` — wired to `pnpm dev:backend` and friends in the root package.json).
+
+## seed-perf-data.ts — simulate a heavy account for performance work
+
+Seeds the **locally running** dev backend with fake users, contacts, offers, and chats around one real (emulator) user, so the app can be profiled against a realistically heavy account. This tooling was built for the investigation documented in [docs/performance_findings_2026_07.md](../../docs/performance_findings_2026_07.md).
+
+The fake users authenticate with headers signed by the committed dev server keys from the repo-root `dev.config.ts` (phone hashes use the dev HMAC key `VexlVexl`, matching the mobile `local` env preset), so no OTP flow is needed and the hashes line up with what the app computes.
+
+### Prerequisites
+
+- Local backend running: `pnpm dev:backend`
+- Mobile app running against the `local` env preset
+- An emulator user you control, logged in with `TARGET_PHONE` (dummy OTP `222222` on the local backend)
+
+### Phases
+
+Phases must run in this order, interleaved with in-app steps. Each phase persists progress to the seed files and can be safely re-run to retry failures.
+
+1. `--phase register` — creates `N_USERS` fake users on contact-service and imports their contacts. "Direct" fake users import `TARGET_PHONE` plus a few fake neighbours; "indirect" ones import only direct users, making them the target's 2nd-degree connections. Writes `seed-users.json` and `seed-fake-numbers.json`.
+2. **In app**: log in as `TARGET_PHONE` and import the direct fake numbers (`numbersToImportInApp` from `seed-fake-numbers.json`) — the DebugScreen button **"Seed perf: import 200 fake contacts"** does exactly this for the default `N_USERS=300`. The target must be fully onboarded before the next phase, otherwise the fake users' offers cannot be encrypted for them. Do NOT import the `secondDegreeOnlyNumbers` — they stay 2nd degree.
+3. `--phase offers` — every fake user creates `OFFERS_PER_USER` offers (connection level ALL) encrypted for their 1st+2nd degree connections, which includes the target. Each offer gets its own inbox on chat-service.
+4. **In app**: the target creates at least one own offer.
+5. `--phase chats` — `N_CHATS` fake users find the target's own offers (any offer not created by this script) and send messaging requests to them.
+6. **In app**: approve the incoming requests — the DebugScreen button **"Seed perf: approve all chat requests"** approves every pending request at once.
+7. `--phase messages` — each fake user with an approved chat sends `MSGS_PER_CHAT` messages to the target's offer inbox. Unapproved chats are reported and skipped (approve them and re-run).
+
+`--phase verify` is a read-only sanity check that prints connection/offer counts for a few sample fake users.
+
+### Usage
+
+From the repo root, with the backend running:
+
+```sh
+TARGET_PHONE=+420605123456 pnpm exec tsx tooling/dev/seed-perf-data.ts --phase register
+```
+
+Parameters via env vars:
+
+| Variable                              | Default                                        | Meaning                                              |
+| ------------------------------------- | ---------------------------------------------- | ---------------------------------------------------- |
+| `TARGET_PHONE`                        | — (required for `register`)                    | E164 phone of the real emulator user                 |
+| `N_USERS`                             | `300`                                          | Number of fake users (2/3 direct, 1/3 second-degree) |
+| `OFFERS_PER_USER`                     | `2`                                            | Offers each fake user creates in `offers`            |
+| `N_CHATS`                             | `30`                                           | Messaging requests sent to the target in `chats`     |
+| `MSGS_PER_CHAT`                       | `40`                                           | Messages per approved chat in `messages`             |
+| `CONCURRENCY`                         | `10`                                           | Parallel API calls                                   |
+| `SEED_DIR`                            | `<os tmpdir>/vexl-seed-perf-data`              | Where the seed state files are written               |
+| `CONTACT_MS` / `OFFER_MS` / `CHAT_MS` | `http://localhost:<port>` from `dev.config.ts` | Service URL overrides                                |
+
+### Output files
+
+Written to `SEED_DIR`:
+
+- `seed-users.json` — key material for all fake users plus offer/chat progress state (this is what makes phases resumable; delete it to regenerate keys from scratch)
+- `seed-fake-numbers.json` — `numbersToImportInApp` (direct fakes the emulator user should import) and `secondDegreeOnlyNumbers` (must NOT be imported)
+
+### Resetting
+
+Restart the backend with a fresh database and delete the seed files:
+
+```sh
+pnpm dev:backend --fresh-db
+```
+
+### DebugScreen helpers
+
+Two buttons in `apps/mobile/src/components/DebugScreen/index.tsx` pair with the script:
+
+- **Seed perf: import 200 fake contacts** — adds the direct fake numbers (`+420777000000`…`+420777000199`) to stored contacts and submits them (step 2 above)
+- **Seed perf: approve all chat requests** — approves all pending incoming messaging requests (step 6 above)

--- a/tooling/dev/README.md
+++ b/tooling/dev/README.md
@@ -38,16 +38,19 @@ TARGET_PHONE=+420605123456 pnpm exec tsx tooling/dev/seed-perf-data.ts --phase r
 
 Parameters via env vars:
 
-| Variable                              | Default                                        | Meaning                                              |
-| ------------------------------------- | ---------------------------------------------- | ---------------------------------------------------- |
-| `TARGET_PHONE`                        | — (required for `register`)                    | E164 phone of the real emulator user                 |
-| `N_USERS`                             | `300`                                          | Number of fake users (2/3 direct, 1/3 second-degree) |
-| `OFFERS_PER_USER`                     | `2`                                            | Offers each fake user creates in `offers`            |
-| `N_CHATS`                             | `30`                                           | Messaging requests sent to the target in `chats`     |
-| `MSGS_PER_CHAT`                       | `40`                                           | Messages per approved chat in `messages`             |
-| `CONCURRENCY`                         | `10`                                           | Parallel API calls                                   |
-| `SEED_DIR`                            | `<os tmpdir>/vexl-seed-perf-data`              | Where the seed state files are written               |
-| `CONTACT_MS` / `OFFER_MS` / `CHAT_MS` | `http://localhost:<port>` from `dev.config.ts` | Service URL overrides                                |
+| Variable                                | Default                                        | Meaning                                              |
+| --------------------------------------- | ---------------------------------------------- | ---------------------------------------------------- |
+| `TARGET_PHONE`                          | — (required for `register`)                    | E164 phone of the real emulator user                 |
+| `N_USERS`                               | `300`                                          | Number of fake users (2/3 direct, 1/3 second-degree) |
+| `OFFERS_PER_USER`                       | `2`                                            | Offers each fake user creates in `offers`            |
+| `N_CHATS`                               | `30`                                           | Messaging requests sent to the target in `chats`     |
+| `MSGS_PER_CHAT`                         | `40`                                           | Messages per approved chat in `messages`             |
+| `CONCURRENCY`                           | `10`                                           | Parallel API calls                                   |
+| `SEED_DIR`                              | `<os tmpdir>/vexl-seed-perf-data`              | Where the seed state files are written               |
+| `CONTACT_MS` / `OFFER_MS` / `CHAT_MS`   | `http://localhost:<port>` from `dev.config.ts` | Service URL overrides                                |
+| `I_KNOW_WHAT_I_AM_DOING_SEEDING_REMOTE` | — (unset)                                      | Escape hatch to bypass the local-only guard          |
+
+The script refuses to run unless every service URL host is local (`localhost`, `*.localhost`, `127.0.0.1`, or `::1`) — this prevents accidentally seeding hundreds of fake users into a shared/staging/prod backend via the `*_MS` overrides. Set `I_KNOW_WHAT_I_AM_DOING_SEEDING_REMOTE=1` only if you truly intend to target a remote backend; it prints a loud warning and proceeds.
 
 ### Output files
 

--- a/tooling/dev/package.json
+++ b/tooling/dev/package.json
@@ -9,8 +9,15 @@
     "typecheck": "tsx check-postgres-init-databases.ts && tsc --noEmit"
   },
   "devDependencies": {
+    "@effect/platform": "^0.93.6",
+    "@vexl-next/cryptography": "0.0.0",
+    "@vexl-next/domain": "0.0.0",
     "@vexl-next/eslint-config": "0.0.0",
+    "@vexl-next/generic-utils": "0.0.0",
     "@vexl-next/prettier-config": "0.0.0",
+    "@vexl-next/resources-utils": "0.0.0",
+    "@vexl-next/rest-api": "0.0.0",
+    "effect": "^3.20.0",
     "eslint": "^9.20.0",
     "prettier": "^3.3.2",
     "typescript": "~6.0.3"

--- a/tooling/dev/seed-perf-data.ts
+++ b/tooling/dev/seed-perf-data.ts
@@ -1,0 +1,1048 @@
+/**
+ * seed-perf-data.ts — seeds the LOCALLY RUNNING vexl backend with fake users
+ * that simulate "other people on the network" around one real (emulator) user,
+ * so the app can be tested against a realistically heavy account.
+ *
+ * The fake users authenticate with headers signed by the committed dev server
+ * key from dev.config.ts (same trick as backend unit tests) — no OTP flow is
+ * needed. Phone-number hashes use the dev HMAC key 'VexlVexl' which matches
+ * the mobile `local` preset, so hashes line up with what the app computes.
+ *
+ * PHASES (must run in this order, interleaved with in-app steps):
+ *
+ *   1. `--phase register`
+ *      Creates N_USERS fake users on contact-service and imports contacts:
+ *      every "direct" fake user imports TARGET_PHONE + a few fake neighbours,
+ *      "indirect" fake users import only direct fake users (=> they end up as
+ *      the target's 2nd-degree connections). Writes key material to
+ *      seed-users.json and the phone list to seed-fake-numbers.json.
+ *
+ *   2. IN APP: log the emulator user in with TARGET_PHONE (dummy OTP 222222 on
+ *      local backend) and make the app import the fake numbers (the
+ *      `numbersToImportInApp` array of seed-fake-numbers.json — e.g. via the
+ *      DebugScreen test contacts or by seeding device contacts). The target
+ *      must be REGISTERED (onboarded) before phase `offers`, otherwise the
+ *      fake users' offers cannot be encrypted for them.
+ *
+ *   3. `--phase offers`
+ *      Every fake user creates OFFERS_PER_USER offers (connection level ALL),
+ *      encrypted for all their 1st+2nd degree connections — which includes the
+ *      target. Each offer gets its own inbox on chat-service.
+ *
+ *   4. IN APP: the target creates at least one own offer.
+ *
+ *   5. `--phase chats`
+ *      N_CHATS fake users fetch offers visible to them, find the target's own
+ *      offers (any offer not created by this script), and send messaging
+ *      requests to those offer inboxes.
+ *
+ *   6. IN APP: approve the incoming requests (chat requests screen).
+ *
+ *   7. `--phase messages`
+ *      Each fake user with an (approved) chat sends MSGS_PER_CHAT messages to
+ *      the target's offer inbox. Requires the in-app approval from step 6 —
+ *      unapproved chats are reported and skipped.
+ *
+ *   `--phase verify` prints connection/offer counts for a few fake users.
+ *
+ * USAGE (from repo root, backend running via `pnpm dev:backend`):
+ *
+ *   TARGET_PHONE=+420605123456 pnpm exec tsx tooling/dev/seed-perf-data.ts --phase register
+ *
+ * Params via env: TARGET_PHONE (required), N_USERS (300), OFFERS_PER_USER (2),
+ * N_CHATS (30), MSGS_PER_CHAT (40), CONCURRENCY (10), SEED_DIR (where the two
+ * json files live), CONTACT_MS / OFFER_MS / CHAT_MS url overrides.
+ *
+ * To wipe everything and start over: restart the backend with a fresh db
+ * (`pnpm dev:backend --fresh-db`) and delete the seed json files.
+ */
+import {FetchHttpClient} from '@effect/platform'
+import {
+  generatePrivateKey,
+  importPrivateKey,
+  type PrivateKeyHolder,
+} from '@vexl-next/cryptography/src/KeyHolder'
+import {
+  PrivateKeyPemBase64,
+  PublicKeyPemBase64,
+} from '@vexl-next/cryptography/src/KeyHolder/brands'
+import {
+  KeyPairV2,
+  PrivateKeyV2,
+} from '@vexl-next/cryptography/src/KeyHolder/brandsV2'
+import {generateKeyPair} from '@vexl-next/cryptography/src/operations/cryptobox'
+import {CountryPrefix} from '@vexl-next/domain/src/general/CountryPrefix.brand'
+import {E164PhoneNumber} from '@vexl-next/domain/src/general/E164PhoneNumber.brand'
+import {HashedPhoneNumber} from '@vexl-next/domain/src/general/HashedPhoneNumber.brand'
+import {
+  generateChatMessageId,
+  type ChatMessage,
+} from '@vexl-next/domain/src/general/messaging'
+import {
+  newOfferId,
+  OfferAdminId,
+  OfferId,
+  OfferPublicPart,
+} from '@vexl-next/domain/src/general/offers'
+import {Base64String} from '@vexl-next/domain/src/utility/Base64String.brand'
+import {PlatformName} from '@vexl-next/domain/src/utility/PlatformName'
+import {SemverString} from '@vexl-next/domain/src/utility/SmeverString.brand'
+import {now} from '@vexl-next/domain/src/utility/UnixMilliseconds.brand'
+import {VersionCode} from '@vexl-next/domain/src/utility/VersionCode.brand'
+import {
+  cryptoBoxSign,
+  ecdsaSignE,
+  hmacSignE,
+} from '@vexl-next/generic-utils/src/effect-helpers/crypto'
+import {messageToNetwork} from '@vexl-next/resources-utils/src/chat/utils/messageIO'
+import {taskEitherToEffect} from '@vexl-next/resources-utils/src/effect-helpers/TaskEitherConverter'
+import createNewOfferForMyContacts from '@vexl-next/resources-utils/src/offers/createNewOfferForMyContacts'
+import decryptOffer from '@vexl-next/resources-utils/src/offers/decryptOffer'
+import {chat, contact, offer} from '@vexl-next/rest-api'
+import {AppSource} from '@vexl-next/rest-api/src/commonHeaders'
+import fetchAllPaginatedData from '@vexl-next/rest-api/src/fetchAllPaginatedData'
+import {type ChatApi} from '@vexl-next/rest-api/src/services/chat'
+import {type ContactApi} from '@vexl-next/rest-api/src/services/contact'
+import {type OfferApi} from '@vexl-next/rest-api/src/services/offer'
+import {type ServerOffer} from '@vexl-next/rest-api/src/services/offer/contracts'
+import {ServiceUrl} from '@vexl-next/rest-api/src/ServiceUrl.brand'
+import {type UserSessionCredentials} from '@vexl-next/rest-api/src/UserSessionCredentials.brand'
+import {UserDataShape} from '@vexl-next/rest-api/src/VexlAuthHeader'
+import {Array, Effect, HashMap, Option, pipe, Schema} from 'effect'
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {devCryptoKeys, ports} from '../../dev.config'
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2)
+const phaseFlagIndex = args.indexOf('--phase')
+const PHASE = phaseFlagIndex >= 0 ? args[phaseFlagIndex + 1] : undefined
+
+const N_USERS = Number(process.env.N_USERS ?? 300)
+const OFFERS_PER_USER = Number(process.env.OFFERS_PER_USER ?? 2)
+const N_CHATS = Number(process.env.N_CHATS ?? 30)
+const MSGS_PER_CHAT = Number(process.env.MSGS_PER_CHAT ?? 40)
+const CONCURRENCY = Number(process.env.CONCURRENCY ?? 10)
+const SEED_DIR = process.env.SEED_DIR ?? join(tmpdir(), 'vexl-seed-perf-data')
+
+const SEED_USERS_FILE = join(SEED_DIR, 'seed-users.json')
+const SEED_NUMBERS_FILE = join(SEED_DIR, 'seed-fake-numbers.json')
+
+const CONTACT_URL = Schema.decodeSync(ServiceUrl)(
+  process.env.CONTACT_MS ?? `http://localhost:${ports.contactService}`
+)
+const OFFER_URL = Schema.decodeSync(ServiceUrl)(
+  process.env.OFFER_MS ?? `http://localhost:${ports.offerService}`
+)
+const CHAT_URL = Schema.decodeSync(ServiceUrl)(
+  process.env.CHAT_MS ?? `http://localhost:${ports.chatService}`
+)
+
+const CLIENT_SEMVER = Schema.decodeSync(SemverString)('1.44.0')
+const CLIENT_VERSION = Schema.decodeSync(VersionCode)(841)
+const PLATFORM = Schema.decodeSync(PlatformName)('ANDROID')
+const APP_SOURCE = Schema.decodeSync(AppSource)('seed-script')
+const COUNTRY_PREFIX = Schema.decodeSync(CountryPrefix)(420)
+
+const DEV_SERVER_PRIVATE_KEY = Schema.decodeSync(PrivateKeyPemBase64)(
+  devCryptoKeys.SECRET_PRIVATE_KEY
+)
+const DEV_LIBSODIUM_PRIVATE_KEY = Schema.decodeSync(PrivateKeyV2)(
+  devCryptoKeys.LIBSODIUM_PRIVATE_KEY
+)
+
+// How many fake neighbours each fake user imports (creates the 2nd degree web)
+const NEIGHBOURS_PER_USER = 6
+// Portion of fake users the target should import directly (1st degree)
+const DIRECT_RATIO = 2 / 3
+
+// ---------------------------------------------------------------------------
+// Seed file persistence
+// ---------------------------------------------------------------------------
+
+const SeedUser = Schema.Struct({
+  index: Schema.Number,
+  phone: E164PhoneNumber,
+  direct: Schema.Boolean,
+  privateKeyPemBase64: PrivateKeyPemBase64,
+  keyPairV2: KeyPairV2,
+})
+type SeedUser = typeof SeedUser.Type
+
+const SeedOffer = Schema.Struct({
+  offerId: OfferId,
+  adminId: OfferAdminId,
+  creatorIndex: Schema.Number,
+  offerKeyPrivatePemBase64: PrivateKeyPemBase64,
+})
+type SeedOffer = typeof SeedOffer.Type
+
+const SeedChat = Schema.Struct({
+  userIndex: Schema.Number,
+  offerId: OfferId,
+  offerPublicKey: PublicKeyPemBase64,
+  requestedAt: Schema.Number,
+  messagesSent: Schema.optionalWith(Schema.Number, {default: () => 0}),
+})
+type SeedChat = typeof SeedChat.Type
+
+const SeedFile = Schema.Struct({
+  targetPhone: E164PhoneNumber,
+  users: Schema.Array(SeedUser),
+  offers: Schema.Array(SeedOffer),
+  chats: Schema.Array(SeedChat),
+})
+type SeedFile = typeof SeedFile.Type
+
+interface MutableSeedChat {
+  userIndex: number
+  offerId: OfferId
+  offerPublicKey: PublicKeyPemBase64
+  requestedAt: number
+  messagesSent: number
+}
+
+interface SeedState {
+  targetPhone: E164PhoneNumber
+  users: SeedUser[]
+  offers: SeedOffer[]
+  chats: MutableSeedChat[]
+}
+
+function loadSeedState(): SeedState | undefined {
+  if (!existsSync(SEED_USERS_FILE)) return undefined
+  const raw = readFileSync(SEED_USERS_FILE, 'utf8')
+  const decoded = Schema.decodeUnknownSync(Schema.parseJson(SeedFile))(raw)
+  return {
+    targetPhone: decoded.targetPhone,
+    users: [...decoded.users],
+    offers: [...decoded.offers],
+    chats: decoded.chats.map((c) => ({...c})),
+  }
+}
+
+function saveSeedState(state: SeedState): void {
+  mkdirSync(SEED_DIR, {recursive: true})
+  const encoded = Schema.encodeSync(SeedFile)({
+    targetPhone: state.targetPhone,
+    users: state.users,
+    offers: state.offers,
+    chats: state.chats,
+  })
+  writeFileSync(SEED_USERS_FILE, JSON.stringify(encoded, null, 2))
+}
+
+// ---------------------------------------------------------------------------
+// Auth + api helpers
+// ---------------------------------------------------------------------------
+
+const hashPhoneNumber = (
+  phone: E164PhoneNumber
+): Effect.Effect<HashedPhoneNumber, unknown> =>
+  hmacSignE(devCryptoKeys.SECRET_HMAC_KEY)(phone).pipe(
+    Effect.map(Schema.decodeSync(HashedPhoneNumber))
+  )
+
+/**
+ * Builds session credentials exactly like the backend would issue them:
+ * - hash: HMAC of the phone number with the dev HMAC key
+ * - signature: ECDSA of `${publicKey}${hash}` with the dev server key
+ * - vexlAuthHeader: `VexlAuth` header carrying the user's V2 (cryptobox)
+ *   public key, signed with the dev libsodium server key. This makes the
+ *   services treat the fake user as a modern V2 user (needed e.g. for the
+ *   offer owner private part check).
+ */
+const makeCredentials = (
+  phone: E164PhoneNumber,
+  keyPair: PrivateKeyHolder,
+  keyPairV2: KeyPairV2
+): Effect.Effect<UserSessionCredentials, unknown> =>
+  Effect.gen(function* (_) {
+    const hash = yield* _(hashPhoneNumber(phone))
+    const signature = yield* _(
+      ecdsaSignE(DEV_SERVER_PRIVATE_KEY)(`${keyPair.publicKeyPemBase64}${hash}`)
+    )
+    const userData = {pk: keyPairV2.publicKey, hash}
+    const userDataEncoded = yield* _(Schema.encode(UserDataShape)(userData))
+    const vexlAuthSignature = yield* _(
+      cryptoBoxSign(DEV_LIBSODIUM_PRIVATE_KEY)(userDataEncoded)
+    )
+    return {
+      publicKey: keyPair.publicKeyPemBase64,
+      hash,
+      signature,
+      vexlAuthHeader: {data: userData, signature: vexlAuthSignature},
+    }
+  })
+
+interface Apis {
+  contact: ContactApi
+  offer: OfferApi
+  chat: ChatApi
+}
+
+function makeApis(credentials: UserSessionCredentials): Apis {
+  const common = {
+    platform: PLATFORM,
+    clientVersion: CLIENT_VERSION,
+    clientSemver: CLIENT_SEMVER,
+    language: 'en',
+    isDeveloper: false,
+    appSource: APP_SOURCE,
+    getUserSessionCredentials: () => credentials,
+  }
+  return Effect.gen(function* (_) {
+    return {
+      contact: yield* _(contact.api({...common, url: CONTACT_URL})),
+      offer: yield* _(offer.api({...common, url: OFFER_URL})),
+      chat: yield* _(chat.api({...common, url: CHAT_URL})),
+    }
+  }).pipe(Effect.provide(FetchHttpClient.layer), Effect.runSync)
+}
+
+const userKeyPair = (user: SeedUser): PrivateKeyHolder =>
+  importPrivateKey({privateKeyPemBase64: user.privateKeyPemBase64})
+
+const apisForUser = (
+  user: SeedUser
+): Effect.Effect<{apis: Apis; keyPair: PrivateKeyHolder}, unknown> =>
+  Effect.gen(function* (_) {
+    const keyPair = userKeyPair(user)
+    const credentials = yield* _(
+      makeCredentials(user.phone, keyPair, user.keyPairV2)
+    )
+    return {apis: makeApis(credentials), keyPair}
+  })
+
+// ---------------------------------------------------------------------------
+// Progress logging
+// ---------------------------------------------------------------------------
+
+function makeProgressLogger(total: number, label: string): () => void {
+  let done = 0
+  return () => {
+    done += 1
+    if (done % 50 === 0 || done === total) {
+      console.log(`[${label}] ${done}/${total}`)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phase: register
+// ---------------------------------------------------------------------------
+
+const fakePhoneForIndex = (i: number): E164PhoneNumber =>
+  Schema.decodeSync(E164PhoneNumber)(`+${420777000000 + i}`)
+
+async function generateSeedUsers(
+  targetPhone: E164PhoneNumber
+): Promise<SeedState> {
+  const nDirect = Math.max(1, Math.ceil(N_USERS * DIRECT_RATIO))
+  const users: SeedUser[] = []
+  for (let i = 0; i < N_USERS; i++) {
+    const keyPair = generatePrivateKey()
+    const keyPairV2 = await generateKeyPair()
+    users.push({
+      index: i,
+      phone: fakePhoneForIndex(i),
+      direct: i < nDirect,
+      privateKeyPemBase64: keyPair.privateKeyPemBase64,
+      keyPairV2,
+    })
+  }
+  return {targetPhone, users, offers: [], chats: []}
+}
+
+/**
+ * Numbers this fake user imports as their contacts. Direct users import the
+ * target + a rolling window of neighbours (both direct and indirect fakes).
+ * Indirect users import only direct users — that makes them reachable as the
+ * target's 2nd degree without ever being the target's direct contact.
+ */
+function contactsForUser(user: SeedUser, state: SeedState): E164PhoneNumber[] {
+  const nDirect = state.users.filter((u) => u.direct).length
+  const phones: E164PhoneNumber[] = []
+  if (user.direct) {
+    phones.push(state.targetPhone)
+    for (let k = 1; k <= NEIGHBOURS_PER_USER; k++) {
+      const neighbour = state.users[(user.index + k) % state.users.length]
+      if (neighbour !== undefined && neighbour.index !== user.index) {
+        phones.push(neighbour.phone)
+      }
+    }
+  } else {
+    for (let k = 0; k < NEIGHBOURS_PER_USER; k++) {
+      const neighbour = state.users[(user.index * 7 + k) % nDirect]
+      if (neighbour !== undefined && neighbour.index !== user.index) {
+        phones.push(neighbour.phone)
+      }
+    }
+  }
+  return pipe(phones, Array.dedupe)
+}
+
+async function phaseRegister(targetPhone: E164PhoneNumber): Promise<void> {
+  let state = loadSeedState()
+  if (state !== undefined) {
+    console.log(
+      `Reusing ${state.users.length} users from ${SEED_USERS_FILE} (delete the file to regenerate keys).`
+    )
+    if (state.targetPhone !== targetPhone) {
+      throw new Error(
+        `TARGET_PHONE mismatch: seed file has ${state.targetPhone}, got ${targetPhone}. Delete ${SEED_USERS_FILE} to start over.`
+      )
+    }
+  } else {
+    console.log(`Generating ${N_USERS} fake users...`)
+    state = await generateSeedUsers(targetPhone)
+    saveSeedState(state)
+  }
+
+  // Write the numbers file for the in-app import step
+  mkdirSync(SEED_DIR, {recursive: true})
+  writeFileSync(
+    SEED_NUMBERS_FILE,
+    JSON.stringify(
+      {
+        targetPhone,
+        // The emulator user should import EXACTLY these (the direct users).
+        numbersToImportInApp: state.users
+          .filter((u) => u.direct)
+          .map((u) => u.phone),
+        // These must NOT be imported by the emulator user — they become
+        // genuine 2nd-degree connections through the direct users.
+        secondDegreeOnlyNumbers: state.users
+          .filter((u) => !u.direct)
+          .map((u) => u.phone),
+      },
+      null,
+      2
+    )
+  )
+  console.log(`Wrote ${SEED_NUMBERS_FILE}`)
+
+  const progress = makeProgressLogger(state.users.length, 'register')
+  const stateForClosure = state
+
+  const registerOne = (user: SeedUser): Effect.Effect<void, unknown> =>
+    Effect.gen(function* (_) {
+      const {apis} = yield* _(apisForUser(user))
+      yield* _(
+        apis.contact.createUser({
+          vexlNotificationToken: Option.none(),
+          firebaseToken: null,
+          expoToken: null,
+          publicKeyV2: Option.none(),
+        })
+      )
+      const contactHashes = yield* _(
+        Effect.forEach(contactsForUser(user, stateForClosure), hashPhoneNumber)
+      )
+      yield* _(
+        apis.contact.importContacts({contacts: contactHashes, replace: true})
+      )
+      progress()
+    })
+
+  const results = await Effect.runPromise(
+    Effect.forEach(
+      state.users,
+      (user) =>
+        registerOne(user).pipe(
+          Effect.either,
+          Effect.map((either) => ({user, either}))
+        ),
+      {concurrency: CONCURRENCY}
+    )
+  )
+
+  const failures = results.filter((r) => r.either._tag === 'Left')
+  for (const failure of failures.slice(0, 5)) {
+    console.error(
+      `register failed for user ${failure.user.index}:`,
+      failure.either._tag === 'Left' ? failure.either.left : undefined
+    )
+  }
+  console.log(
+    `register done: ${results.length - failures.length} ok, ${failures.length} failed`
+  )
+  if (failures.length > 0) process.exitCode = 1
+}
+
+// ---------------------------------------------------------------------------
+// Phase: offers
+// ---------------------------------------------------------------------------
+
+const OFFER_CITIES = [
+  {name: 'Prague', latitude: 50.0755, longitude: 14.4378},
+  {name: 'Brno', latitude: 49.1951, longitude: 16.6068},
+  {name: 'Ostrava', latitude: 49.8209, longitude: 18.2625},
+  {name: 'Plzen', latitude: 49.7384, longitude: 13.3736},
+  {name: 'Liberec', latitude: 50.7663, longitude: 15.0543},
+  {name: 'Olomouc', latitude: 49.5938, longitude: 17.2509},
+  {name: 'Vienna', latitude: 48.2082, longitude: 16.3738},
+  {name: 'Bratislava', latitude: 48.1486, longitude: 17.1077},
+  {name: 'Berlin', latitude: 52.52, longitude: 13.405},
+  {name: 'Dresden', latitude: 51.0504, longitude: 13.7373},
+]
+
+function buildOfferPublicPart({
+  globalIndex,
+  offerPublicKey,
+}: {
+  globalIndex: number
+  offerPublicKey: PublicKeyPemBase64
+}): OfferPublicPart {
+  const city =
+    OFFER_CITIES[globalIndex % OFFER_CITIES.length] ?? OFFER_CITIES[0]
+  if (city === undefined) throw new Error('No city')
+  const jitterLat = (((globalIndex * 13) % 40) - 20) * 0.01
+  const jitterLon = (((globalIndex * 7) % 40) - 20) * 0.01
+  return Schema.decodeUnknownSync(OfferPublicPart)({
+    offerPublicKey,
+    location: [
+      {
+        placeId: `seed-perf-offer-place-${globalIndex}`,
+        latitude: city.latitude + jitterLat,
+        longitude: city.longitude + jitterLon,
+        radius: 0.15,
+        address: `${city.name} seed location ${globalIndex}`,
+        shortAddress: city.name,
+      },
+    ],
+    offerDescription: `Seed offer #${globalIndex} — ${
+      globalIndex % 2 === 0 ? 'selling' : 'buying'
+    } sats for cash in ${city.name}. Perf-test data.`,
+    amountBottomLimit: 1000 * ((globalIndex % 10) + 1),
+    amountTopLimit: 10000 * ((globalIndex % 10) + 5),
+    feeState: globalIndex % 3 === 0 ? 'WITH_FEE' : 'WITHOUT_FEE',
+    feeAmount: globalIndex % 3 === 0 ? (globalIndex % 5) + 1 : 0,
+    locationState: ['IN_PERSON'],
+    paymentMethod: globalIndex % 4 === 0 ? ['BANK', 'REVOLUT'] : ['CASH'],
+    btcNetwork: globalIndex % 2 === 0 ? ['LIGHTING', 'ON_CHAIN'] : ['ON_CHAIN'],
+    currency: globalIndex % 3 === 0 ? 'EUR' : 'CZK',
+    spokenLanguages: globalIndex % 2 === 0 ? ['CZE', 'ENG'] : ['ENG'],
+    expirationDate: new Date(
+      Date.now() + 30 * 24 * 60 * 60 * 1000
+    ).toISOString(),
+    offerType: globalIndex % 2 === 0 ? 'SELL' : 'BUY',
+    activePriceState: 'NONE',
+    activePriceValue: 0,
+    activePriceCurrency: 'CZK',
+    active: true,
+    groupUuids: [],
+    listingType: 'BITCOIN',
+    authorClientVersion: CLIENT_SEMVER,
+  })
+}
+
+async function phaseOffers(): Promise<void> {
+  const state = loadSeedState()
+  if (state === undefined) {
+    throw new Error(`No ${SEED_USERS_FILE}. Run --phase register first.`)
+  }
+
+  const offersByCreator = new Map<number, number>()
+  for (const o of state.offers) {
+    offersByCreator.set(
+      o.creatorIndex,
+      (offersByCreator.get(o.creatorIndex) ?? 0) + 1
+    )
+  }
+  const usersToProcess = state.users.filter(
+    (u) => (offersByCreator.get(u.index) ?? 0) < OFFERS_PER_USER
+  )
+  console.log(
+    `Creating offers for ${usersToProcess.length}/${state.users.length} users (${OFFERS_PER_USER} each)...`
+  )
+
+  const progress = makeProgressLogger(usersToProcess.length, 'offers')
+  let processedSinceSave = 0
+
+  const createOffersForUser = (
+    user: SeedUser
+  ): Effect.Effect<SeedOffer[], unknown> =>
+    Effect.gen(function* (_) {
+      const {apis, keyPair} = yield* _(apisForUser(user))
+      const created: SeedOffer[] = []
+      const alreadyHave = offersByCreator.get(user.index) ?? 0
+      for (let k = alreadyHave; k < OFFERS_PER_USER; k++) {
+        const globalIndex = user.index * OFFERS_PER_USER + k
+        const offerKey = generatePrivateKey()
+
+        // Give the offer a real inbox on chat-service, like the app does
+        yield* _(apis.chat.createInbox({keyPair: offerKey}))
+
+        const result = yield* _(
+          createNewOfferForMyContacts({
+            offerApi: apis.offer,
+            contactApi: apis.contact,
+            publicPart: buildOfferPublicPart({
+              globalIndex,
+              offerPublicKey: offerKey.publicKeyPemBase64,
+            }),
+            ownerKeyPair: keyPair,
+            ownerKeyPairV2: user.keyPairV2,
+            countryPrefix: COUNTRY_PREFIX,
+            intendedConnectionLevel: 'ALL',
+            intendedClubs: {},
+            offerId: newOfferId(),
+            serverToClientHashesToHashedPhoneNumbersMap: HashMap.empty(),
+          })
+        )
+        created.push({
+          offerId: result.offerInfo.offerId,
+          adminId: result.adminId,
+          creatorIndex: user.index,
+          offerKeyPrivatePemBase64: offerKey.privateKeyPemBase64,
+        })
+      }
+      progress()
+      return created
+    })
+
+  const results = await Effect.runPromise(
+    Effect.forEach(
+      usersToProcess,
+      (user) =>
+        createOffersForUser(user).pipe(
+          Effect.either,
+          Effect.map((either) => ({user, either})),
+          Effect.tap(({either}) =>
+            Effect.sync(() => {
+              if (either._tag === 'Right') {
+                state.offers.push(...either.right)
+                processedSinceSave += 1
+                if (processedSinceSave >= 20) {
+                  processedSinceSave = 0
+                  saveSeedState(state)
+                }
+              }
+            })
+          )
+        ),
+      {concurrency: CONCURRENCY}
+    )
+  )
+  saveSeedState(state)
+
+  const failures = results.filter((r) => r.either._tag === 'Left')
+  for (const failure of failures.slice(0, 5)) {
+    console.error(
+      `offers failed for user ${failure.user.index}:`,
+      failure.either._tag === 'Left' ? failure.either.left : undefined
+    )
+  }
+  console.log(
+    `offers done: ${state.offers.length} offers exist, ${failures.length} users failed`
+  )
+  if (failures.length > 0) process.exitCode = 1
+}
+
+// ---------------------------------------------------------------------------
+// Phase: chats (send messaging requests to the target's own offers)
+// ---------------------------------------------------------------------------
+
+const REQUEST_TEXTS = [
+  'Hi! I would like to trade with you. Cash meetup possible?',
+  'Hello, is this offer still active? I am interested.',
+  'Hey there, I can do the amount you listed. When are you free?',
+  'Hi, long-time vexler here. Interested in your offer.',
+  'Ahoj, mel bych zajem o tvou nabidku. Muzeme se domluvit?',
+]
+
+const fetchAllOffersForMe = (
+  apis: Apis
+): Effect.Effect<ServerOffer[], unknown> =>
+  fetchAllPaginatedData({
+    fetchEffectToRun: (nextPageToken) =>
+      apis.offer.getOffersForMeModifiedOrCreatedAfterPaginated({
+        limit: 100,
+        nextPageToken:
+          nextPageToken === undefined
+            ? undefined
+            : Schema.decodeSync(Base64String)(nextPageToken),
+      }),
+  })
+
+async function phaseChats(): Promise<void> {
+  const state = loadSeedState()
+  if (state === undefined) {
+    throw new Error(`No ${SEED_USERS_FILE}. Run --phase register first.`)
+  }
+  const seedOfferIds = new Set<string>(state.offers.map((o) => o.offerId))
+  const usersWithChat = new Set(state.chats.map((c) => c.userIndex))
+  const senders = state.users
+    .filter((u) => u.direct && !usersWithChat.has(u.index))
+    .slice(0, Math.max(0, N_CHATS - state.chats.length))
+
+  if (senders.length === 0) {
+    console.log(`Nothing to do: ${state.chats.length} chats already recorded.`)
+    return
+  }
+  console.log(
+    `Sending ${senders.length} messaging requests to the target's own offers...`
+  )
+
+  const progress = makeProgressLogger(senders.length, 'chats')
+
+  const sendRequestForUser = (
+    user: SeedUser,
+    orderIndex: number
+  ): Effect.Effect<SeedChat, unknown> =>
+    Effect.gen(function* (_) {
+      const {apis, keyPair} = yield* _(apisForUser(user))
+
+      const allOffers = yield* _(fetchAllOffersForMe(apis))
+      const candidates = allOffers.filter((o) => !seedOfferIds.has(o.offerId))
+      if (candidates.length === 0) {
+        return yield* _(
+          Effect.fail(
+            new Error(
+              `Fake user ${user.index} sees no offers created by the target. ` +
+                'Did the emulator user import the fake numbers AND create own offers in the app?'
+            )
+          )
+        )
+      }
+
+      const decryptedEithers = yield* _(
+        Effect.forEach(
+          candidates,
+          (c) => decryptOffer(keyPair, user.keyPairV2)(c).pipe(Effect.either),
+          {concurrency: 5}
+        )
+      )
+      const targetOffers = pipe(
+        decryptedEithers,
+        Array.filterMap((either) =>
+          either._tag === 'Right' ? Option.some(either.right) : Option.none()
+        )
+      )
+      if (!Array.isNonEmptyArray(targetOffers)) {
+        return yield* _(
+          Effect.fail(
+            new Error(
+              `Fake user ${user.index} could not decrypt any target offer.`
+            )
+          )
+        )
+      }
+
+      const pickedOffer = targetOffers[orderIndex % targetOffers.length]
+      if (pickedOffer === undefined) {
+        return yield* _(Effect.fail(new Error('No offer picked')))
+      }
+      const receiverPublicKey = pickedOffer.publicPart.offerPublicKey
+
+      // The sender needs their own inbox for the request handshake
+      yield* _(apis.chat.createInbox({keyPair}))
+
+      const requestMessage: ChatMessage = {
+        uuid: generateChatMessageId(),
+        messageType: 'REQUEST_MESSAGING',
+        text:
+          REQUEST_TEXTS[user.index % REQUEST_TEXTS.length] ?? REQUEST_TEXTS[0],
+        time: now(),
+        myVersion: CLIENT_SEMVER,
+        senderPublicKey: keyPair.publicKeyPemBase64,
+      }
+      const cypher = yield* _(
+        taskEitherToEffect(messageToNetwork(receiverPublicKey)(requestMessage))
+      )
+      yield* _(
+        apis.chat.requestApprovalV2({
+          keyPair,
+          receiverPublicKey,
+          message: cypher,
+        })
+      )
+      progress()
+      return {
+        userIndex: user.index,
+        offerId: pickedOffer.offerId,
+        offerPublicKey: receiverPublicKey,
+        requestedAt: Date.now(),
+        messagesSent: 0,
+      }
+    })
+
+  const results = await Effect.runPromise(
+    Effect.forEach(
+      senders,
+      (user, orderIndex) =>
+        sendRequestForUser(user, orderIndex).pipe(
+          Effect.either,
+          Effect.map((either) => ({user, either}))
+        ),
+      {concurrency: Math.min(CONCURRENCY, 5)}
+    )
+  )
+
+  for (const result of results) {
+    if (result.either._tag === 'Right') state.chats.push(result.either.right)
+  }
+  saveSeedState(state)
+
+  const failures = results.filter((r) => r.either._tag === 'Left')
+  for (const failure of failures.slice(0, 5)) {
+    console.error(
+      `chat request failed for user ${failure.user.index}:`,
+      failure.either._tag === 'Left' ? failure.either.left : undefined
+    )
+  }
+  console.log(
+    `chats done: ${state.chats.length} requests recorded, ${failures.length} failed`
+  )
+  if (failures.length > 0) process.exitCode = 1
+}
+
+// ---------------------------------------------------------------------------
+// Phase: messages (requires the target to have APPROVED the requests in-app)
+// ---------------------------------------------------------------------------
+
+const MESSAGE_TEXTS = [
+  'Sounds good. What time works for you?',
+  'I can do tomorrow afternoon, around 15:00.',
+  'Great — where should we meet?',
+  'The usual spot near the main square works for me.',
+  'Perfect. What amount are we settling on?',
+  'Let me double check the price... deal.',
+  'Do you prefer on-chain or lightning?',
+  'Lightning is fine for this amount.',
+  'Alright, see you there.',
+  'By the way, thanks for the smooth communication!',
+]
+
+async function phaseMessages(): Promise<void> {
+  const state = loadSeedState()
+  if (state === undefined) {
+    throw new Error(`No ${SEED_USERS_FILE}. Run --phase register first.`)
+  }
+  const chatsToProcess = state.chats.filter(
+    (c) => c.messagesSent < MSGS_PER_CHAT
+  )
+  if (chatsToProcess.length === 0) {
+    console.log('Nothing to do: all recorded chats have their messages.')
+    return
+  }
+  console.log(
+    `Sending up to ${MSGS_PER_CHAT} messages for ${chatsToProcess.length} chats...`
+  )
+  const progress = makeProgressLogger(chatsToProcess.length, 'messages')
+
+  const recordMessageSent = (
+    seedChat: MutableSeedChat,
+    sentCount: number
+  ): void => {
+    seedChat.messagesSent = sentCount
+  }
+
+  const sendMessagesForChat = (
+    seedChat: MutableSeedChat
+  ): Effect.Effect<void, unknown> =>
+    Effect.gen(function* (_) {
+      const user = state.users.find((u) => u.index === seedChat.userIndex)
+      if (user === undefined) {
+        return yield* _(
+          Effect.fail(new Error(`No seed user ${seedChat.userIndex}`))
+        )
+      }
+      const {apis, keyPair} = yield* _(apisForUser(user))
+
+      for (let m = seedChat.messagesSent; m < MSGS_PER_CHAT; m++) {
+        const message: ChatMessage = {
+          uuid: generateChatMessageId(),
+          messageType: 'MESSAGE',
+          text: `${MESSAGE_TEXTS[m % MESSAGE_TEXTS.length] ?? '...'} (#${
+            m + 1
+          })`,
+          time: now(),
+          myVersion: CLIENT_SEMVER,
+          senderPublicKey: keyPair.publicKeyPemBase64,
+        }
+        const cypher = yield* _(
+          taskEitherToEffect(messageToNetwork(seedChat.offerPublicKey)(message))
+        )
+        yield* _(
+          apis.chat.sendMessage({
+            keyPair,
+            senderPublicKey: keyPair.publicKeyPemBase64,
+            receiverPublicKey: seedChat.offerPublicKey,
+            message: cypher,
+            messageType: 'MESSAGE',
+          })
+        )
+        yield* _(
+          Effect.sync(() => {
+            recordMessageSent(seedChat, m + 1)
+          })
+        )
+      }
+      progress()
+    })
+
+  const results = await Effect.runPromise(
+    Effect.forEach(
+      chatsToProcess,
+      (seedChat) =>
+        sendMessagesForChat(seedChat).pipe(
+          Effect.either,
+          Effect.map((either) => ({seedChat, either}))
+        ),
+      {concurrency: Math.min(CONCURRENCY, 5)}
+    )
+  )
+  saveSeedState(state)
+
+  const failures = results.filter((r) => r.either._tag === 'Left')
+  for (const failure of failures.slice(0, 5)) {
+    const error =
+      failure.either._tag === 'Left' ? failure.either.left : undefined
+    const notPermitted =
+      typeof error === 'object' &&
+      error !== null &&
+      '_tag' in error &&
+      error._tag === 'NotPermittedToSendMessageToTargetInboxError'
+    console.error(
+      `messages failed for chat of user ${failure.seedChat.userIndex}` +
+        (notPermitted
+          ? ' — the request is NOT approved yet. Approve it in the app and re-run --phase messages.'
+          : ':'),
+      notPermitted ? '' : error
+    )
+  }
+  console.log(
+    `messages done: ${results.length - failures.length} chats completed, ${failures.length} failed`
+  )
+  if (failures.length > 0) process.exitCode = 1
+}
+
+// ---------------------------------------------------------------------------
+// Phase: verify (read-only sanity check)
+// ---------------------------------------------------------------------------
+
+async function phaseVerify(): Promise<void> {
+  const state = loadSeedState()
+  if (state === undefined) {
+    throw new Error(`No ${SEED_USERS_FILE}. Run --phase register first.`)
+  }
+  const seedOfferIds = new Set<string>(state.offers.map((o) => o.offerId))
+  const sampleUsers = pipe(
+    [
+      state.users[0],
+      state.users[Math.floor(state.users.length / 2)],
+      state.users[state.users.length - 1],
+    ],
+    Array.filterMap(Option.fromNullable),
+    Array.dedupeWith((a, b) => a.index === b.index)
+  )
+
+  const verifyUser = (user: SeedUser): Effect.Effect<void, unknown> =>
+    Effect.gen(function* (_) {
+      const {apis, keyPair} = yield* _(apisForUser(user))
+      const first = yield* _(
+        fetchAllPaginatedData({
+          fetchEffectToRun: (nextPageToken) =>
+            apis.contact.fetchMyContactsPaginated({
+              level: 'FIRST',
+              limit: 500,
+              nextPageToken:
+                nextPageToken === undefined
+                  ? undefined
+                  : Schema.decodeSync(Base64String)(nextPageToken),
+            }),
+        })
+      )
+      const second = yield* _(
+        fetchAllPaginatedData({
+          fetchEffectToRun: (nextPageToken) =>
+            apis.contact.fetchMyContactsPaginated({
+              level: 'SECOND',
+              limit: 500,
+              nextPageToken:
+                nextPageToken === undefined
+                  ? undefined
+                  : Schema.decodeSync(Base64String)(nextPageToken),
+            }),
+        })
+      )
+      const offersForMe = yield* _(fetchAllOffersForMe(apis))
+      const fromTarget = offersForMe.filter((o) => !seedOfferIds.has(o.offerId))
+      let decryptedOk = 0
+      if (offersForMe.length > 0) {
+        const sample = offersForMe.slice(0, 3)
+        const decrypted = yield* _(
+          Effect.forEach(sample, (o) =>
+            decryptOffer(keyPair, user.keyPairV2)(o).pipe(Effect.either)
+          )
+        )
+        decryptedOk = decrypted.filter((d) => d._tag === 'Right').length
+      }
+      console.log(
+        `user ${user.index} (${user.phone}, ${
+          user.direct ? 'direct' : 'indirect'
+        }): 1st-degree=${first.length}, 2nd-degree=${second.length}, ` +
+          `offersForMe=${offersForMe.length} (from target: ${fromTarget.length}), ` +
+          `sample decrypt ok=${decryptedOk}`
+      )
+    })
+
+  for (const user of sampleUsers) {
+    const result = await Effect.runPromise(verifyUser(user).pipe(Effect.either))
+    if (result._tag === 'Left') {
+      console.error(`verify failed for user ${user.index}:`, result.left)
+      process.exitCode = 1
+    }
+  }
+  console.log(
+    `seed state: ${state.users.length} users, ${state.offers.length} offers, ${state.chats.length} chats`
+  )
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const targetPhoneRaw = process.env.TARGET_PHONE
+  if (PHASE === undefined) {
+    throw new Error(
+      'Usage: tsx tooling/dev/seed-perf-data.ts --phase <register|offers|chats|messages|verify>'
+    )
+  }
+  if (PHASE === 'register') {
+    if (targetPhoneRaw === undefined) {
+      throw new Error('TARGET_PHONE env var is required for --phase register')
+    }
+    await phaseRegister(Schema.decodeSync(E164PhoneNumber)(targetPhoneRaw))
+    return
+  }
+  if (PHASE === 'offers') {
+    await phaseOffers()
+    return
+  }
+  if (PHASE === 'chats') {
+    await phaseChats()
+    return
+  }
+  if (PHASE === 'messages') {
+    await phaseMessages()
+    return
+  }
+  if (PHASE === 'verify') {
+    await phaseVerify()
+    return
+  }
+  throw new Error(`Unknown phase: ${PHASE}`)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/tooling/dev/seed-perf-data.ts
+++ b/tooling/dev/seed-perf-data.ts
@@ -142,6 +142,75 @@ const CHAT_URL = Schema.decodeSync(ServiceUrl)(
   process.env.CHAT_MS ?? `http://localhost:${ports.chatService}`
 )
 
+// ---------------------------------------------------------------------------
+// Safety guard: refuse to seed anything but a local backend
+// ---------------------------------------------------------------------------
+
+// This script mass-mutates backends (hundreds of fake users, offers, chats).
+// Pointing it at a shared/staging/prod service via the *_MS overrides would
+// pollute real data, so we hard-fail unless every service host is local.
+const REMOTE_OVERRIDE_ENV = 'I_KNOW_WHAT_I_AM_DOING_SEEDING_REMOTE'
+
+const isLocalHost = (host: string): boolean => {
+  // URL.hostname keeps IPv6 in brackets, e.g. "[::1]"
+  const normalized =
+    host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host
+  return (
+    normalized === 'localhost' ||
+    normalized.endsWith('.localhost') ||
+    normalized === '127.0.0.1' ||
+    normalized === '::1'
+  )
+}
+
+function assertLocalServiceUrls(): void {
+  const services: Array<{name: string; url: ServiceUrl}> = [
+    {name: 'CONTACT_MS', url: CONTACT_URL},
+    {name: 'OFFER_MS', url: OFFER_URL},
+    {name: 'CHAT_MS', url: CHAT_URL},
+  ]
+
+  const nonLocal = pipe(
+    services,
+    Array.filterMap(({name, url}) => {
+      let host: string
+      try {
+        host = new URL(url).hostname
+      } catch {
+        return Option.some(`${name} (${url}) is not a valid URL`)
+      }
+      return isLocalHost(host)
+        ? Option.none()
+        : Option.some(`${name} points at non-local host "${host}" (${url})`)
+    })
+  )
+
+  if (!Array.isNonEmptyArray(nonLocal)) return
+
+  if (process.env[REMOTE_OVERRIDE_ENV] === '1') {
+    console.warn(
+      '\n############################################################\n' +
+        '# WARNING: seeding a NON-LOCAL backend with fake data!\n' +
+        `# ${REMOTE_OVERRIDE_ENV}=1 is set, so the local-only guard\n` +
+        '# is bypassed. This will write hundreds of fake users, offers\n' +
+        '# and chats to:\n' +
+        nonLocal.map((line) => `#   - ${line}`).join('\n') +
+        '\n############################################################\n'
+    )
+    return
+  }
+
+  console.error(
+    'Refusing to run: seed-perf-data.ts may only target a LOCAL backend.\n' +
+      nonLocal.map((line) => `  - ${line}`).join('\n') +
+      '\n\nThis script mass-creates fake users/offers/chats and must never touch\n' +
+      'shared/staging/prod services. Point CONTACT_MS/OFFER_MS/CHAT_MS at\n' +
+      'localhost, or (only if you truly mean it) re-run with ' +
+      `${REMOTE_OVERRIDE_ENV}=1.`
+  )
+  process.exit(1)
+}
+
 const CLIENT_SEMVER = Schema.decodeSync(SemverString)('1.44.0')
 const CLIENT_VERSION = Schema.decodeSync(VersionCode)(841)
 const PLATFORM = Schema.decodeSync(PlatformName)('ANDROID')
@@ -1010,6 +1079,7 @@ async function phaseVerify(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
+  assertLocalServiceUrls()
   const targetPhoneRaw = process.env.TARGET_PHONE
   if (PHASE === undefined) {
     throw new Error(

--- a/tooling/dev/tsconfig.json
+++ b/tooling/dev/tsconfig.json
@@ -10,6 +10,8 @@
     "noUncheckedIndexedAccess": false,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "allowJs": true,
+    "checkJs": false,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true


### PR DESCRIPTION
Users report the Android app feeling slow — laggy taps for the first minute after opening, seconds-long freezes when returning to the foreground, a sluggish Chats tab, and chats that open to a blank message area. On-device profiling with a realistic seeded account traced this to a handful of JS-thread hotspots: quadratic merges over offers/contacts, per-offer full-blob MMKV rewrites, untimed push-token fetches blocking sync, and identity-churning jotai selectors that remount entire lists. This PR fixes the confirmed hotspots.

## Methodology

The app (staging dev build, Hermes, Metro) was profiled on an Android emulator against a local backend — first with an empty account, then with a seeded realistic account (200 imported contacts, 700 offers, 30 chats x 40 messages, backed by 300 registered fake users). Measurements came from `adb dumpsys gfxinfo`, `am start -W`, React DevTools render profiles, and the app's own task-timing logs; every measured regression was traced to code before being reported. Full report with ranked findings: **[docs/performance_findings_2026_07.md](docs/performance_findings_2026_07.md)** (committed in this PR).

## Before / after (on-device verification, same emulator + seeded account)

| Metric | Before (pre-fix, report) | After (fixed working tree) | Delta |
|---|---|---|---|
| Native cold-start TTI | 1537 ms median | 1504 / 1511 ms (2 cold starts) | unchanged (not data-driven) |
| JS task: syncConnections (total) | 60.4 s | **7.5–7.8 s** | **~8×** |
| — inner "Sync connections" step | 45.7 s (untimed token fetch inline) | **4.0–4.2 s** | **~11×** |
| — "Update and reencrypt all offers" (silent MMKV stall) | ~15 s | **470–515 ms** (single batched write) | **~30×** |
| — clubs token-fetch residual (prev. round: ~37 s untimed `getNotificationTokenE` hangs) | part of 60.4 s | **eliminated** — "Check for clubs admission" 0 ms, "Sync all clubs" 4–5 ms (3 s `Effect.timeout` added in both club atoms) | fixed |
| JS task: refreshOffersAndEnsureInboxes | 4.3 s | **510–515 ms** ("Check offer inboxes" 4 ms) | **~8×** |
| JS task: fetchMessagesForAllInboxes (steady, 0 new msgs) | 5.4 s (130 unbounded parallel requests) | 5.4–5.6 s (concurrency capped at 6) | parity wall-time, JS/network burst removed |
| JS task: loadContactsFromDevice | 5.0 s | **3.6–3.7 s** | −28% |
| Startup first two offer refreshes | 4.3 / 2.3 s | **0.50 / 1.6 s** | ~4× |
| Offer refresh, steady state (pull-to-refresh, no new offers) | 149–217 ms | **132 / 39 / 38 ms** | ~4× on repeat refreshes (no-op merge returns same reference, no MMKV rewrite) |
| Resume task batch, total wall | ~60+ s (JS-thread saturated) | 22 s, of which last 13 s is only `refreshNotificationTokenOnResume` waiting on emulator-only exp.host DNS; all other tasks done in ~8 s | JS thread free after ~8 s |
| Tab-nav profile: total commit time | 2163 ms / 24 commits | **~1118 ms / 21 commits** | −48% |
| Chats tab render | avg 432 / max 1007 ms; 20× Memo(ChatListItem)+Swipeable remount every visit | first-mount commit 433 ms; **revisit commits 21–95 ms**; every ChatListItem rendered exactly once | **~10–20× on revisit; remount storm gone** |
| Chat open → full history visible | 2–3.3 s (shell 1.4 s); ViewHolderCollection 81 renders / 812 ms | shell commit 306 ms + history commit 620 ms (~1.06 s total commit time); ViewHolderCollection 21 renders; opened correctly scrolled to newest message | **~2–3× faster, 4× fewer list re-renders** |
| Data integrity after 2 cold starts + full session | — | 400 marketplace offers, 100 own offers, 30 conversations with correct previews, 200 contacts / reach 300, zero MMKV parse errors | intact |

Absolute numbers are dev-build inflated; deltas are the meaningful signal. Functional checks (pull-to-refresh, chat open/send, list previews updating, filter toggles, data integrity) all passed; no new errors in logs across two cold starts and ~10 min of use.

## Fixes by finding (numbers reference the docs report)

**Finding 1 — syncConnections O(offers²) MMKV-rewrite stall (`state/connections`)**
- Per-offer connection updates are computed in memory and persisted in chunks of 10 offers (final flush via `Effect.ensuring`) instead of rewriting the whole `offer-to-connections` blob once per offer. Encryption/upload behavior per offer is unchanged.
- Orphan-record cleanup uses a `Set` lookup instead of O(n²) `includes`.
- The new-connections reporting block is forked as a daemon with `getNotificationTokenE()` bounded by a 3 s `Effect.timeout`, so a hanging push-token fetch can no longer stall the whole sync. The same 3 s timeout was added to the two club atoms (`checkForClubsAdmissionActionAtom`, `refreshClubsActionAtom`) that had the identical untimed call.

**Finding 2 — monolithic MMKV persisted atoms (`utils/atomUtils/atomWithParsedMmkvStorage.ts`)**
- O(1) in-memory own-write detection replaces the full-blob JSON.parse authorship check in the change listener; the author key is no longer embedded in writes (old blobs still decode).
- Removed the redundant double decode for foreign writes and the per-write `Schema.extend`; decoder/encoder built once per atom.
- Single startup decode: `onMount` only re-decodes when the raw stored string actually changed.
- Write coalescing: bursts of writes to the same atom persist only the newest value (last-write-wins) behind the existing `InteractionManager` deferral.
- New 13-test jest suite; the mobile `test` script is re-enabled (the pre-existing `@sentry/react-native` jest transform failure that had disabled it is fixed), so 21 suites / 154 tests now run in CI.

**Finding 3 — offer refresh pipeline O(N²) merge + unconditional writes (`state/marketplace`)**
- Map/Set-keyed O(n) merge preserving object identity of unchanged offers; a no-op refresh returns the same array reference and skips the persisted-state write (and derived-atom invalidation) entirely.
- Set-based, per-offer-memoized visible-common-friends derivation shared across all call sites; the Sentry side effect moved out of the atom getter.
- Removed-offers reconciliation throttled to a 10-minute cadence instead of POSTing every stored offer id on every refresh.

**Finding 4 — one HTTP roundtrip per inbox on every resume (`state/chat`)**
- Full-inbox sweep throttled (5 s, collapsing duplicate resume-burst triggers, with throttle rollback if the sweep fails) and per-inbox fetches capped at concurrency 6. The proper fix (batched server endpoint) is deferred pending privacy review — see below.

**Finding 5 — Chats tab remounts every row on any messaging-state change (`ChatsList`)**
- `selectAtom` gains a reference-based array equivalence and `splitAtom` rows are keyed by chat id, so row atoms and FlashList keys are stable; only the changed row re-renders.

**Finding 6 — chat open re-keys the whole message list (`ChatDetailScreen`)**
- List items are reused by their stable builder key and `splitAtom` is keyed by `item.key`, so appending one message no longer regenerates every row atom; FlashList props hoisted/memoized.

**Finding 7 — contacts pipeline O(n²) passes (`state/contacts`)**
- Resume-time device-contacts diff preserves identity of unchanged contacts and skips the store write when nothing changed; Set-keyed single-pass dedupes replace O(n²) `Array.dedupeWith`; `Array.partition` replaces a spread-in-reduce partition. Hashing untouched.

**Finding 8 — empty-marketplace 5 s poll (`EmptyList`)**
- Poll backs off 5 s → 30 s → 60 s and only runs when the offer store is truly empty (not merely all-hidden).

**Finding 9 — self-sustaining owner-private-payload re-upload loop (`state/marketplace`)**
- The ensure step skips when there is nothing to upload and reuses `updateMyOfferPrivatePayloadActionAtom`, so the uploaded owner private payload is persisted locally and the re-encrypt/re-upload loop converges.

**Finding 10 — strictly sequential per-message decryption (`packages/resources-utils`)**
- Per-message decrypts run at concurrency 6 (concurrency only; no KDF or other crypto changes).

**Report caveats A/B — in-app log store + debug notification stringify**
- The in-app log store is now a 1000-line ring buffer with an in-memory cache instead of an unbounded full-blob read+rewrite per log line; the per-stream-event pretty `JSON.stringify` is gated behind the debug-notifications toggle.

Plus a safety guard found during verification: the empty-inbox cleanup task now skips when the offers store has not hydrated, preventing destructive inbox deletion on a slow/failed hydration.

## Reviewer attention: crypto-adjacent change (Finding 9)

The owner-private-payload ensure step now persists the uploaded payload locally by reusing `updateMyOfferPrivatePayloadActionAtom`. The encryption/upload call and its inputs are byte-identical to before — only local persistence was added — but since it touches the owner private payload path, please double-check with offers created by older app versions that the re-encrypted payload decrypts correctly and `ownershipInfo`/private part stay consistent.

## Explicitly out of scope (follow-ups)

- **Batched "which inboxes have messages" server endpoint** (Finding 4 proper fix) — needs a privacy/linkability review before any server work, per the report.
- **KDF migration** away from the legacy 2× PBKDF2-2000 per message (Finding 10) — crypto change, separate effort.
- **Sharded MMKV persistence** (per-inbox/per-chat/paged-offers keys, Finding 2e) — larger persistence-format change requiring a migration path.
- **Startup fixed costs** (eager parsing of all 14 locales, side-effect import graph, splash bounce — Finding 11).

## Notes

- Commit `df9a3934d` ("fix: repeating task layer blocks dependent layers from building") is a pre-existing fix on this branch and rides along in this PR.
- `pnpm turbo:typecheck`, `turbo:format`, `turbo:lint`, and `turbo:test` pass; on-device re-verification confirmed data integrity (offers, chats, contacts) across cold starts with zero MMKV parse errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added performance seeding workflow and new debug actions for importing contacts, approving chat requests, and generating test chat/message data.
  * Improved app diagnostics for silent local data loss on startup.
  * Enhanced app logs behavior with cached log lines and custom logging toggle.
* **Bug Fixes**
  * Improved stability of chat/messages list rendering by keeping row identities consistent.
  * Made empty marketplace refreshes smarter and reduced unnecessary refresh work; added safer inbox cleanup during temporary desyncs.
  * Added timeouts to prevent stalled background flows.
* **Performance**
  * Reduced redundant storage updates and added bounded concurrency for message/inbox processing.
* **Tests/Documentation**
  * Added Jest coverage for MMKV-backed storage and updated performance-seeding documentation plus the July 2026 findings report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->