### PR TITLE
Fix Android chat initial scroll

### DIFF
--- a/apps/mobile/src/components/ChatDetailScreen/components/MessagesList.tsx
+++ b/apps/mobile/src/components/ChatDetailScreen/components/MessagesList.tsx
@@ -3,7 +3,7 @@ import {type ChatMessageId} from '@vexl-next/domain/src/general/messaging'
 import {tokens, useScreenFooterHeight} from '@vexl-next/ui'
 import {useMolecule} from 'bunshi/dist/react'
 import {useAtomValue, useSetAtom, useStore, type Atom} from 'jotai'
-import React, {useCallback, useEffect, useMemo, useRef} from 'react'
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {
   Animated,
   Easing,
@@ -68,6 +68,20 @@ function MessagesList({
   const latestMessageIdRef = useRef<ChatMessageId | undefined>(undefined)
   const scrolledToTargetMessageIdRef = useRef<ChatMessageId | undefined>(
     undefined
+  )
+  const [isListLoaded, setIsListLoaded] = useState(false)
+  const [isContentShorterThanViewport, setIsContentShorterThanViewport] =
+    useState(false)
+
+  const updateIsContentShorterThanViewport = useCallback(
+    (contentHeight: number, viewportHeight: number) => {
+      setIsContentShorterThanViewport(
+        contentHeight !== 0 &&
+          viewportHeight !== 0 &&
+          contentHeight <= viewportHeight
+      )
+    },
+    []
   )
 
   const updateScrollRefsToBottom = useCallback(() => {
@@ -357,8 +371,11 @@ function MessagesList({
   const maintainVisibleContentPosition = useMemo(
     () => ({
       autoscrollToBottomThreshold: targetMessageId ? undefined : 0.2,
+      // Let onLoad own the initial scroll while long lists are still measuring.
+      startRenderingFromBottom:
+        isListLoaded && !targetMessageId && isContentShorterThanViewport,
     }),
-    [targetMessageId]
+    [isContentShorterThanViewport, isListLoaded, targetMessageId]
   )
 
   const onContentSizeChange = useCallback(
@@ -368,6 +385,7 @@ function MessagesList({
         isContentScrolledToBottom(contentHeightRef.current)
 
       contentHeightRef.current = height
+      updateIsContentShorterThanViewport(height, viewportHeightRef.current)
 
       if (height <= viewportHeightRef.current) {
         updateScrollRefsToBottom()
@@ -390,6 +408,7 @@ function MessagesList({
       scrollToViewportBottomAnchor,
       targetMessageId,
       tryInitialScrollToBottom,
+      updateIsContentShorterThanViewport,
       updateScrollRefsToBottom,
     ]
   )
@@ -402,9 +421,17 @@ function MessagesList({
       if (contentHeightRef.current <= event.nativeEvent.layout.height) {
         isScrolledToBottomRef.current = true
       }
+      updateIsContentShorterThanViewport(
+        contentHeightRef.current,
+        event.nativeEvent.layout.height
+      )
       tryInitialScrollToBottom()
     },
-    [preserveBottomVisibleContentOnViewportChange, tryInitialScrollToBottom]
+    [
+      preserveBottomVisibleContentOnViewportChange,
+      tryInitialScrollToBottom,
+      updateIsContentShorterThanViewport,
+    ]
   )
 
   const onScroll = useCallback(
@@ -415,6 +442,7 @@ function MessagesList({
   )
 
   const onLoad = useCallback(() => {
+    setIsListLoaded(true)
     if (tryScrollToTargetMessage()) return
 
     didInitialScrollToBottomRef.current = true

--- a/apps/mobile/src/components/ChatDetailScreen/components/MessagesList.tsx
+++ b/apps/mobile/src/components/ChatDetailScreen/components/MessagesList.tsx
@@ -90,13 +90,7 @@ function MessagesList({
   const scrollToBottom = useCallback(
     (animated: boolean) => {
       runAfterAnimationFrame(() => {
-        listRef.current?.scrollToOffset({
-          animated,
-          offset: Math.max(
-            contentHeightRef.current - viewportHeightRef.current,
-            0
-          ),
-        })
+        listRef.current?.scrollToEnd({animated})
         updateScrollRefsToBottom()
       })
     },
@@ -363,7 +357,6 @@ function MessagesList({
   const maintainVisibleContentPosition = useMemo(
     () => ({
       autoscrollToBottomThreshold: targetMessageId ? undefined : 0.2,
-      startRenderingFromBottom: !targetMessageId,
     }),
     [targetMessageId]
   )
@@ -421,6 +414,13 @@ function MessagesList({
     [updateIsScrolledToBottom]
   )
 
+  const onLoad = useCallback(() => {
+    if (tryScrollToTargetMessage()) return
+
+    didInitialScrollToBottomRef.current = true
+    scrollToBottom(false)
+  }, [scrollToBottom, tryScrollToTargetMessage])
+
   return (
     <FlashList
       ref={listRef}
@@ -431,7 +431,7 @@ function MessagesList({
       maintainVisibleContentPosition={maintainVisibleContentPosition}
       onContentSizeChange={onContentSizeChange}
       onLayout={onLayout}
-      onLoad={tryInitialScrollToBottom}
+      onLoad={onLoad}
       onScroll={onScroll}
       renderItem={renderItem}
       scrollEventThrottle={16}


### PR DESCRIPTION
## Summary

- make FlashList's `onLoad` callback the authoritative initial chat scroll
- use `scrollToEnd` so the last item can be resolved even while list measurements are settling
- remove the competing `startRenderingFromBottom` behavior while preserving target-message navigation and later maintain-visible behavior

## Root cause

The list's layout/content callbacks could mark the initial scroll as complete while FlashList was still progressively measuring rows. `startRenderingFromBottom` could then race with the app's calculated offset and leave later-opened chats around messages 7–17 instead of at the latest message.

## Verification

- `pnpm turbo:typecheck`
- `pnpm turbo:format`
- `pnpm turbo:lint`
- Android Medium Phone API 36 emulator with the local backend and three seeded 40-message chats
- opened all three chats sequentially and confirmed each displayed message 40 at the bottom
- enabled and opened Gboard and confirmed message 40 remained at the bottom after the viewport resize


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message list loading and initial positioning.
  * Enhanced automatic scrolling to the latest messages.
  * Improved handling of short content and layout changes to keep the conversation positioned correctly.
  * Improved navigation to target messages during initial loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->