### PR TITLE
Fix iOS short chat flicker

### DIFF
--- a/apps/mobile/src/components/ChatDetailScreen/components/MessagesList.tsx
+++ b/apps/mobile/src/components/ChatDetailScreen/components/MessagesList.tsx
@@ -69,19 +69,21 @@ function MessagesList({
   const scrolledToTargetMessageIdRef = useRef<ChatMessageId | undefined>(
     undefined
   )
-  const [isListLoaded, setIsListLoaded] = useState(false)
-  const [isContentShorterThanViewport, setIsContentShorterThanViewport] =
-    useState(false)
+  const [contentTopPadding, setContentTopPadding] = useState(0)
 
-  const updateIsContentShorterThanViewport = useCallback(
+  const updateContentTopPadding = useCallback(
     (contentHeight: number, viewportHeight: number) => {
-      setIsContentShorterThanViewport(
-        contentHeight !== 0 &&
-          viewportHeight !== 0 &&
-          contentHeight <= viewportHeight
+      setContentTopPadding(
+        targetMessageId || contentHeight === 0 || viewportHeight === 0
+          ? 0
+          : Math.max(
+              // Content size already includes the currently applied top padding.
+              viewportHeight - (contentHeight - contentTopPadding),
+              0
+            )
       )
     },
-    []
+    [contentTopPadding, targetMessageId]
   )
 
   const updateScrollRefsToBottom = useCallback(() => {
@@ -364,18 +366,16 @@ function MessagesList({
   const contentContainerStyle = useMemo(
     () => ({
       paddingBottom: footerHeight + tokens.size[4].val,
+      paddingTop: targetMessageId ? 0 : contentTopPadding,
     }),
-    [footerHeight]
+    [contentTopPadding, footerHeight, targetMessageId]
   )
 
   const maintainVisibleContentPosition = useMemo(
     () => ({
       autoscrollToBottomThreshold: targetMessageId ? undefined : 0.2,
-      // Let onLoad own the initial scroll while long lists are still measuring.
-      startRenderingFromBottom:
-        isListLoaded && !targetMessageId && isContentShorterThanViewport,
     }),
-    [isContentShorterThanViewport, isListLoaded, targetMessageId]
+    [targetMessageId]
   )
 
   const onContentSizeChange = useCallback(
@@ -385,7 +385,7 @@ function MessagesList({
         isContentScrolledToBottom(contentHeightRef.current)
 
       contentHeightRef.current = height
-      updateIsContentShorterThanViewport(height, viewportHeightRef.current)
+      updateContentTopPadding(height, viewportHeightRef.current)
 
       if (height <= viewportHeightRef.current) {
         updateScrollRefsToBottom()
@@ -408,7 +408,7 @@ function MessagesList({
       scrollToViewportBottomAnchor,
       targetMessageId,
       tryInitialScrollToBottom,
-      updateIsContentShorterThanViewport,
+      updateContentTopPadding,
       updateScrollRefsToBottom,
     ]
   )
@@ -421,7 +421,7 @@ function MessagesList({
       if (contentHeightRef.current <= event.nativeEvent.layout.height) {
         isScrolledToBottomRef.current = true
       }
-      updateIsContentShorterThanViewport(
+      updateContentTopPadding(
         contentHeightRef.current,
         event.nativeEvent.layout.height
       )
@@ -430,7 +430,7 @@ function MessagesList({
     [
       preserveBottomVisibleContentOnViewportChange,
       tryInitialScrollToBottom,
-      updateIsContentShorterThanViewport,
+      updateContentTopPadding,
     ]
   )
 
@@ -442,7 +442,6 @@ function MessagesList({
   )
 
   const onLoad = useCallback(() => {
-    setIsListLoaded(true)
     if (tryScrollToTargetMessage()) return
 
     didInitialScrollToBottomRef.current = true


### PR DESCRIPTION
## Summary

- replace the post-load `startRenderingFromBottom` toggle with explicit top padding for short chats
- calculate the unused viewport space without counting already-applied padding, so repeated measurements converge
- preserve PR #2601's `onLoad` + `scrollToEnd` behavior for long chats and keep target-message navigation unpadded

## Root cause

PR #2601 conditionally enabled FlashList's `startRenderingFromBottom` after measuring the list as shorter than the viewport. On iOS, enabling that option changes FlashList's content layout and reported content height. The new measurement then disabled the option, which changed the height back and created a feedback loop that rapidly moved short conversations between the top and bottom of the viewport.

The replacement uses stable content-container padding for the unused space. Because the calculation subtracts the currently applied padding from the reported content height, subsequent content-size callbacks produce the same padding instead of toggling layout modes.

## User impact

Short conversations remain bottom-aligned above the composer without flickering. Long conversations still open at the latest message, and searches that open a target message retain their existing positioning behavior.

## Verification

- `pnpm turbo:typecheck`
- `pnpm turbo:format`
- `pnpm turbo:lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message list layout when content is shorter than the available screen space.
  * Adjusted spacing automatically when the content or viewport size changes.
  * Improved initial rendering and scrolling behavior when navigating to a specific message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->