### PR TITLE
Ignore duplicate metric inserts

### DIFF
--- a/apps/metrics-service/src/db/MetricsDbService/index.ts
+++ b/apps/metrics-service/src/db/MetricsDbService/index.ts
@@ -12,17 +12,13 @@ import {
 import {
   createInsertMetricRecord,
   type InsertMetricsParams,
-  type MessageWithUuidAlreadyStoredError,
 } from './queries/createInsertMetricRecord'
 import {createQueryAllLastReportedByService} from './queries/createQueryAllLastReportedByService'
 
 export interface MetricsDbOperations {
   insertMetricRecord: (
     record: InsertMetricsParams
-  ) => Effect.Effect<
-    void,
-    UnexpectedServerError | MessageWithUuidAlreadyStoredError
-  >
+  ) => Effect.Effect<void, UnexpectedServerError>
 
   insertDeadMetricRecord: (
     record: InsertDeadMetricsParams

--- a/apps/metrics-service/src/db/MetricsDbService/queries/createInsertMetricRecord.ts
+++ b/apps/metrics-service/src/db/MetricsDbService/queries/createInsertMetricRecord.ts
@@ -4,13 +4,6 @@ import {UnexpectedServerError} from '@vexl-next/domain/src/general/commonErrors'
 import {Uuid} from '@vexl-next/domain/src/utility/Uuid.brand'
 import {Effect, flow, Schema} from 'effect'
 
-export class MessageWithUuidAlreadyStoredError extends Schema.TaggedError<MessageWithUuidAlreadyStoredError>(
-  'MessageWithUuidAlreadyStoredError'
-)('MessageWithUuidAlreadyStoredError', {
-  cause: Schema.Unknown,
-  message: Schema.String,
-}) {}
-
 export const InsertMetricsParams = Schema.Struct({
   name: Schema.String,
   uuid: Uuid,
@@ -44,37 +37,18 @@ export const createInsertMetricRecord = Effect.gen(function* (_) {
           ${params.type},
           ${sql.json(params.attributes ?? null)}::jsonb
         )
+      ON CONFLICT (UUID) DO NOTHING
     `,
   })
 
   return flow(
     query,
-    Effect.catchAll(
-      (
-        e
-      ): Effect.Effect<
-        void,
-        MessageWithUuidAlreadyStoredError | UnexpectedServerError
-      > => {
-        if (
-          e._tag === 'SqlError' &&
-          (e.cause as any)?.code === '23505' &&
-          (e.cause as any)?.constraint_name === 'metrics_uuid_key'
-        ) {
-          const cause = e.cause as any
-          return Effect.fail(
-            new MessageWithUuidAlreadyStoredError({
-              message: String(cause.detail),
-              cause: e,
-            })
-          )
-        }
-        return Effect.zipRight(
-          Effect.logError('Error in insertMetricRecord', e),
-          Effect.fail(new UnexpectedServerError({status: 500, cause: e}))
-        )
-      }
-    ),
+    Effect.catchAll((e): Effect.Effect<void, UnexpectedServerError> => {
+      return Effect.zipRight(
+        Effect.logError('Error in insertMetricRecord', e),
+        Effect.fail(new UnexpectedServerError({status: 500, cause: e}))
+      )
+    }),
     Effect.withSpan('insertMetricRecord query')
   )
 })

--- a/apps/metrics-service/src/metricsConsumer.ts
+++ b/apps/metrics-service/src/metricsConsumer.ts
@@ -14,12 +14,7 @@ const consumeMessage = (
 
     yield* _(Effect.log('Received message', message))
     const metricsDb = yield* _(MetricsDbService)
-    yield* _(
-      metricsDb.insertMetricRecord(message),
-      Effect.catchTag('MessageWithUuidAlreadyStoredError', (e) =>
-        Effect.logWarning('Message with uuid already stored', message)
-      )
-    )
+    yield* _(metricsDb.insertMetricRecord(message))
 
     yield* _(
       metricsDb.insertLastReportedByService({

--- a/apps/metrics-service/src/routes/reportNotificationInteraction.ts
+++ b/apps/metrics-service/src/routes/reportNotificationInteraction.ts
@@ -43,13 +43,7 @@ export const reportNotificationInteraction = HttpApiBuilder.handler(
           uuid: query.uuid,
           value: query.count,
           attributes: dataToSave,
-        }),
-        Effect.catchTag('MessageWithUuidAlreadyStoredError', () =>
-          Effect.zipRight(
-            Effect.logInfo('Message with uuid already exists. Not inserting.'),
-            Effect.void
-          )
-        )
+        })
       )
 
       return {}


### PR DESCRIPTION
## What changed

- make metric inserts idempotent with `ON CONFLICT (uuid) DO NOTHING`
- remove the custom duplicate-UUID error and the now-obsolete catch branches
- preserve normal error reporting for all other database failures

## Why

Repeated notification telemetry can submit an already-stored UUID. PostgreSQL returns unique-violation code `23505`, but the service checked a non-existent `constraint_name` field while the driver exposes `constraint`. Duplicate events were therefore returned as HTTP 500 responses and retried three more times by the mobile client.

Handling the conflict directly in PostgreSQL makes duplicate reporting safe under retries and concurrent requests without depending on driver-specific error shapes.

## Impact

Duplicate telemetry remains stored only once and is acknowledged successfully instead of producing misleading 5xx responses. Other database errors still fail normally.

## Validation

- `pnpm turbo:typecheck`
- `pnpm turbo:format`
- `pnpm turbo:lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate metric records (same UUID) are now safely ignored at insertion time, preventing unnecessary error handling during ingestion.
  * Duplicate-identifier insert failures no longer trigger dedicated “already stored” handling in both message consumption and report notification interaction flows.
  * Other unexpected database errors continue to be surfaced consistently for clearer reliability and monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->