### PR TITLE
Drop legacy token column from chat inbox

### DIFF
--- a/apps/chat-service/src/db/layer.ts
+++ b/apps/chat-service/src/db/layer.ts
@@ -7,6 +7,7 @@ import addExpiresAtToMessage from './migrations/0002_add_expires_at_to_messages'
 import removeUnusedTables from './migrations/0003_remove_unused_tables'
 import dropChallengeTable from './migrations/0004_drop_challenge_table'
 import addReceivedByServerAtToMessage from './migrations/0005_add_received_by_server_at_to_message'
+import dropInboxTokenColumn from './migrations/0006_drop_inbox_token_column'
 
 const migrations = [
   {
@@ -33,6 +34,11 @@ const migrations = [
     id: 5,
     name: 'Add received_by_server_at to message',
     migrationEffect: addReceivedByServerAtToMessage,
+  },
+  {
+    id: 6,
+    name: 'Drop inbox token column',
+    migrationEffect: dropInboxTokenColumn,
   },
 ] as const
 

--- a/apps/chat-service/src/db/migrations/0006_drop_inbox_token_column.ts
+++ b/apps/chat-service/src/db/migrations/0006_drop_inbox_token_column.ts
@@ -1,0 +1,10 @@
+import {SqlClient} from '@effect/sql'
+import {Effect} from 'effect'
+
+export default Effect.flatMap(
+  SqlClient.SqlClient,
+  (sql) => sql`
+    ALTER TABLE inbox
+    DROP COLUMN IF EXISTS token;
+  `
+)

--- a/apps/mobile/src/state/chat/atoms/fetchNewMessagesActionAtom.ts
+++ b/apps/mobile/src/state/chat/atoms/fetchNewMessagesActionAtom.ts
@@ -30,7 +30,6 @@ import {refreshNotificationBadgeCountActionAtom} from '../../../components/Badge
 import {type ActionAtomType} from '../../../utils/atomUtils/ActionAtomType'
 import {version} from '../../../utils/environment'
 import {isOnSpecificChat} from '../../../utils/navigation'
-import {getNotificationToken} from '../../../utils/notifications'
 import {
   cancelNewChatNotifications,
   cancelNewChatNotificationsForTargetTokens,
@@ -395,15 +394,10 @@ export const fetchAndStoreMessagesForInboxAtom = atom<
             {error}
           )
           return pipe(
-            getNotificationToken(),
-            TE.fromTask,
-            TE.chainW((token) =>
-              effectToTaskEither(
-                api.chat.createInbox({
-                  token: token ?? undefined,
-                  keyPair: inbox.inbox.privateKey,
-                })
-              )
+            effectToTaskEither(
+              api.chat.createInbox({
+                keyPair: inbox.inbox.privateKey,
+              })
             ),
             TE.match(
               (e) => {

--- a/apps/mobile/src/state/chat/hooks/useCreateInbox.ts
+++ b/apps/mobile/src/state/chat/hooks/useCreateInbox.ts
@@ -5,7 +5,6 @@ import {generateKeyPairE} from '@vexl-next/resources-utils/src/utils/crypto'
 import {Array, Effect, Option} from 'effect/index'
 import {atom} from 'jotai'
 import {apiAtom} from '../../../api'
-import {getNotificationTokenE} from '../../../utils/notifications'
 import messagingStateAtom from '../atoms/messagingStateAtom'
 import {ApiErrorCreatingInbox, type InboxInState} from '../domain'
 
@@ -43,7 +42,6 @@ export const upsertInboxOnBeAndLocallyActionAtom = atom(
         // Always hit create inbox. The backend wont fail if the inbox exists
         yield* _(
           api.chat.createInbox({
-            token: (yield* _(getNotificationTokenE())) ?? undefined,
             keyPair: existingInbox.value.inbox.privateKey,
           })
         )
@@ -51,10 +49,8 @@ export const upsertInboxOnBeAndLocallyActionAtom = atom(
       }
 
       const inboxKeypair = yield* _(generateKeyPairE())
-      const notificationToken = yield* _(getNotificationTokenE())
       yield* _(
         api.chat.createInbox({
-          token: notificationToken ?? undefined,
           keyPair: inboxKeypair,
         }),
         Effect.mapError((e) => new ApiErrorCreatingInbox({cause: e}))

--- a/packages/rest-api/src/services/chat/contracts.ts
+++ b/packages/rest-api/src/services/chat/contracts.ts
@@ -76,18 +76,14 @@ export type ServerMessageWithId = Schema.Schema.Type<typeof ServerMessageWithId>
 
 export const UpdateInboxRequest = Schema.Struct({
   ...RequestBaseWithChallenge.fields,
-  token: Schema.optional(Schema.String),
 })
 export type UpdateInboxRequest = Schema.Schema.Type<typeof UpdateInboxRequest>
 
-export const UpdateInboxResponse = Schema.Struct({
-  firebaseToken: Schema.optional(Schema.String),
-})
+export const UpdateInboxResponse = Schema.Struct({})
 export type UpdateInboxResponse = Schema.Schema.Type<typeof UpdateInboxResponse>
 
 export const CreateInboxRequest = Schema.Struct({
   ...RequestBaseWithChallenge.fields,
-  token: Schema.optional(Schema.String),
 })
 export type CreateInboxRequest = Schema.Schema.Type<typeof CreateInboxRequest>
 


### PR DESCRIPTION
## What

Removes the legacy FCM `token` plumbing around the chat service inbox:

- **New migration** dropping the unused `token` column from the `inbox` table. The column was created in the initial migration and has never been read or written by any query since — `InboxRecord` doesn't include it and the server never sends push notifications itself (notifications are handled by the separate notification system; `sendMessage` returns `notificationHandled: false`).
- **Contracts**: removed the optional `token` field from `CreateInboxRequest`/`UpdateInboxRequest` and `firebaseToken` from `UpdateInboxResponse`. The `createInbox` handler never read the field and `updateInbox` is already a deprecated no-op, so old clients still sending it are unaffected (extra payload fields are ignored on decode).
- **Mobile**: stopped sending the notification token on `createInbox` calls (`useCreateInbox`, inbox recreation in `fetchNewMessagesActionAtom`). This is also a small privacy win — the app was transmitting the device notification token to the chat service for no reason.

## Verification

`pnpm turbo:typecheck`, `turbo:format`, and `turbo:lint` pass for chat-service, rest-api, resources-utils, and mobile-app (remaining lint warnings are pre-existing deprecations in unrelated files).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified inbox creation by removing notification-token handling.
  * Updated inbox update requests and responses to reflect the streamlined flow.
* **Bug Fixes**
  * Removed the obsolete notification token from stored inbox data.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->