### PR TITLE
fix: decimal separator normalization in trade inputs

### DIFF
--- a/apps/mobile/src/components/TradeCalculator/__tests__/tradeCalculator.test.ts
+++ b/apps/mobile/src/components/TradeCalculator/__tests__/tradeCalculator.test.ts
@@ -80,6 +80,57 @@ describe('TradeCalculator domain transitions', () => {
     expect(normalizeLocalizedDecimalInput('1.234,56', 'cs')).toBe('1234.56')
   })
 
+  test('reads a lone thousands separator as grouping in the fiat input', () => {
+    expect(
+      normalizeLocalizedDecimalInput('1,000', 'en-US', 'thousandsSeparator')
+    ).toBe('1000')
+    expect(
+      normalizeLocalizedDecimalInput('1.000', 'cs', 'thousandsSeparator')
+    ).toBe('1000')
+    expect(
+      normalizeLocalizedDecimalInput('1,5', 'cs', 'thousandsSeparator')
+    ).toBe('1.5')
+    expect(
+      normalizeLocalizedDecimalInput('0,50', 'en-US', 'thousandsSeparator')
+    ).toBe('0.50')
+    expect(
+      normalizeLocalizedDecimalInput('1.234.567,89', 'cs', 'thousandsSeparator')
+    ).toBe('1234567.89')
+    expect(
+      normalizeLocalizedDecimalInput(
+        '1,234,567.89',
+        'en-US',
+        'thousandsSeparator'
+      )
+    ).toBe('1234567.89')
+    expect(
+      normalizeLocalizedDecimalInput('١٬٠٠٠٫٥', 'ar', 'thousandsSeparator')
+    ).toBe('1000.5')
+    expect(
+      normalizeLocalizedDecimalInput('١٠٠٠', 'ar', 'thousandsSeparator')
+    ).toBe('1000')
+  })
+
+  test('keeps a lone separator as the decimal point in the BTC input', () => {
+    expect(normalizeLocalizedDecimalInput('0.005', 'cs', 'decimalPoint')).toBe(
+      '0.005'
+    )
+    expect(normalizeLocalizedDecimalInput('1,000', 'cs', 'decimalPoint')).toBe(
+      '1.000'
+    )
+    expect(normalizeLocalizedDecimalInput('٠٫٠٠٥', 'ar', 'decimalPoint')).toBe(
+      '0.005'
+    )
+  })
+
+  test('keeps the first separator when the same separator is typed twice', () => {
+    expect(normalizeLocalizedDecimalInput('1,5,', 'cs')).toBe('1.5')
+    expect(
+      normalizeLocalizedDecimalInput('1,5,', 'cs', 'thousandsSeparator')
+    ).toBe('1.5')
+    expect(normalizeLocalizedDecimalInput('0.5.5', 'en-US')).toBe('0.55')
+  })
+
   test('does not require Intl.NumberFormat.formatToParts support', () => {
     const formatToPartsSpy = jest
       .spyOn(Intl.NumberFormat.prototype, 'formatToParts')

--- a/packages/ui/src/components/Exchange.tsx
+++ b/packages/ui/src/components/Exchange.tsx
@@ -224,7 +224,14 @@ export function Exchange({
         <FieldInput
           value={btcDisplayValue}
           onChangeText={(value) => {
-            onBtcValueChange?.(normalizeLocalizedDecimalInput(value, locale))
+            onBtcValueChange?.(
+              normalizeLocalizedDecimalInput(
+                value,
+                locale,
+                // SATS amounts are whole numbers, BTC amounts have up to 8 decimals
+                btcUnit === 'SATS' ? 'thousandsSeparator' : 'decimalPoint'
+              )
+            )
           }}
           placeholder="0.00"
           placeholderTextColor={theme.foregroundTertiary.get()}
@@ -275,7 +282,13 @@ export function Exchange({
           autoFocus={fiatAutoFocus}
           value={fiatDisplayValue}
           onChangeText={(value) => {
-            onFiatValueChange(normalizeLocalizedDecimalInput(value, locale))
+            onFiatValueChange(
+              normalizeLocalizedDecimalInput(
+                value,
+                locale,
+                'thousandsSeparator'
+              )
+            )
           }}
           placeholder={fiatPlaceholder}
           placeholderTextColor={theme.foregroundTertiary.get()}

--- a/packages/ui/src/components/normalizeLocalizedDecimalInput.ts
+++ b/packages/ui/src/components/normalizeLocalizedDecimalInput.ts
@@ -1,3 +1,5 @@
+import {Array, pipe} from 'effect'
+
 const ARABIC_INDIC_DIGITS = '٠١٢٣٤٥٦٧٨٩'
 const EXTENDED_ARABIC_INDIC_DIGITS = '۰۱۲۳۴۵۶۷۸۹'
 const ARABIC_DECIMAL_SEPARATOR = '٫'
@@ -92,9 +94,48 @@ function hasOnlyThreeDigitGroups(value: string, separator: string): boolean {
   return false
 }
 
+/**
+ * How to read a single separator that could be either a decimal point or a
+ * thousands separator. See the tie-break rules on `getDecimalSeparatorIndex`.
+ */
+export type LoneSeparatorMode = 'decimalPoint' | 'thousandsSeparator'
+
+function isLoneThousandsSeparator(
+  value: string,
+  separatorIndex: number,
+  separator: string,
+  localizedDecimalSeparator: string
+): boolean {
+  if (separator === localizedDecimalSeparator) return false
+  if (separatorIndex <= 0) return false
+
+  const trailing = value.slice(separatorIndex + 1)
+
+  return (
+    trailing.length === 3 &&
+    pipe(Array.fromIterable(trailing), Array.every(isAsciiDigit))
+  )
+}
+
+/**
+ * A value being typed is not a formatted number, so `.` and `,` are ambiguous.
+ * Tie-break rules, in order:
+ * 1. Different separators (`1.234,56`): the last one is the decimal point.
+ * 2. Repeated identical separators forming 3-digit groups (`1.234.567`): all of
+ *    them are thousands separators, there is no decimal point.
+ * 3. Repeated identical separators that do not form 3-digit groups (`1,5,`):
+ *    the first one is the decimal point, the rest are dropped - the decimal
+ *    point must never move while typing.
+ * 4. A lone separator is the decimal point, except in `thousandsSeparator`
+ *    mode, where a separator that is not the locale decimal separator and is
+ *    followed by exactly three digits (`1,000` in en-US) groups thousands.
+ *    Values with many decimals (BTC) use `decimalPoint` mode instead, because
+ *    `0.005` in a comma-decimal locale has to stay `0.005`.
+ */
 function getDecimalSeparatorIndex(
   value: string,
-  localizedDecimalSeparator: string
+  localizedDecimalSeparator: string,
+  loneSeparatorMode: LoneSeparatorMode
 ): number {
   let firstSeparatorIndex = -1
   let lastSeparatorIndex = -1
@@ -118,24 +159,36 @@ function getDecimalSeparatorIndex(
   }
 
   if (separatorCount === 0) return -1
-  if (separatorCount === 1 || hasDifferentSeparators) {
-    return lastSeparatorIndex
+  if (hasDifferentSeparators) return lastSeparatorIndex
+
+  if (separatorCount === 1) {
+    return loneSeparatorMode === 'thousandsSeparator' &&
+      isLoneThousandsSeparator(
+        value,
+        firstSeparatorIndex,
+        firstSeparator,
+        localizedDecimalSeparator
+      )
+      ? -1
+      : firstSeparatorIndex
   }
 
   return hasOnlyThreeDigitGroups(value, firstSeparator)
     ? -1
-    : lastSeparatorIndex
+    : firstSeparatorIndex
 }
 
 export function normalizeLocalizedDecimalInput(
   value: string,
-  locale: string
+  locale: string,
+  loneSeparatorMode: LoneSeparatorMode = 'decimalPoint'
 ): string {
   const normalizedDigits = normalizeDigits(value)
   const separators = getNumberSeparators(locale)
   const decimalSeparatorIndex = getDecimalSeparatorIndex(
     normalizedDigits,
-    separators.decimal
+    separators.decimal,
+    loneSeparatorMode
   )
   let normalized = ''
 


### PR DESCRIPTION
Found while reviewing #2608. Two verified bugs in `packages/ui/src/components/normalizeLocalizedDecimalInput.ts` (`getDecimalSeparatorIndex`), which normalizes what the user types in the BTC and fiat fields of `Exchange`.

## Bug 1 — a lone separator was always the decimal point (1000x error in fiat)

`normalizeLocalizedDecimalInput('1,000', 'en-US')` returned `'1.000'` = **1** instead of **1000**. An en-US user typing `1,000` into the fiat amount got one dollar. Same for `1.000` in cs.

This was a regression against `main`, whose `normalizeDecimalSeparator` stripped a non-locale-decimal separator followed by exactly 3 trailing digits. `hasOnlyThreeDigitGroups` already existed in the new file but was only consulted when there were **two or more** identical separators.

## Bug 2 — the decimal point silently moved (10x error)

With two or more identical separators that do not form 3-digit groups, the **last** one was kept as the decimal point. In cs, typing `1,5` and accidentally hitting comma again (`1,5,`) normalized to `'15.'` — the amount became 15 instead of 1.5.

## Design: per-field tie-break for the ambiguous lone separator

A lone separator is genuinely ambiguous and cannot be resolved the same way in both fields: `0.005` typed in a comma-decimal locale must stay `0.005` in the BTC field (blindly restoring main's strip-3-digits rule would break BTC entry — that bug existed on main too), while `1,000` in the fiat field must be 1000.

So `normalizeLocalizedDecimalInput` takes a third argument, `LoneSeparatorMode`:

- `'decimalPoint'` (default) — a lone separator is always the decimal point. Used by the BTC field.
- `'thousandsSeparator'` — a lone separator that (a) is not the locale decimal separator and (b) is followed by exactly three digits groups thousands. Used by the fiat field, and by the BTC field when the unit is SATS (whole numbers).

Full tie-break order, documented in a comment on `getDecimalSeparatorIndex`:

1. Different separators (`1.234,56`) — the **last** one is the decimal point.
2. Repeated identical separators forming 3-digit groups (`1.234.567`) — all grouping, no decimal point.
3. Repeated identical separators not forming 3-digit groups (`1,5,`) — the **first** one is the decimal point, the rest are dropped (fixes Bug 2, applies in both modes).
4. Lone separator — mode-dependent as above (fixes Bug 1).

## Tests

Extended `apps/mobile/src/components/TradeCalculator/__tests__/tradeCalculator.test.ts` (36 passing):

- fiat mode: `'1,000'` en-US -> `1000`, `'1.000'` cs -> `1000`, `'1,5'` cs -> `1.5`, `'0,50'` en-US -> `0.50`, `'1.234.567,89'` cs -> `1234567.89`, `'1,234,567.89'` en-US -> `1234567.89`, Arabic-Indic `'١٬٠٠٠٫٥'` ar -> `1000.5`
- BTC mode: `'0.005'` cs -> `0.005`, `'1,000'` cs -> `1.000`, Arabic-Indic `'٠٫٠٠٥'` ar -> `0.005`
- first-separator-wins: `'1,5,'` cs -> `1.5` in both modes, `'0.5.5'` en-US -> `0.55`

Verified with `turbo typecheck`, `format`, and `lint` for `@vexl-next/ui` and `@vexl-next/mobile-app` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
