### PR TITLE
fix #2570: Copy fix

### DIFF
--- a/apps/mobile/src/components/CRUDOfferFlow/atoms/offerFormStateAtoms.ts
+++ b/apps/mobile/src/components/CRUDOfferFlow/atoms/offerFormStateAtoms.ts
@@ -1204,7 +1204,7 @@ export const offerFormMolecule = molecule(() => {
         const confirmed = yield* _(
           set(globalDialogAtom, {
             title: t('editOffer.pauseOfferTitle'),
-            subtitle: t('editOffer.pauseOfferDescription'),
+            subtitle: t('editOffer.pauseOfferDescriptionOffer'),
             positiveButtonText: t('editOffer.yesPause'),
             negativeButtonText: t('common.cancel'),
           })

--- a/packages/localization/base.json
+++ b/packages/localization/base.json
@@ -792,6 +792,7 @@
   "editOffer.deleteOfferDescriptionShort": "Once deleted, it's gone for good. Want to continue?",
   "editOffer.pauseOfferTitle": "Pause offer?",
   "editOffer.pauseOfferDescription": "Your trade will be hidden from the market until you resume it.",
+  "editOffer.pauseOfferDescriptionOffer": "Your offer will be hidden from the market until you resume it.",
   "editOffer.yesPause": "Yes, pause",
   "editOffer.activeOffer": "Active offer",
   "editOffer.pausedOffer": "Paused offer",

--- a/packages/localization/en-base.json
+++ b/packages/localization/en-base.json
@@ -792,6 +792,7 @@
   "editOffer.deleteOfferDescriptionShort": "Once deleted, it's gone for good. Want to continue?",
   "editOffer.pauseOfferTitle": "Pause offer?",
   "editOffer.pauseOfferDescription": "Your trade will be hidden from the market until you resume it.",
+  "editOffer.pauseOfferDescriptionOffer": "Your offer will be hidden from the market until you resume it.",
   "editOffer.yesPause": "Yes, pause",
   "editOffer.activeOffer": "Active offer",
   "editOffer.pausedOffer": "Paused offer",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the pause offer confirmation message to use more offer-specific wording.
  * Added the corresponding localized string in the base English localization set to keep the updated message consistent across the pause flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->