### PR TITLE
fix: OffersList swipe-action queue deadlock

### DIFF
--- a/apps/mobile/src/components/OffersList/index.tsx
+++ b/apps/mobile/src/components/OffersList/index.tsx
@@ -156,6 +156,12 @@ function OffersList({
   const resetListAnimationFrameRef = useRef<number | null>(null)
   const isMountedRef = useRef(true)
   const [shouldAnimateListLayout, setShouldAnimateListLayout] = useState(false)
+  // Bumped by every arming. React collapses a reset to `false` and a re-arm to
+  // `true` queued in the same batch into no update at all, so arming must never
+  // rely on shouldAnimateListLayout changing value to re-run the arming effect
+  // below - otherwise the queued change would neither be applied nor completed
+  // and the queue would stall for the lifetime of the list.
+  const [listChangeGeneration, setListChangeGeneration] = useState(0)
   const [exitingItemKey, setExitingItemKey] = useState<string | null>(null)
   const theme = useTheme()
   const refreshIndicatorColor = hideRefreshIndicator
@@ -251,6 +257,7 @@ function OffersList({
     hasAppliedActiveListChangeRef.current = false
     itemsBeforeAnimationRef.current = currentItemsRef.current
     setShouldAnimateListLayout(true)
+    setListChangeGeneration((current) => current + 1)
   }, [])
 
   const animateNextListChange = useCallback(
@@ -279,6 +286,9 @@ function OffersList({
     currentItemsRef.current = items
   }, [items])
 
+  // Arms the layout transition for the next queued change. listChangeGeneration
+  // is part of the dependencies so a change armed within the same batch as the
+  // previous one's reset still re-runs this effect.
   useLayoutEffect(() => {
     if (!shouldAnimateListLayout || activeListChangeRef.current === null) {
       return
@@ -306,7 +316,7 @@ function OffersList({
         startNextListChange()
       })
     }, OFFERS_LIST_CHANGE_COMMIT_TIMEOUT_MS)
-  }, [shouldAnimateListLayout, startNextListChange])
+  }, [listChangeGeneration, shouldAnimateListLayout, startNextListChange])
 
   const handleCommitLayoutEffect = useCallback(() => {
     onCommitLayoutEffect?.()
@@ -337,6 +347,19 @@ function OffersList({
 
     listChangeCompletionTimeoutRef.current = setTimeout(() => {
       listChangeCompletionTimeoutRef.current = null
+
+      // Timers can outrun the frame loop - it stops while the app is
+      // backgrounded and overdue timers flush before it resumes - so the reset
+      // frame above may still be queued here. Running its work now keeps the
+      // animation disarmed before the next change arms itself and prevents the
+      // stale frame from disarming that next change mid-flight.
+      if (resetListAnimationFrameRef.current !== null) {
+        cancelAnimationFrame(resetListAnimationFrameRef.current)
+        resetListAnimationFrameRef.current = null
+        setShouldAnimateListLayout(false)
+        itemsBeforeAnimationRef.current = null
+      }
+
       activeListChangeRef.current = null
       hasAppliedActiveListChangeRef.current = false
       activeListChange.complete()


### PR DESCRIPTION
Found while reviewing #2608 (`feat-features_and_fixes`).

## The bug

`apps/mobile/src/components/OffersList/index.tsx` serialises swipe mark actions (favourite / archive) through a promise queue so each one gets its own layout transition. The queue could deadlock permanently, leaving favourite/archive silently dead on that list until the screen unmounted.

`handleCommitLayoutEffect` splits the end of a cycle across two schedulers:

- a `requestAnimationFrame` that resets `shouldAnimateListLayout` to `false` (kept in a frame so the transition actually starts before the layout prop is removed),
- an unconditional `setTimeout(OFFERS_LIST_LAYOUT_TRANSITION_DURATION_MS)` that completes the change and calls `startNextListChange()`.

Timers can outrun the frame loop: RN stops delivering frames while the app is backgrounded and flushes overdue timers first on resume (heavy JS-thread jank does the same). If the completion timeout wins the race, `startNextListChange()` calls `setShouldAnimateListLayout(true)` while the state is *already* `true`. React collapses the queued `false` -> `true` pair into no update at all (final state equals `memoizedState`, so the render bails out and the layout-effect flag is stripped), the arming `useLayoutEffect` never re-runs, and therefore:

- the queued change's `applyChange()` (the actual `toggleOfferMark` state write) never executes,
- no fallback commit timeout is armed for it (that only happens inside the arming effect),
- its `complete()` never resolves and `activeListChangeRef.current` stays non-null forever, so every later swipe early-returns in `startNextListChange`.

Note the 1000ms commit-timeout fallback path does not have this problem: it calls `setShouldAnimateListLayout(false)` synchronously, one batch before the re-arm.

## The fix

Two small, surgical changes that remove the ordering dependency:

1. `listChangeGeneration` state, bumped on every arming and added to the arming effect's dependencies. Arming no longer depends on the boolean *transitioning*, so a change armed in the same batch as the previous one's reset still re-renders and re-arms. This is what actually breaks the deadlock — no amount of reordering helps, because React only skips the bailout when the new state differs, and a rendered `false` in between cannot be guaranteed when frames are stalled.
2. In the completion timeout, if the reset frame is still pending, cancel it and run its work (`setShouldAnimateListLayout(false)`, clear `itemsBeforeAnimationRef`) synchronously before completing. Without this the stale frame would later fire and disarm the *next* change mid-flight (no animation, plus a 1000ms fallback delay), and the flag could be left armed if the queue drained.

Interleavings checked: normal commit path, the 1000ms commit-timeout fallback, completion-before-frame, stale frame after re-arm, rapid successive swipes (queued behind a non-null `activeListChangeRef`), and unmount cleanup (still cancels both timers and the frame, applies + completes everything). The commit timeout is never double-armed, and the change still animates in the pathological path because the flag stays `true` across the collapsed batch.

## Verification

`apps/mobile`: `tsc --noemit` clean, prettier clean, `eslint src` 0 errors (3 pre-existing deprecation warnings unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
