### PR TITLE
Add versions to mobile release names

### DIFF
--- a/.github/actions/resolve-mobile-app-version/action.yaml
+++ b/.github/actions/resolve-mobile-app-version/action.yaml
@@ -1,0 +1,41 @@
+name: Resolve mobile app version
+description: Validate and expose the mobile app version from the Expo config
+
+inputs:
+  app_version:
+    description: App version in the format 1.2.3 (520)
+    required: true
+
+outputs:
+  version:
+    description: Semantic app version
+    value: ${{ steps.resolve.outputs.version }}
+  version_code:
+    description: Native app build number
+    value: ${{ steps.resolve.outputs.version_code }}
+  filename_suffix:
+    description: App version formatted for artifact filenames
+    value: ${{ steps.resolve.outputs.filename_suffix }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve and validate app version
+      id: resolve
+      shell: bash
+      env:
+        INPUT_APP_VERSION: ${{ inputs.app_version }}
+      run: |
+        CONFIG="$(pnpm --dir apps/mobile exec expo config --json)"
+        VERSION="$(jq -er '.version' <<< "$CONFIG")"
+        VERSION_CODE="$(jq -er '.android.versionCode | tostring' <<< "$CONFIG")"
+        RESOLVED_APP_VERSION="$VERSION ($VERSION_CODE)"
+
+        if [ "$INPUT_APP_VERSION" != "$RESOLVED_APP_VERSION" ]; then
+          echo "::error::Expected app version '$RESOLVED_APP_VERSION', got '$INPUT_APP_VERSION'."
+          exit 1
+        fi
+
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
+        echo "filename_suffix=${VERSION}_${VERSION_CODE}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-eas-apk.yaml
+++ b/.github/workflows/build-eas-apk.yaml
@@ -1,5 +1,5 @@
 name: "[Build] APK"
-run-name: "Build APK (${{ inputs.environment }}) on ${{ github.sha }}"
+run-name: "Build APK (${{ inputs.environment }}) ${{ inputs.app_version }} on ${{ github.sha }}"
 
 on:
   workflow_dispatch:
@@ -12,10 +12,18 @@ on:
         options:
           - staging
           - production
+      app_version:
+        description: "App version in the format 1.2.3 (520); must match apps/mobile/app.config.ts"
+        required: true
+        type: string
   workflow_call:
     inputs:
       environment:
         description: "Environment to build"
+        required: true
+        type: string
+      app_version:
+        description: "App version in the format 1.2.3 (520)"
         required: true
         type: string
 
@@ -41,6 +49,11 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter @vexl-next/mobile-app...
+      - name: Resolve mobile app version
+        id: app-version
+        uses: ./.github/actions/resolve-mobile-app-version
+        with:
+          app_version: ${{ inputs.app_version }}
       - name: Resolve APK build profile
         id: profile
         run: |
@@ -54,10 +67,10 @@ jobs:
           eas build --platform android --profile ${{ steps.profile.outputs.name }} --non-interactive --wait --json > build.json
           APK_URL="$(jq -r 'if type == "array" then .[0].artifacts.buildUrl else .artifacts.buildUrl end' build.json)"
           test "$APK_URL" != "null"
-          curl -L "$APK_URL" -o vexl-${{ inputs.environment }}.apk
+          curl -L "$APK_URL" -o vexl-${{ inputs.environment }}-${{ steps.app-version.outputs.filename_suffix }}.apk
         working-directory: apps/mobile
       - name: Upload signed APK
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: vexl-${{ inputs.environment }}-signed-apk
-          path: apps/mobile/vexl-${{ inputs.environment }}.apk
+          name: vexl-${{ inputs.environment }}-${{ steps.app-version.outputs.filename_suffix }}-signed-apk
+          path: apps/mobile/vexl-${{ inputs.environment }}-${{ steps.app-version.outputs.filename_suffix }}.apk

--- a/.github/workflows/build-eas-apk.yaml
+++ b/.github/workflows/build-eas-apk.yaml
@@ -67,7 +67,7 @@ jobs:
           eas build --platform android --profile ${{ steps.profile.outputs.name }} --non-interactive --wait --json > build.json
           APK_URL="$(jq -r 'if type == "array" then .[0].artifacts.buildUrl else .artifacts.buildUrl end' build.json)"
           test "$APK_URL" != "null"
-          curl -L "$APK_URL" -o vexl-${{ inputs.environment }}-${{ steps.app-version.outputs.filename_suffix }}.apk
+          curl -L "$APK_URL" -o "vexl-${{ inputs.environment }}-${{ steps.app-version.outputs.filename_suffix }}.apk"
         working-directory: apps/mobile
       - name: Upload signed APK
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/release-eas-full.yaml
+++ b/.github/workflows/release-eas-full.yaml
@@ -1,5 +1,5 @@
 name: "[Release] Full app (stores + APK)"
-run-name: "Full app release on ${{ github.sha }}${{ inputs.skip_production && ' (staging only)' || '' }}"
+run-name: "Full app release ${{ inputs.app_version }} on ${{ github.sha }}${{ inputs.skip_production && ' (staging only)' || '' }}"
 
 on:
   workflow_dispatch:
@@ -9,6 +9,10 @@ on:
         required: false
         type: boolean
         default: false
+      app_version:
+        description: "App version in the format 1.2.3 (520); must match apps/mobile/app.config.ts"
+        required: true
+        type: string
 
 jobs:
   # ---- Staging ----
@@ -18,12 +22,14 @@ jobs:
     with:
       environment: staging
       platform: all
+      app_version: ${{ inputs.app_version }}
 
   staging-apk:
     uses: ./.github/workflows/build-eas-apk.yaml
     secrets: inherit
     with:
       environment: staging
+      app_version: ${{ inputs.app_version }}
 
   # ---- Production (skipped when skip_production is checked) ----
   production-store:
@@ -33,6 +39,7 @@ jobs:
     with:
       environment: production
       platform: all
+      app_version: ${{ inputs.app_version }}
 
   production-apk:
     if: ${{ !inputs.skip_production }}
@@ -40,3 +47,4 @@ jobs:
     secrets: inherit
     with:
       environment: production
+      app_version: ${{ inputs.app_version }}

--- a/.github/workflows/release-eas-store.yaml
+++ b/.github/workflows/release-eas-store.yaml
@@ -1,5 +1,5 @@
 name: "[Release] Build & submit to store"
-run-name: "Build & submit ${{ inputs.platform }} (${{ inputs.environment }}) on ${{ github.sha }}"
+run-name: "Build & submit ${{ inputs.platform }} (${{ inputs.environment }}) ${{ inputs.app_version }} on ${{ github.sha }}"
 
 on:
   workflow_dispatch:
@@ -21,6 +21,10 @@ on:
           - all
           - android
           - ios
+      app_version:
+        description: "App version in the format 1.2.3 (520); must match apps/mobile/app.config.ts"
+        required: true
+        type: string
   workflow_call:
     inputs:
       environment:
@@ -32,6 +36,10 @@ on:
         required: false
         type: string
         default: all
+      app_version:
+        description: "App version in the format 1.2.3 (520)"
+        required: true
+        type: string
 
 jobs:
   build-submit:
@@ -54,6 +62,10 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter @vexl-next/mobile-app...
+      - name: Resolve mobile app version
+        uses: ./.github/actions/resolve-mobile-app-version
+        with:
+          app_version: ${{ inputs.app_version }}
       - name: Decode Google Service Account key
         env:
           GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}


### PR DESCRIPTION
## Summary

- include the requested `1.x.x (xxx)` app version before the commit SHA in every mobile binary-build workflow run name
- validate the manually supplied release version against the resolved Expo config before starting an EAS build
- include `1.x.x_xxx` in APK filenames and uploaded artifact names

## Impact

Release runs are easier to identify in GitHub Actions, and downloaded APKs are self-identifying (for example, `vexl-staging-1.44.2_852.apk`). A mismatched version input fails before EAS starts.

## Validation

- `pnpm turbo:typecheck`
- `pnpm turbo:format`
- `pnpm turbo:lint`
- Prettier check for the changed action/workflow YAML
- YAML parse check
- positive and negative mobile version resolver checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit app version input to the mobile release workflows, including validation against the Expo configuration.
  * Improved workflow run naming to include the selected app version.
  * Updated Android APK download and artifact naming to use the resolved version suffix.
  * Passed the selected app version through the full release, store release, and APK build steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->