### PR TITLE
fix: SwipeableOfferCard post-unmount timer writes and stale drag distance

### DIFF
--- a/packages/ui/src/components/SwipeableOfferCard.tsx
+++ b/packages/ui/src/components/SwipeableOfferCard.tsx
@@ -175,6 +175,10 @@ export function SwipeableOfferCard({
   const cardHeightRef = useRef(0)
   const offerIdRef = useRef(offerId)
   offerIdRef.current = offerId
+  const isMountedRef = useRef(true)
+  const slideOutTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  )
   // Signed per-gesture drag distance, latched on the UI thread by the
   // observer pan. The swipeable's own translation keeps animating after
   // release, so sampling it from JS in the will-open/close callbacks is
@@ -189,6 +193,16 @@ export function SwipeableOfferCard({
     cardOpacity.set(1)
     cardTranslateY.set(0)
   }, [cardOpacity, cardTranslateY, offerId])
+
+  // The exit choreography runs on JS timers, so it can outlive the row. Drop
+  // the purely visual timer and stop touching shared values once unmounted.
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      clearTimeout(slideOutTimeoutRef.current)
+    }
+  }, [])
 
   const fadeStyle = useAnimatedStyle(() => ({
     opacity: cardOpacity.get(),
@@ -215,11 +229,12 @@ export function SwipeableOfferCard({
       onExitAnimationStart?.()
       swipeableRef.current?.close()
 
-      // JS timers rather than animation callbacks keep the sequence (and the
-      // mark commit itself) running even if FlashList recycles the closing
-      // row mid-way; the offerId guard only skips the visuals in that case.
-      setTimeout(() => {
-        if (offerIdRef.current !== offerId) return
+      // JS timers rather than animation callbacks keep the mark commit itself
+      // running even if FlashList recycles the closing row mid-way; the
+      // offerId and mounted guards only skip the visuals in that case.
+      clearTimeout(slideOutTimeoutRef.current)
+      slideOutTimeoutRef.current = setTimeout(() => {
+        if (!isMountedRef.current || offerIdRef.current !== offerId) return
         cardTranslateY.set(
           withTiming(exitOffset, {
             duration: CARD_SLIDE_OUT_DURATION_MS,
@@ -236,9 +251,11 @@ export function SwipeableOfferCard({
         )
       }, CLOSE_SETTLE_DURATION_MS)
 
+      // Deliberately not cleared on unmount: the mark has to be committed even
+      // when the row is recycled before the slide-out finishes.
       setTimeout(() => {
         const restoreCard = (): void => {
-          if (offerIdRef.current !== offerId) return
+          if (!isMountedRef.current || offerIdRef.current !== offerId) return
           cardTranslateY.set(0)
           cardOpacity.set(withTiming(1, {duration: CARD_FADE_IN_DURATION_MS}))
         }
@@ -281,9 +298,14 @@ export function SwipeableOfferCard({
   )
 
   const handleSwipeRelease = useCallback(() => {
-    if (committedRef.current) return
-
+    // Consume the latched distance on every open/close, not just when the
+    // observer pan restarts. The swipeable's own pan can open or close a row
+    // without the observer activating, and a leftover distance from an earlier
+    // gesture would then commit an action the user never performed.
     const dragDistance = dragTranslation.get()
+    dragTranslation.set(0)
+
+    if (committedRef.current) return
     if (Math.abs(dragDistance) < FULL_SWIPE_COMMIT_DISTANCE) return
 
     commit(dragDistance > 0 ? 'favourite' : 'archived')


### PR DESCRIPTION
Two issues found while reviewing #2608, both in `packages/ui/src/components/SwipeableOfferCard.tsx`.

## 1. Exit-choreography timers wrote to an unmounted view

`commit()` schedules two `setTimeout`s (slide-out at `CLOSE_SETTLE_DURATION_MS`, mark commit at `CLOSE_SETTLE_DURATION_MS + CARD_SLIDE_OUT_DURATION_MS`) and neither was ever cleared. When the row unmounts (offer filtered out of the list, FlashList cell released), both still fire. The existing `offerIdRef.current !== offerId` guard does not help there: after unmount the ref still holds the same id, so the guard passes and the timers write `cardTranslateY` / `cardOpacity` and run `restoreCard` against a view that no longer exists.

Fix: track mounted state in an `isMountedRef` flipped by an effect cleanup, and include it in the guards on both the slide-out body and `restoreCard`. The slide-out timer id is kept in a ref and cleared on unmount (and before rescheduling), since it is purely visual.

The commit timer is intentionally left uncleared — committing the mark even when the row is recycled mid-animation is deliberate behaviour documented in the file, so `onToggleMark` still runs. Only the visual writes are now guarded. A comment makes that intent explicit so it is not "cleaned up" later.

## 2. Stale drag distance could commit an unintended action

`dragTranslation` was zeroed only in the observer pan's `onStart`, so between gestures it retained the previous gesture's signed distance. The swipeable's own pan can open or close a row without the observer pan activating (it needs `activeOffsetX` ±10 to start). In that case `handleSwipeRelease` read a leftover value of ≥180px from an earlier gesture and committed a favourite/archive action the user never performed.

Fix: `handleSwipeRelease` now consumes the latched value — it reads the distance and immediately resets `dragTranslation` to 0 before the guards, so every open/close clears it regardless of which code path returns early. `onSwipeableWillOpen` / `onSwipeableWillClose` are invoked through `runOnJS` by `ReanimatedSwipeable`, so this runs on the JS thread and plain `.get()` / `.set()` is correct here.

## Verification

- `@vexl-next/ui`: typecheck, format, lint — all pass
- `@vexl-next/mobile-app` typecheck — passes
- `@vexl-next/ui-book` typecheck — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
