### PR TITLE
Allow crawling the web app homepage

### DIFF
--- a/apps/web-app/public/robots.txt
+++ b/apps/web-app/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
+Allow: /$
 Disallow: /


### PR DESCRIPTION
## Summary

- allow crawlers to access the exact web app homepage (`/`)
- keep all other paths blocked by `robots.txt`

## Why

The web app currently blocks crawlers from the entire site. The homepage should be discoverable without exposing the rest of the application to indexing.

## Validation

- `pnpm turbo:typecheck --filter=web-app`
- `pnpm turbo:format`
- `pnpm turbo:lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated search engine crawling rules to explicitly allow access to the site’s root page while continuing to block all other paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->