### PR TITLE
fix #1984: Contact images are broken on iOS fro legacy contact images

### DIFF
--- a/apps/mobile/src/components/CommonFriends/index.tsx
+++ b/apps/mobile/src/components/CommonFriends/index.tsx
@@ -6,16 +6,15 @@ import {
   type CommonFriend,
 } from '@vexl-next/ui'
 import {Array, Effect, HashMap, Option, pipe} from 'effect'
-import {Contact, ContactField} from 'expo-contacts'
 import {useAtomValue, useStore} from 'jotai'
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
-import {Platform} from 'react-native'
 import {
   type CommonFriendsClub,
   type RootStackScreenProps,
 } from '../../navigationTypes'
 import createImportedContactsForHashesAtom from '../../state/contacts/atom/createImportedContactsForHashesAtom'
 import {type StoredContactWithComputedValues} from '../../state/contacts/domain'
+import {getContactImageUri} from '../../state/contacts/getContactImageUri'
 import {useTranslation} from '../../utils/localization/I18nProvider'
 import {formatInteger} from '../../utils/localization/formatting'
 import {formattingLocaleAtom} from '../../utils/localization/formattingLocaleAtom'
@@ -40,21 +39,10 @@ const resolveContactImage = (
     onNone: () => Effect.succeed(null),
     onSome: (id) =>
       pipe(
-        Effect.tryPromise(() =>
-          new Contact(id).getDetails([ContactField.IMAGE])
+        Effect.tryPromise(() => getContactImageUri(id)),
+        Effect.map((uri) =>
+          uri ? {hash: contact.computedValues.hash, uri} : null
         ),
-        Effect.map((resolved) => {
-          const uri = resolved.image
-
-          // TODO: lets monitor this issue in https://github.com/vexl-it/vexl/issues/1984
-          // and then change back to previous behaviour once fixed
-          if (
-            !uri ||
-            (Platform.OS === 'ios' && resolved.id.includes(':ABPerson'))
-          )
-            return null
-          return {hash: contact.computedValues.hash, uri}
-        }),
         Effect.catchAll(() => Effect.succeed(null))
       ),
   })

--- a/apps/mobile/src/components/ContactPictureImage.tsx
+++ b/apps/mobile/src/components/ContactPictureImage.tsx
@@ -1,10 +1,9 @@
 import {Option} from 'effect'
-import {Contact, ContactField} from 'expo-contacts'
 import React, {useEffect, useState} from 'react'
-import {Platform} from 'react-native'
 import {FilterImage} from 'react-native-svg/filter-image'
 import {getTokens} from 'tamagui'
 import {type NonUniqueContactId} from '../state/contacts/domain'
+import {getContactImageUri} from '../state/contacts/getContactImageUri'
 
 const GRAYSCALE_FILTER = [
   {name: 'feColorMatrix', type: 'saturate', values: 0},
@@ -22,11 +21,6 @@ interface Props {
   readonly borderRadius?: number | string
   readonly br?: number | string
   readonly objectFit?: ObjectFit
-}
-
-interface ImageDetails {
-  uri: string
-  isABImageOnIos: boolean
 }
 
 function buildRadiusTokenMap(): Record<string, number> {
@@ -81,35 +75,28 @@ export default function ContactPictureImage({
   br,
   objectFit,
 }: Props): React.ReactElement | null {
-  const [imageDetails, setImageDetails] = useState<ImageDetails | null>(null)
+  const [imageUri, setImageUri] = useState<string | null>(null)
 
   useEffect(() => {
+    setImageUri(null)
     if (Option.isNone(contactId)) return
 
-    setImageDetails(null)
+    let cancelled = false
 
-    void new Contact(contactId.value)
-      .getDetails([ContactField.IMAGE])
-      .then((contact) => {
-        const contactImageUri = contact.image
-
-        if (contactImageUri) {
-          setImageDetails({
-            uri: contactImageUri,
-            isABImageOnIos: !!(
-              Platform.OS === 'ios' && contact.id.includes(':ABPerson')
-            ),
-          })
-        }
+    void getContactImageUri(contactId.value)
+      .then((uri) => {
+        if (!cancelled) setImageUri(uri)
       })
       .catch((err) => {
-        console.debug('Error loading image', err)
+        if (!cancelled) console.debug('Error loading image', err)
       })
+
+    return () => {
+      cancelled = true
+    }
   }, [contactId])
 
-  // TODO: lets monitor this issue in https://github.com/vexl-it/vexl/issues/1984
-  // and then change back to previous behaviour once fixed
-  if (!imageDetails || imageDetails?.isABImageOnIos) {
+  if (!imageUri) {
     return fallback ? <>{fallback}</> : null
   }
 
@@ -124,7 +111,7 @@ export default function ContactPictureImage({
       filters={grayscale ? GRAYSCALE_FILTER : undefined}
       width={width}
       height={height}
-      source={{uri: imageDetails.uri}}
+      source={{uri: imageUri}}
     />
   )
 }

--- a/apps/mobile/src/state/contacts/getContactImageUri.ts
+++ b/apps/mobile/src/state/contacts/getContactImageUri.ts
@@ -1,0 +1,22 @@
+import {Contact} from 'expo-contacts'
+import {Platform} from 'react-native'
+import {type NonUniqueContactId} from './domain'
+
+// expo-contacts returns a raw filesystem path on iOS (no file:// scheme). For
+// contacts synced from legacy sources the contact id — and thus the cached
+// image filename — contains a colon (`<uuid>:ABPerson`), which React Native's
+// new architecture misparses as a scheme separator, leaving the image
+// unloadable (https://github.com/vexl-it/vexl/issues/1984). An explicit
+// file:// scheme with percent-encoded segments keeps the uri unambiguous.
+function toFileUri(path: string): string {
+  return `file://${path.split('/').map(encodeURIComponent).join('/')}`
+}
+
+export async function getContactImageUri(
+  contactId: NonUniqueContactId
+): Promise<string | null> {
+  const uri = await new Contact(contactId).getThumbnail()
+  if (!uri) return null
+
+  return Platform.OS === 'ios' && uri.startsWith('/') ? toFileUri(uri) : uri
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact photo loading so common-friend and contact pictures resolve more reliably across platforms.
  * Fixed handling of iOS contact image paths to avoid display issues for certain contact IDs.
  * Kept fallback behavior intact when a contact image can’t be loaded, so the app still shows the fallback image or nothing as appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->