### PR TITLE
Target selected Android device during release install

### DIFF
--- a/apps/mobile/expo-plugins/android-install-release-plugin.js
+++ b/apps/mobile/expo-plugins/android-install-release-plugin.js
@@ -133,8 +133,12 @@ afterEvaluate {
                         return match.find() ? match.group(1) : null
                     }
                     androidSerial = emulatorSerials.find { serial ->
-                        def avdNameOutput = vexlCommandOutput([adbExecutable, "-s", serial, "emu", "avd", "name"])
-                        return avdNameOutput.readLines().find { line -> line.trim() }?.trim() == androidAvdName
+                        try {
+                            def avdNameOutput = vexlCommandOutput([adbExecutable, "-s", serial, "emu", "avd", "name"])
+                            return avdNameOutput.readLines().find { line -> line.trim() }?.trim() == androidAvdName
+                        } catch (Exception ignored) {
+                            return false
+                        }
                     }
                     if (androidSerial == null) {
                         throw new GradleException("Could not find the selected Android emulator " + androidAvdName + " after Expo started it.")

--- a/apps/mobile/expo-plugins/android-install-release-plugin.js
+++ b/apps/mobile/expo-plugins/android-install-release-plugin.js
@@ -73,6 +73,18 @@ def vexlRunCommand = { List command ->
     }
 }
 
+def vexlCommandOutput = { List command ->
+    def process = new ProcessBuilder(command.collect { item -> item.toString() }).redirectErrorStream(true).start()
+    def output = process.inputStream.getText("UTF-8")
+    def exitCode = process.waitFor()
+
+    if (exitCode != 0) {
+        throw new GradleException("Command failed with exit code " + exitCode + ": " + command.join(" ") + "\\n" + output)
+    }
+
+    return output
+}
+
 afterEvaluate {
     if (tasks.findByName("installRelease") == null) {
         tasks.register("installRelease") {
@@ -109,10 +121,29 @@ afterEvaluate {
                     apkToInstall = signedApk
                 }
 
-                def adbArguments = []
+                def adbExecutable = vexlResolveExistingExecutable(new File(vexlAndroidSdkDir(), "platform-tools/adb")).absolutePath
                 def androidSerial = System.getenv("ANDROID_SERIAL")
-                if (androidSerial != null && androidSerial.trim()) {
-                    adbArguments.addAll(["-s", androidSerial.trim()])
+                androidSerial = androidSerial != null ? androidSerial.trim() : null
+
+                def androidAvdName = System.getenv("VEXL_ANDROID_AVD_NAME")
+                androidAvdName = androidAvdName != null ? androidAvdName.trim() : null
+                if (!androidSerial && androidAvdName) {
+                    def emulatorSerials = vexlCommandOutput([adbExecutable, "devices"]).readLines().findResults { line ->
+                        def match = line =~ /^(emulator-[0-9]+)\\s+device\\b/
+                        return match.find() ? match.group(1) : null
+                    }
+                    androidSerial = emulatorSerials.find { serial ->
+                        def avdNameOutput = vexlCommandOutput([adbExecutable, "-s", serial, "emu", "avd", "name"])
+                        return avdNameOutput.readLines().find { line -> line.trim() }?.trim() == androidAvdName
+                    }
+                    if (androidSerial == null) {
+                        throw new GradleException("Could not find the selected Android emulator " + androidAvdName + " after Expo started it.")
+                    }
+                }
+
+                def adbArguments = []
+                if (androidSerial) {
+                    adbArguments.addAll(["-s", androidSerial])
                 }
 
                 adbArguments.addAll(["install", "-r", "-d"])
@@ -125,7 +156,7 @@ afterEvaluate {
                 adbArguments << apkToInstall.absolutePath
 
                 println "Installing " + apkToInstall.absolutePath
-                vexlRunCommand([vexlResolveExistingExecutable(new File(vexlAndroidSdkDir(), "platform-tools/adb")).absolutePath] + adbArguments)
+                vexlRunCommand([adbExecutable] + adbArguments)
             }
         }
     }

--- a/tooling/dev/dev-mobile.ts
+++ b/tooling/dev/dev-mobile.ts
@@ -883,9 +883,7 @@ async function main(): Promise<void> {
     ...generated.vars,
     // Expo resolves Android's --device by display/AVD name, but the custom
     // release Gradle installer targets devices through ANDROID_SERIAL.
-    ...(options.androidSerial === undefined
-      ? {}
-      : {ANDROID_SERIAL: options.androidSerial}),
+    ANDROID_SERIAL: options.androidSerial,
     // Do not inherit a stale selector from the parent shell. This is only set
     // for a stopped AVD selected by this picker.
     VEXL_ANDROID_AVD_NAME: options.androidAvdName,

--- a/tooling/dev/dev-mobile.ts
+++ b/tooling/dev/dev-mobile.ts
@@ -83,6 +83,7 @@ type BackendTarget =
 interface CliOptions {
   readonly platform: Platform
   readonly device?: string
+  readonly androidSerial?: string
   readonly deviceKind?: DeviceKind
   readonly selectDevice: boolean
   readonly backend: BackendTarget
@@ -229,6 +230,7 @@ function printHelp(): void {
 interface DeviceChoice {
   readonly id: string
   readonly expoName: string
+  readonly androidSerial?: string
   readonly label: string
   readonly kind: DeviceKind
 }
@@ -386,6 +388,7 @@ function findAndroidDevices(): readonly DeviceChoice[] {
       (device): DeviceChoice => ({
         id: device.id,
         expoName: device.model ?? `Device ${device.id}`,
+        androidSerial: device.id,
         label: `[connected] ${device.model ?? device.id} (${device.id})`,
         kind: 'physical',
       })
@@ -408,6 +411,7 @@ function findAndroidDevices(): readonly DeviceChoice[] {
       return {
         id: device.id,
         expoName: avdName ?? device.model ?? device.id,
+        androidSerial: device.id,
         avdName,
         label: `[running emulator] ${avdName ?? device.model ?? device.id} (${device.id})`,
         kind: 'virtual',
@@ -768,6 +772,9 @@ function printSummary(
   console.log('dev:mobile')
   console.log(`  platform:    ${options.platform}`)
   console.log(`  device:      ${options.device ?? '(default)'}`)
+  if (options.androidSerial !== undefined) {
+    console.log(`  adb serial:  ${options.androidSerial}`)
+  }
   console.log(`  variant:     ${options.variant}`)
   console.log(
     `  backend:     ${describeBackend(options.backend)} → ENV_PRESET=${generated.preset}`
@@ -822,6 +829,7 @@ async function main(): Promise<void> {
       : {
           ...parsedOptions,
           device: selectedDevice.expoName,
+          androidSerial: selectedDevice.androidSerial,
           deviceKind: selectedDevice.kind,
           selectDevice: false,
         }
@@ -869,6 +877,11 @@ async function main(): Promise<void> {
   const env: Record<string, string | undefined> = {
     ...process.env,
     ...generated.vars,
+    // Expo resolves Android's --device by display/AVD name, but the custom
+    // release Gradle installer targets devices through ANDROID_SERIAL.
+    ...(options.androidSerial === undefined
+      ? {}
+      : {ANDROID_SERIAL: options.androidSerial}),
   }
 
   if (willPrebuild) {

--- a/tooling/dev/dev-mobile.ts
+++ b/tooling/dev/dev-mobile.ts
@@ -84,6 +84,7 @@ interface CliOptions {
   readonly platform: Platform
   readonly device?: string
   readonly androidSerial?: string
+  readonly androidAvdName?: string
   readonly deviceKind?: DeviceKind
   readonly selectDevice: boolean
   readonly backend: BackendTarget
@@ -231,6 +232,7 @@ interface DeviceChoice {
   readonly id: string
   readonly expoName: string
   readonly androidSerial?: string
+  readonly androidAvdName?: string
   readonly label: string
   readonly kind: DeviceKind
 }
@@ -429,6 +431,7 @@ function findAndroidDevices(): readonly DeviceChoice[] {
       (name): DeviceChoice => ({
         id: name,
         expoName: name,
+        androidAvdName: name,
         label: `[emulator] ${name}`,
         kind: 'virtual',
       })
@@ -830,6 +833,7 @@ async function main(): Promise<void> {
           ...parsedOptions,
           device: selectedDevice.expoName,
           androidSerial: selectedDevice.androidSerial,
+          androidAvdName: selectedDevice.androidAvdName,
           deviceKind: selectedDevice.kind,
           selectDevice: false,
         }
@@ -882,6 +886,9 @@ async function main(): Promise<void> {
     ...(options.androidSerial === undefined
       ? {}
       : {ANDROID_SERIAL: options.androidSerial}),
+    // Do not inherit a stale selector from the parent shell. This is only set
+    // for a stopped AVD selected by this picker.
+    VEXL_ANDROID_AVD_NAME: options.androidAvdName,
   }
 
   if (willPrebuild) {


### PR DESCRIPTION
## What changed

- preserve the ADB serial separately from Expo's Android device name when using the `dev:mobile` picker
- pass the selected serial to native commands through `ANDROID_SERIAL`
- display the resolved ADB serial in the command summary

## Why

Expo resolves Android's `--device` argument by display or AVD name. Release builds can fall back to Vexl's custom Gradle `installRelease` task, which invokes `adb` directly and only targets a specific device when `ANDROID_SERIAL` is set. Previously that serial was discarded by the picker, so `adb install` was ambiguous whenever multiple Android devices were attached.

iOS is unaffected because selected devices already use their UDID and installation remains handled by Expo's iOS device manager.

## Verification

- `pnpm turbo:typecheck`
- `pnpm turbo:format`
- `pnpm turbo:lint`
- Android picker dry run for a physical device and a running emulator
- iOS picker dry run confirming the selected UDID is passed to `expo run:ios`
- end-to-end Android release build and install with multiple devices attached; `installRelease` successfully targeted the selected `emulator-5554`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Android device/emulator targeting during development builds.
  * When available, the resolved ADB serial is shown in the build/run summary.
  * If an AVD name is provided without a serial, the correct running emulator is automatically selected.
* **Improvements**
  * Android install/build commands now provide clearer command output when failures occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->