### PR TITLE
fix: upload progress bar no longer restarts between phases

### DIFF
--- a/apps/mobile/src/components/UploadingOfferProgressModal/atoms.ts
+++ b/apps/mobile/src/components/UploadingOfferProgressModal/atoms.ts
@@ -5,7 +5,7 @@ import {atom} from 'jotai'
 import {translationAtom} from '../../utils/localization/I18nProvider'
 import {formatInteger} from '../../utils/localization/formatting'
 import {formattingLocaleAtom} from '../../utils/localization/formattingLocaleAtom'
-import {percentageAcrossItems} from './progressUtils'
+import {percentageAcrossItems, type AggregateProgress} from './progressUtils'
 
 export type {ProgressIndication} from '@vexl-next/ui'
 
@@ -67,10 +67,7 @@ export const offerProgressModalActionAtoms = {
         progress,
         textData,
       }: {
-        aggregateProgress?: {
-          readonly processingIndex: number
-          readonly totalToProcess: number
-        }
+        aggregateProgress?: AggregateProgress
         progress: OfferEncryptionProgress
         textData: ProgressStepDataActionParam
       }

--- a/apps/mobile/src/components/UploadingOfferProgressModal/progressUtils.test.ts
+++ b/apps/mobile/src/components/UploadingOfferProgressModal/progressUtils.test.ts
@@ -1,0 +1,114 @@
+import {type OfferEncryptionProgress} from '@vexl-next/resources-utils/src/offers/OfferEncryptionProgress'
+import {Array, pipe} from 'effect'
+import {percentageAcrossItems, progressSpan} from './progressUtils'
+
+const ITEM_STEPS: readonly OfferEncryptionProgress[] = [
+  {type: 'CONSTRUCTING_PRIVATE_PAYLOADS'},
+  {
+    type: 'ENCRYPTING_PRIVATE_PAYLOADS',
+    totalToEncrypt: 2,
+    currentlyProcessingIndex: 0,
+  },
+  {
+    type: 'ENCRYPTING_PRIVATE_PAYLOADS',
+    totalToEncrypt: 2,
+    currentlyProcessingIndex: 1,
+  },
+  {type: 'SENDING_OFFER_TO_NETWORK'},
+  {type: 'DONE'},
+]
+
+function percentagesForBatch({
+  totalToProcess,
+  span,
+}: {
+  readonly totalToProcess: number
+  readonly span: ReturnType<typeof progressSpan>
+}): readonly number[] {
+  return pipe(
+    Array.range(0, Math.max(0, totalToProcess - 1)),
+    Array.flatMap((processingIndex) =>
+      pipe(
+        ITEM_STEPS,
+        Array.map((progress) =>
+          percentageAcrossItems({
+            processingIndex,
+            totalToProcess,
+            span,
+            progress,
+          })
+        )
+      )
+    )
+  )
+}
+
+describe('percentageAcrossItems', () => {
+  it('fills the whole bar when no span is passed', () => {
+    const percentages = percentagesForBatch({
+      totalToProcess: 3,
+      span: {startPercentage: 0, endPercentage: 100},
+    })
+
+    expect(percentages.at(0)).toBe(2)
+    expect(percentages.at(-1)).toBe(100)
+  })
+
+  it('never goes backwards across two batches sharing one bar', () => {
+    const offersCount = 4
+    const notesCount = 2
+    const totalWeight = offersCount + notesCount
+
+    const percentages = [
+      ...percentagesForBatch({
+        totalToProcess: offersCount,
+        span: progressSpan({
+          weight: offersCount,
+          weightBefore: 0,
+          totalWeight,
+        }),
+      }),
+      ...percentagesForBatch({
+        totalToProcess: notesCount,
+        span: progressSpan({
+          weight: notesCount,
+          weightBefore: offersCount,
+          totalWeight,
+        }),
+      }),
+    ]
+
+    expect(percentages.at(-1)).toBe(100)
+    pipe(
+      percentages,
+      Array.zip(Array.drop(percentages, 1)),
+      Array.forEach(([previous, next]) => {
+        expect(next).toBeGreaterThanOrEqual(previous)
+      })
+    )
+  })
+
+  it('stays within its span even when the batch has more items than estimated', () => {
+    const percentages = percentagesForBatch({
+      totalToProcess: 10,
+      span: progressSpan({weight: 2, weightBefore: 3, totalWeight: 5}),
+    })
+
+    expect(Math.min(...percentages)).toBeGreaterThanOrEqual(60)
+    expect(Math.max(...percentages)).toBe(100)
+  })
+})
+
+describe('progressSpan', () => {
+  it('falls back to the whole bar when there is nothing to weight', () => {
+    expect(
+      progressSpan({weight: 0, weightBefore: 0, totalWeight: 0})
+    ).toStrictEqual({startPercentage: 0, endPercentage: 100})
+  })
+
+  it('gives an empty batch an empty span', () => {
+    expect(
+      progressSpan({weight: 0, weightBefore: 4, totalWeight: 4})
+    ).toStrictEqual({startPercentage: 100, endPercentage: 100})
+  })
+})

--- a/apps/mobile/src/components/UploadingOfferProgressModal/progressUtils.ts
+++ b/apps/mobile/src/components/UploadingOfferProgressModal/progressUtils.ts
@@ -1,5 +1,24 @@
 import {type OfferEncryptionProgress} from '@vexl-next/resources-utils/src/offers/OfferEncryptionProgress'
 
+/** Part of the 0-100 progress bar a single batch of items fills. */
+export interface ProgressSpan {
+  readonly startPercentage: number
+  readonly endPercentage: number
+}
+
+const WHOLE_BAR: ProgressSpan = {startPercentage: 0, endPercentage: 100}
+
+export interface AggregateProgress {
+  readonly processingIndex: number
+  readonly totalToProcess: number
+  /**
+   * Part of the bar this batch fills. Defaults to the whole bar. Pass a span
+   * whenever multiple batches report into the same dialog one after another —
+   * without it each batch would restart the bar from 0.
+   */
+  readonly span?: ProgressSpan
+}
+
 function progressWithinCurrentItem(progress: OfferEncryptionProgress): number {
   switch (progress.type) {
     case 'FETCHING_CONTACTS':
@@ -20,21 +39,47 @@ function progressWithinCurrentItem(progress: OfferEncryptionProgress): number {
   }
 }
 
+/**
+ * Assigns a part of the 0-100 bar to one batch of a flow that processes several
+ * batches one after another. Weights are the item counts each batch is expected
+ * to process — they only decide how the bar is divided between batches, every
+ * batch always fills its own span exactly, keeping the bar monotonic even when
+ * the estimate was off.
+ */
+export function progressSpan({
+  weight,
+  weightBefore,
+  totalWeight,
+}: {
+  readonly weight: number
+  readonly weightBefore: number
+  readonly totalWeight: number
+}): ProgressSpan {
+  if (totalWeight <= 0) return WHOLE_BAR
+
+  return {
+    startPercentage: (weightBefore / totalWeight) * 100,
+    endPercentage: ((weightBefore + weight) / totalWeight) * 100,
+  }
+}
+
 export function percentageAcrossItems({
   processingIndex,
   progress,
+  span,
   totalToProcess,
-}: {
-  readonly processingIndex: number
+}: AggregateProgress & {
   readonly progress: OfferEncryptionProgress
-  readonly totalToProcess: number
 }): number {
-  if (totalToProcess === 0) return 100
+  const {startPercentage, endPercentage} = span ?? WHOLE_BAR
 
-  const completedItemsAndCurrentProgress =
-    processingIndex + progressWithinCurrentItem(progress)
+  const fractionDone =
+    totalToProcess === 0
+      ? 1
+      : (processingIndex + progressWithinCurrentItem(progress)) / totalToProcess
+
   const percentage = Math.round(
-    (completedItemsAndCurrentProgress / totalToProcess) * 100
+    startPercentage + fractionDone * (endPercentage - startPercentage)
   )
 
   return Math.min(100, Math.max(0, percentage))

--- a/apps/mobile/src/state/connections/atom/noteToConnectionsAtom.ts
+++ b/apps/mobile/src/state/connections/atom/noteToConnectionsAtom.ts
@@ -118,6 +118,15 @@ const dropOrphanRepostConnectionsRecordsActionAtom = atom(null, (get, set) => {
   }))
 })
 
+// Number of records `updateAndReencryptAllNotesConnectionsActionAtom` will
+// process — one per own note plus one per tracked repost. Read up front by
+// flows that need to size the notes part of an aggregated progress bar.
+export const noteRecordsToReencryptCountAtom = atom(
+  (get) =>
+    get(myNotesAtom).length +
+    get(repostToConnectionsAtom).repostToConnections.length
+)
+
 export const updateAndReencryptAllNotesConnectionsActionAtom = atom(
   null,
   (

--- a/apps/mobile/src/state/connections/atom/offerToConnectionsAtom.ts
+++ b/apps/mobile/src/state/connections/atom/offerToConnectionsAtom.ts
@@ -200,6 +200,17 @@ export const ensureConnectionsForEveryOffer = atom(null, (get, set) => {
   }))
 })
 
+// Number of records `updateAndReencryptAllOffersConnectionsActionAtom` will
+// process — the pass keeps exactly one record per own offer. Read up front by
+// flows that need to size the offers part of an aggregated progress bar.
+export const offersToReencryptCountAtom = atom((get) =>
+  pipe(
+    get(offersStateAtom).offers,
+    Array.filter((one) => !!one.ownershipInfo?.adminId),
+    Array.length
+  )
+)
+
 type ClubConnections = Record<
   ClubUuid,
   ReadonlyArray<PublicKeyPemBase64 | PublicKeyV2>

--- a/apps/mobile/src/state/contacts/atom/submitContactsActionAtom.ts
+++ b/apps/mobile/src/state/contacts/atom/submitContactsActionAtom.ts
@@ -11,6 +11,7 @@ import {
   offerProgressModalActionAtoms,
   type ProgressIndication,
 } from '../../../components/UploadingOfferProgressModal/atoms'
+import {progressSpan} from '../../../components/UploadingOfferProgressModal/progressUtils'
 import {translationAtom} from '../../../utils/localization/I18nProvider'
 import {formatInteger} from '../../../utils/localization/formatting'
 import {formattingLocaleAtom} from '../../../utils/localization/formattingLocaleAtom'
@@ -18,8 +19,14 @@ import reportError from '../../../utils/reportError'
 import {waitForNextAnimationFrameEffect} from '../../../utils/runAfterAnimationFrames'
 import {toCommonErrorMessage} from '../../../utils/useCommonErrorMessages'
 import {syncConnectionsActionAtom} from '../../connections/atom/connectionStateAtom'
-import {updateAndReencryptAllNotesConnectionsActionAtom} from '../../connections/atom/noteToConnectionsAtom'
-import {updateAndReencryptAllOffersConnectionsActionAtom} from '../../connections/atom/offerToConnectionsAtom'
+import {
+  noteRecordsToReencryptCountAtom,
+  updateAndReencryptAllNotesConnectionsActionAtom,
+} from '../../connections/atom/noteToConnectionsAtom'
+import {
+  offersToReencryptCountAtom,
+  updateAndReencryptAllOffersConnectionsActionAtom,
+} from '../../connections/atom/offerToConnectionsAtom'
 import {
   updatePersistentDataAboutNumberOfImportedContactsActionAtom,
   updatePersistentDataAboutReachActionAtom,
@@ -577,6 +584,24 @@ const syncNetworkAfterContactsImportActionAtom = atom(
     const areThereAnyMyOffers = get(areThereAnyMyOffersAtom)
     const areThereAnyMyNotes = get(areThereAnyMyNotesAtom)
 
+    // Offers and notes are re-encrypted one batch after another but report into
+    // the same dialog. Each batch gets its own part of the bar - sized by how
+    // many items it is expected to process - so the bar never restarts at 0
+    // when the notes batch takes over.
+    const offersToReencryptCount = get(offersToReencryptCountAtom)
+    const noteRecordsToReencryptCount = get(noteRecordsToReencryptCountAtom)
+    const totalWeight = offersToReencryptCount + noteRecordsToReencryptCount
+    const offersProgressSpan = progressSpan({
+      weight: offersToReencryptCount,
+      weightBefore: 0,
+      totalWeight,
+    })
+    const notesProgressSpan = progressSpan({
+      weight: noteRecordsToReencryptCount,
+      weightBefore: offersToReencryptCount,
+      totalWeight,
+    })
+
     return Effect.gen(function* (_) {
       if (
         (areThereAnyMyOffers || areThereAnyMyNotes) &&
@@ -603,6 +628,7 @@ const syncNetworkAfterContactsImportActionAtom = atom(
                   aggregateProgress: {
                     processingIndex: offerI,
                     totalToProcess: totalOffers,
+                    span: offersProgressSpan,
                   },
                   progress,
                   textData: {
@@ -630,6 +656,7 @@ const syncNetworkAfterContactsImportActionAtom = atom(
                   aggregateProgress: {
                     processingIndex: noteI,
                     totalToProcess: totalNotes,
+                    span: notesProgressSpan,
                   },
                   progress,
                   textData: {


### PR DESCRIPTION
Found while reviewing #2608.

## Bug

During contact submission with offer re-encryption the aggregated progress bar runs 0 -> 100%, then visibly jumps **back to 0%** and runs up again.

`syncNetworkAfterContactsImportActionAtom` drives one `ProgressDialog` from two batches that run one after another - first `updateAndReencryptAllOffersConnectionsActionAtom`, then `updateAndReencryptAllNotesConnectionsActionAtom` - and each reported its own independent `processingIndex`/`totalToProcess` pair, i.e. its own full 0-100 range. `ProgressDialog` deliberately snaps backwards without animation (a sensible guard, left untouched), so the user sees the bar restart mid-dialog.

## Fix

Both batches are aggregated into a single 0-100 range by giving each batch its own span of the bar:

- `progressUtils.ts` gains `ProgressSpan` + `progressSpan({weight, weightBefore, totalWeight})`, and `percentageAcrossItems` now maps a batch's fraction into that span (no span = whole bar, i.e. unchanged behaviour for every other caller of `showStep`).
- Spans are sized by how many records each batch is expected to process. Those counts are now exposed next to the passes that consume them, as the single source of truth for "how much work is this pass": `offersToReencryptCountAtom` (one record per own offer) and `noteRecordsToReencryptCountAtom` (own notes plus tracked reposts).
- `submitContactsActionAtom` computes both spans once, up front, and passes them along with the per-batch index/total.

Weights only decide **where** the handoff point sits. Each batch still fills its own span exactly using its real item count, so an off estimate can never make the bar go backwards - it only shifts the split. Empty batch -> empty span; nothing known -> whole bar.

Added `progressUtils.test.ts` covering the monotonicity of a simulated two-batch run, span clamping when a batch has more items than estimated, and the degenerate weight cases.

## Verification

- `turbo typecheck --filter=@vexl-next/mobile-app` - pass
- `turbo format --filter=@vexl-next/mobile-app` - pass
- `turbo lint --filter=@vexl-next/mobile-app` - pass (only 3 pre-existing deprecation warnings, unrelated)
- `jest src/components/UploadingOfferProgressModal` - 5 passed

`packages/ui` was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)