### PR TITLE
Add client metadata to backend metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,10 @@ When changing any UI / UX in the mobile app or in the ui package you must read @
 - packages/rest-api - effect-ts based rest api definitions and client for both backend and mobile app
 - tooling/* - shared tooling for the repo (esling, prettier, etc...)
 
+## Backend metrics
+
+All backend metrics are documented in docs/backend_stats.md. When you add, remove, or change a metric or its attributes, update that doc as part of the same change.
+
 ## Verification
 IMPORTANT -- Verification steps (do this to verify your code changes. Not all bugs / errors will be caught by CI, but the most obvious ones will):
 1. Run `pnpm turbo:typecheck` in the affected workspace. Read the output and fix all errors.

--- a/apps/chat-service/src/__tests__/routes/approveRequest.test.ts
+++ b/apps/chat-service/src/__tests__/routes/approveRequest.test.ts
@@ -14,6 +14,7 @@ import {Effect, Schema} from 'effect'
 import {NodeTestingApp} from '../utils/NodeTestingApp'
 import {addChallengeForKey} from '../utils/addChallengeForKey'
 import {
+  commonHeaders,
   createMockedUser,
   makeTestCommonAndSecurityHeaders,
   type MockedUser,
@@ -65,6 +66,7 @@ describe('Approve request', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         yield* _(
           client.Inboxes.approveRequest({
+            headers: commonHeaders,
             payload: yield* _(
               user2.inbox1.addChallenge({
                 message: 'acceptMessage' as MessageCypher,
@@ -93,6 +95,7 @@ describe('Approve request', () => {
               yield* _(setAuthHeaders(user2.authHeaders))
               return yield* _(
                 client.Messages.sendMessage({
+                  headers: commonHeaders,
                   payload: yield* _(
                     user2.inbox1.addChallenge({
                       message: 'someOtherMessage' as MessageCypher,
@@ -108,6 +111,7 @@ describe('Approve request', () => {
               yield* _(setAuthHeaders(user1.authHeaders))
               return yield* _(
                 client.Messages.sendMessage({
+                  headers: commonHeaders,
                   payload: yield* _(
                     user1.addChallengeForMainInbox({
                       message: 'someOtherMessage2' as MessageCypher,
@@ -135,6 +139,7 @@ describe('Approve request', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         yield* _(
           client.Inboxes.approveRequest({
+            headers: commonHeaders,
             payload: yield* _(
               user2.inbox1.addChallenge({
                 message: 'disapproveMessage' as MessageCypher,
@@ -163,6 +168,7 @@ describe('Approve request', () => {
               yield* _(setAuthHeaders(user2.authHeaders))
               return yield* _(
                 client.Messages.sendMessage({
+                  headers: commonHeaders,
                   payload: yield* _(
                     user2.inbox1.addChallenge({
                       message: 'someOtherMessage' as MessageCypher,
@@ -179,6 +185,7 @@ describe('Approve request', () => {
               yield* _(setAuthHeaders(user1.authHeaders))
               return yield* _(
                 client.Messages.sendMessage({
+                  headers: commonHeaders,
                   payload: yield* _(
                     user1.addChallengeForMainInbox({
                       message: 'someOtherMessage2' as MessageCypher,
@@ -227,6 +234,7 @@ describe('Approve request', () => {
           yield* _(setAuthHeaders(user2.authHeaders))
           const errorResponse = yield* _(
             client.Inboxes.approveRequest({
+              headers: commonHeaders,
               payload: yield* _(
                 user2.inbox1.addChallenge({
                   message: 'acceptMessage' as MessageCypher,
@@ -250,6 +258,7 @@ describe('Approve request', () => {
           yield* _(setAuthHeaders(user2.authHeaders))
           const errorResponse = yield* _(
             client.Inboxes.approveRequest({
+              headers: commonHeaders,
               payload: yield* _(
                 user2.inbox1.addChallenge({
                   message: 'acceptMessage' as MessageCypher,
@@ -273,6 +282,7 @@ describe('Approve request', () => {
           yield* _(setAuthHeaders(user2.authHeaders))
           const errorResponse = yield* _(
             client.Inboxes.approveRequest({
+              headers: commonHeaders,
               payload: yield* _(
                 user2.inbox1.addChallenge({
                   message: 'acceptMessage' as MessageCypher,
@@ -296,6 +306,7 @@ describe('Approve request', () => {
           yield* _(setAuthHeaders(user2.authHeaders))
           const errorResponse = yield* _(
             client.Inboxes.approveRequest({
+              headers: commonHeaders,
               payload: yield* _(
                 addChallengeForKey(
                   generatePrivateKey(),

--- a/apps/chat-service/src/__tests__/routes/blockInbox.test.ts
+++ b/apps/chat-service/src/__tests__/routes/blockInbox.test.ts
@@ -12,6 +12,7 @@ import {setAuthHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
 import {Effect} from 'effect'
 import {addChallengeForKey} from '../utils/addChallengeForKey'
 import {
+  commonHeaders,
   createMockedUser,
   makeTestCommonAndSecurityHeaders,
   type MockedUser,
@@ -53,6 +54,7 @@ beforeEach(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox1.addChallenge({
               message: 'someMessage2' as MessageCypher,
@@ -88,6 +90,7 @@ describe('Block inbox', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         const shouldBeRejectedResponse = yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: (yield* _(
               user1.addChallengeForMainInbox({
                 message: 'someMessage' as MessageCypher,

--- a/apps/chat-service/src/__tests__/routes/cancelRequest.test.ts
+++ b/apps/chat-service/src/__tests__/routes/cancelRequest.test.ts
@@ -14,6 +14,7 @@ import {setAuthHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
 import {Effect, Schema} from 'effect'
 import {NodeTestingApp} from '../utils/NodeTestingApp'
 import {
+  commonHeaders,
   createMockedUser,
   makeTestCommonAndSecurityHeaders,
   type MockedUser,
@@ -129,6 +130,7 @@ describe('Cancel request', () => {
           yield* _(setAuthHeaders(user2.authHeaders))
           yield* _(
             client.Inboxes.approveRequest({
+              headers: commonHeaders,
               payload: yield* _(
                 user2.inbox1.addChallenge({
                   publicKeyToConfirm: user1.mainKeyPair.publicKeyPemBase64,
@@ -169,6 +171,7 @@ describe('Cancel request', () => {
           yield* _(setAuthHeaders(user2.authHeaders))
           yield* _(
             client.Inboxes.approveRequest({
+              headers: commonHeaders,
               payload: yield* _(
                 user2.inbox1.addChallenge({
                   publicKeyToConfirm: user1.mainKeyPair.publicKeyPemBase64,

--- a/apps/chat-service/src/__tests__/routes/cancelRequestV2.test.ts
+++ b/apps/chat-service/src/__tests__/routes/cancelRequestV2.test.ts
@@ -14,7 +14,11 @@ import {setAuthHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
 import {Effect, Schema} from 'effect'
 import {NodeTestingApp} from '../utils/NodeTestingApp'
 import {addChallengeForKey} from '../utils/addChallengeForKey'
-import {createMockedUser, type MockedUser} from '../utils/createMockedUser'
+import {
+  commonHeaders,
+  createMockedUser,
+  type MockedUser,
+} from '../utils/createMockedUser'
 import {runPromiseInMockedEnvironment} from '../utils/runPromiseInMockedEnvironment'
 
 let user1: MockedUser
@@ -35,6 +39,7 @@ beforeEach(async () => {
       yield* _(setAuthHeaders(user1.authHeaders))
       yield* _(
         client.Inboxes.requestApprovalV2({
+          headers: commonHeaders,
           payload: yield* _(
             user1.inbox1.addChallenge({
               receiverPublicKey: user2.inbox1.keyPair.publicKeyPemBase64,
@@ -58,6 +63,7 @@ describe('Cancel request', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         yield* _(
           client.Inboxes.cancelRequestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 receiverPublicKey: user2.inbox1.keyPair.publicKeyPemBase64,
@@ -91,6 +97,7 @@ describe('Cancel request', () => {
           yield* _(setAuthHeaders(user1.authHeaders))
           const failedReqResponse = yield* _(
             client.Inboxes.cancelRequestApprovalV2({
+              headers: commonHeaders,
               payload: yield* _(
                 user1.inbox1.addChallenge({
                   receiverPublicKey: user2.inbox2.keyPair.publicKeyPemBase64,
@@ -114,6 +121,7 @@ describe('Cancel request', () => {
           yield* _(setAuthHeaders(user2.authHeaders))
           yield* _(
             client.Inboxes.approveRequest({
+              headers: commonHeaders,
               payload: yield* _(
                 user2.inbox1.addChallenge({
                   publicKeyToConfirm: user1.inbox1.keyPair.publicKeyPemBase64,
@@ -127,6 +135,7 @@ describe('Cancel request', () => {
           yield* _(setAuthHeaders(user1.authHeaders))
           const failedReqResponse = yield* _(
             client.Inboxes.cancelRequestApprovalV2({
+              headers: commonHeaders,
               payload: yield* _(
                 user1.inbox1.addChallenge({
                   receiverPublicKey: user2.inbox2.keyPair.publicKeyPemBase64,
@@ -150,6 +159,7 @@ describe('Cancel request', () => {
           yield* _(setAuthHeaders(user2.authHeaders))
           yield* _(
             client.Inboxes.approveRequest({
+              headers: commonHeaders,
               payload: yield* _(
                 user2.inbox1.addChallenge({
                   publicKeyToConfirm: user1.inbox1.keyPair.publicKeyPemBase64,
@@ -163,6 +173,7 @@ describe('Cancel request', () => {
           yield* _(setAuthHeaders(user1.authHeaders))
           const failedReqResponse = yield* _(
             client.Inboxes.cancelRequestApprovalV2({
+              headers: commonHeaders,
               payload: yield* _(
                 user1.inbox1.addChallenge({
                   receiverPublicKey: user2.inbox2.keyPair.publicKeyPemBase64,
@@ -194,6 +205,7 @@ describe('Cancel request', () => {
           yield* _(setAuthHeaders(dummyAuthHeaders))
           const failedReqResponse = yield* _(
             client.Inboxes.cancelRequestApprovalV2({
+              headers: commonHeaders,
               payload: yield* _(
                 addChallengeForKey(
                   dummyKeyPair,
@@ -219,6 +231,7 @@ describe('Cancel request', () => {
           yield* _(setAuthHeaders(user1.authHeaders))
           const failedReqResponse = yield* _(
             client.Inboxes.cancelRequestApprovalV2({
+              headers: commonHeaders,
               payload: yield* _(
                 user1.inbox1.addChallenge({
                   receiverPublicKey: generatePrivateKey().publicKeyPemBase64,

--- a/apps/chat-service/src/__tests__/routes/challenge.test.ts
+++ b/apps/chat-service/src/__tests__/routes/challenge.test.ts
@@ -3,6 +3,7 @@ import {type MessageCypher} from '@vexl-next/domain/src/general/messaging'
 import {setAuthHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
 import {Effect, Option} from 'effect'
 import {
+  commonHeaders,
   createMockedUser,
   makeTestCommonAndSecurityHeaders,
   type MockedUser,
@@ -39,6 +40,7 @@ beforeAll(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox1.addChallenge({
               message: 'someMessage2' as MessageCypher,

--- a/apps/chat-service/src/__tests__/routes/deleteExpiredMessages.test.ts
+++ b/apps/chat-service/src/__tests__/routes/deleteExpiredMessages.test.ts
@@ -7,6 +7,7 @@ import {Effect, Schema} from 'effect'
 import {clearExpiredMessagesTask} from '../../expiredMessagesCleanupWorker'
 import {NodeTestingApp} from '../utils/NodeTestingApp'
 import {
+  commonHeaders,
   createMockedUser,
   makeTestCommonAndSecurityHeaders,
   type MockedUser,
@@ -42,6 +43,7 @@ beforeAll(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox1.addChallenge({
               message: 'someMessage2' as MessageCypher,
@@ -83,12 +85,14 @@ describe('clear expired messages', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: messageToSend,
           })
         )
 
         yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: messageToSend2,
           })
         )

--- a/apps/chat-service/src/__tests__/routes/deleteInbox.test.ts
+++ b/apps/chat-service/src/__tests__/routes/deleteInbox.test.ts
@@ -7,6 +7,7 @@ import {setAuthHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
 import {Effect} from 'effect'
 import {hashPublicKey} from '../../db/domain'
 import {
+  commonHeaders,
   createMockedUser,
   makeTestCommonAndSecurityHeaders,
   type MockedUser,
@@ -50,6 +51,7 @@ beforeEach(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox1.addChallenge({
               message: 'someMessage2' as MessageCypher,
@@ -71,6 +73,7 @@ beforeEach(async () => {
 
       yield* _(
         client.Messages.sendMessage({
+          headers: commonHeaders,
           payload: messageToSend,
         })
       )

--- a/apps/chat-service/src/__tests__/routes/deleteInboxes.test.ts
+++ b/apps/chat-service/src/__tests__/routes/deleteInboxes.test.ts
@@ -9,6 +9,7 @@ import {hashPublicKey} from '../../db/domain'
 import {NodeTestingApp} from '../utils/NodeTestingApp'
 import {addChallengeForKey} from '../utils/addChallengeForKey'
 import {
+  commonHeaders,
   createMockedUser,
   makeTestCommonAndSecurityHeaders,
   type MockedUser,
@@ -53,6 +54,7 @@ beforeEach(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox1.addChallenge({
               message: 'someMessage2' as MessageCypher,
@@ -83,6 +85,7 @@ beforeEach(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox2.addChallenge({
               message: 'someMessage2' as MessageCypher,

--- a/apps/chat-service/src/__tests__/routes/deletePulledMessages.test.ts
+++ b/apps/chat-service/src/__tests__/routes/deletePulledMessages.test.ts
@@ -13,6 +13,7 @@ import {
 } from '@vexl-next/server-utils/src/tests/nodeTestingApp'
 import {addChallengeForKey} from '../utils/addChallengeForKey'
 import {
+  commonHeaders,
   createMockedUser,
   makeTestCommonAndSecurityHeaders,
   type MockedUser,
@@ -48,6 +49,7 @@ beforeAll(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox1.addChallenge({
               message: 'someMessage2' as MessageCypher,
@@ -91,6 +93,7 @@ describe('Delete pulled messages', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: messageToSend,
           })
         )

--- a/apps/chat-service/src/__tests__/routes/leaveChat.test.ts
+++ b/apps/chat-service/src/__tests__/routes/leaveChat.test.ts
@@ -13,6 +13,7 @@ import {setAuthHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
 import {Effect, Schema} from 'effect'
 import {addChallengeForKey} from '../utils/addChallengeForKey'
 import {
+  commonHeaders,
   createMockedUser,
   makeTestCommonAndSecurityHeaders,
   type MockedUser,
@@ -56,6 +57,7 @@ beforeEach(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox1.addChallenge({
               message: 'someMessage2' as MessageCypher,
@@ -77,6 +79,7 @@ beforeEach(async () => {
 
       yield* _(
         client.Messages.sendMessage({
+          headers: commonHeaders,
           payload: messageToSend,
         })
       )
@@ -95,6 +98,7 @@ describe('Leave chat', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         yield* _(
           client.Inboxes.leaveChat({
+            headers: commonHeaders,
             payload: yield* _(
               user2.inbox1.addChallenge({
                 message: 'leaveMessage' as MessageCypher,
@@ -137,6 +141,7 @@ describe('Leave chat', () => {
           yield* _(setAuthHeaders(user2.authHeaders))
           const failedResponse = yield* _(
             client.Inboxes.leaveChat({
+              headers: commonHeaders,
               payload: yield* _(
                 user2.inbox1.addChallenge({
                   message: 'leaveMessage' as MessageCypher,
@@ -160,6 +165,7 @@ describe('Leave chat', () => {
           yield* _(setAuthHeaders(user2.authHeaders))
           const failedResponse = yield* _(
             client.Inboxes.leaveChat({
+              headers: commonHeaders,
               payload: yield* _(
                 addChallengeForKey(
                   generatePrivateKey(),
@@ -186,6 +192,7 @@ describe('Leave chat', () => {
           yield* _(setAuthHeaders(user2.authHeaders))
           const failedResponse = yield* _(
             client.Inboxes.leaveChat({
+              headers: commonHeaders,
               payload: yield* _(
                 user2.inbox1.addChallenge({
                   message: 'leaveMessage' as MessageCypher,

--- a/apps/chat-service/src/__tests__/routes/requestApproval.test.ts
+++ b/apps/chat-service/src/__tests__/routes/requestApproval.test.ts
@@ -14,6 +14,7 @@ import {setAuthHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
 import {Effect, Schema} from 'effect'
 import {NodeTestingApp} from '../utils/NodeTestingApp'
 import {
+  commonHeaders,
   createMockedUser,
   makeTestCommonAndSecurityHeaders,
   type MockedUser,
@@ -194,6 +195,7 @@ describe('Request approval', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         yield* _(
           client.Inboxes.approveRequest({
+            headers: commonHeaders,
             payload: yield* _(
               user2.inbox1.addChallenge({
                 message: 'approval message' as MessageCypher,
@@ -244,6 +246,7 @@ describe('Request approval', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         yield* _(
           client.Inboxes.approveRequest({
+            headers: commonHeaders,
             payload: yield* _(
               user2.inbox1.addChallenge({
                 message: 'approval message' as MessageCypher,

--- a/apps/chat-service/src/__tests__/routes/requestApprovalV2.test.ts
+++ b/apps/chat-service/src/__tests__/routes/requestApprovalV2.test.ts
@@ -14,7 +14,11 @@ import {setAuthHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
 import {Effect, Schema} from 'effect'
 import {NodeTestingApp} from '../utils/NodeTestingApp'
 import {addChallengeForKey} from '../utils/addChallengeForKey'
-import {createMockedUser, type MockedUser} from '../utils/createMockedUser'
+import {
+  commonHeaders,
+  createMockedUser,
+  type MockedUser,
+} from '../utils/createMockedUser'
 import {runPromiseInMockedEnvironment} from '../utils/runPromiseInMockedEnvironment'
 
 let user1: MockedUser
@@ -44,6 +48,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request message' as MessageCypher,
@@ -80,6 +85,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request message' as MessageCypher,
@@ -91,6 +97,7 @@ describe('Request approval V2', () => {
 
         const toFail = yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request' as MessageCypher,
@@ -113,6 +120,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request message' as MessageCypher,
@@ -131,6 +139,7 @@ describe('Request approval V2', () => {
 
         const toNotFail = yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request' as MessageCypher,
@@ -144,6 +153,7 @@ describe('Request approval V2', () => {
 
         const toFail = yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request' as MessageCypher,
@@ -166,6 +176,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request message' as MessageCypher,
@@ -178,6 +189,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         yield* _(
           client.Inboxes.approveRequest({
+            headers: commonHeaders,
             payload: yield* _(
               user2.inbox1.addChallenge({
                 message: 'approval message' as MessageCypher,
@@ -191,6 +203,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         const toFail = yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request' as MessageCypher,
@@ -213,6 +226,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request message' as MessageCypher,
@@ -225,6 +239,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         yield* _(
           client.Inboxes.approveRequest({
+            headers: commonHeaders,
             payload: yield* _(
               user2.inbox1.addChallenge({
                 message: 'approval message' as MessageCypher,
@@ -238,6 +253,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         const toFail = yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request' as MessageCypher,
@@ -260,6 +276,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request message' as MessageCypher,
@@ -283,6 +300,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         const toFail = yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request' as MessageCypher,
@@ -305,6 +323,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request message' as MessageCypher,
@@ -316,6 +335,7 @@ describe('Request approval V2', () => {
 
         yield* _(
           client.Inboxes.cancelRequestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'cancel message' as MessageCypher,
@@ -327,6 +347,7 @@ describe('Request approval V2', () => {
 
         const toFail = yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request' as MessageCypher,
@@ -349,6 +370,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request message' as MessageCypher,
@@ -360,6 +382,7 @@ describe('Request approval V2', () => {
 
         yield* _(
           client.Inboxes.cancelRequestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'cancel message' as MessageCypher,
@@ -378,6 +401,7 @@ describe('Request approval V2', () => {
 
         const toNotFail = yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request' as MessageCypher,
@@ -392,6 +416,7 @@ describe('Request approval V2', () => {
 
         const toFail = yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request' as MessageCypher,
@@ -414,6 +439,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         const failedResponse = yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               user1.inbox1.addChallenge({
                 message: 'request message' as MessageCypher,
@@ -449,6 +475,7 @@ describe('Request approval V2', () => {
         yield* _(setAuthHeaders(dummyAuthHeaders))
         const failedResponse = yield* _(
           client.Inboxes.requestApprovalV2({
+            headers: commonHeaders,
             payload: yield* _(
               dummyAddChallenge({
                 message: 'request message' as MessageCypher,

--- a/apps/chat-service/src/__tests__/routes/retrieveMessages.test.ts
+++ b/apps/chat-service/src/__tests__/routes/retrieveMessages.test.ts
@@ -12,6 +12,7 @@ import {setAuthHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
 import {hashPublicKey} from '../../db/domain'
 import {addChallengeForKey} from '../utils/addChallengeForKey'
 import {
+  commonHeaders,
   createMockedUser,
   makeTestCommonAndSecurityHeaders,
   type MockedUser,
@@ -47,6 +48,7 @@ beforeAll(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox1.addChallenge({
               message: 'someMessage2' as MessageCypher,
@@ -77,6 +79,7 @@ describe('Retrieve messages', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: messageToSend,
           })
         )
@@ -119,6 +122,7 @@ describe('Retrieve messages', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: messageToSend,
           })
         )
@@ -167,6 +171,7 @@ describe('Retrieve messages', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: messageToSend,
           })
         )

--- a/apps/chat-service/src/__tests__/routes/sendMessage.test.ts
+++ b/apps/chat-service/src/__tests__/routes/sendMessage.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../../configs'
 import {addChallengeForKey} from '../utils/addChallengeForKey'
 import {
+  commonHeaders,
   createMockedUser,
   makeTestCommonAndSecurityHeaders,
   type MockedUser,
@@ -57,6 +58,7 @@ beforeAll(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox1.addChallenge({
               message: 'someMessage2' as MessageCypher,
@@ -90,6 +92,7 @@ describe('Send message', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         const sendMessageResponse = yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: messageToSend,
           })
         )
@@ -139,6 +142,7 @@ describe('Send message', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: messageToSend,
           })
         )
@@ -181,6 +185,7 @@ describe('Send message', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         const response = yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: messageToSend,
           }),
           Effect.either
@@ -210,6 +215,7 @@ describe('Send message', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         const response = yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: messageToSend,
           }),
           Effect.either
@@ -236,6 +242,7 @@ describe('Send message', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         const response = yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: messageToSend,
           }),
           Effect.either
@@ -263,6 +270,7 @@ describe('Send message', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         const response = yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: {...messageToSend, messageType: 'REQUEST_MESSAGING'},
           }),
           Effect.either
@@ -272,6 +280,7 @@ describe('Send message', () => {
 
         const response2 = yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: {...messageToSend, messageType: 'APPROVE_MESSAGING'},
           }),
           Effect.either
@@ -281,6 +290,7 @@ describe('Send message', () => {
 
         const response3 = yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: {...messageToSend, messageType: 'DISAPPROVE_MESSAGING'},
           }),
           Effect.either
@@ -290,6 +300,7 @@ describe('Send message', () => {
 
         const response4 = yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: {
               ...messageToSend,
               messageType: 'CANCEL_REQUEST_MESSAGING',
@@ -302,6 +313,7 @@ describe('Send message', () => {
 
         const response5 = yield* _(
           client.Messages.sendMessage({
+            headers: commonHeaders,
             payload: {
               ...messageToSend,
               messageType: 'INACTIVITY_REMINDER',

--- a/apps/chat-service/src/__tests__/routes/sendMessages.test.ts
+++ b/apps/chat-service/src/__tests__/routes/sendMessages.test.ts
@@ -13,6 +13,7 @@ import {Effect, Schema} from 'effect'
 import {NodeTestingApp} from '../utils/NodeTestingApp'
 import {addChallengeForKey} from '../utils/addChallengeForKey'
 import {
+  commonHeaders,
   createMockedUser,
   makeTestCommonAndSecurityHeaders,
   type MockedUser,
@@ -57,6 +58,7 @@ beforeEach(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox1.addChallenge({
               message: 'someMessage2' as MessageCypher,
@@ -87,6 +89,7 @@ beforeEach(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox2.addChallenge({
               message: 'someMessage2' as MessageCypher,
@@ -117,6 +120,7 @@ beforeEach(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox1.addChallenge({
               message: 'someMessage2' as MessageCypher,
@@ -147,6 +151,7 @@ beforeEach(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox2.addChallenge({
               message: 'someMessage2' as MessageCypher,
@@ -207,6 +212,7 @@ describe('Send messages', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         yield* _(
           client.Messages.sendMessages({
+            headers: commonHeaders,
             payload: {data: messagesToSend},
           })
         )
@@ -286,6 +292,7 @@ describe('Send messages', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         const errorResponse = yield* _(
           client.Messages.sendMessages({
+            headers: commonHeaders,
             payload: {data: messagesToSend},
           }),
           Effect.either
@@ -389,6 +396,7 @@ describe('Send messages', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         const errorResponse = yield* _(
           client.Messages.sendMessages({
+            headers: commonHeaders,
             payload: {data: messagesToSend},
           }),
           Effect.either
@@ -435,6 +443,7 @@ describe('Send messages', () => {
         yield* _(setAuthHeaders(user2.authHeaders))
         const errorResponse1 = yield* _(
           client.Messages.sendMessages({
+            headers: commonHeaders,
             payload: {
               data: [
                 yield* _(
@@ -458,6 +467,7 @@ describe('Send messages', () => {
 
         const errorResponse2 = yield* _(
           client.Messages.sendMessages({
+            headers: commonHeaders,
             payload: {
               data: [
                 yield* _(
@@ -481,6 +491,7 @@ describe('Send messages', () => {
 
         const errorResponse3 = yield* _(
           client.Messages.sendMessages({
+            headers: commonHeaders,
             payload: {
               data: [
                 yield* _(
@@ -504,6 +515,7 @@ describe('Send messages', () => {
 
         const errorResponse4 = yield* _(
           client.Messages.sendMessages({
+            headers: commonHeaders,
             payload: {
               data: [
                 yield* _(
@@ -527,6 +539,7 @@ describe('Send messages', () => {
 
         const errorResponse5 = yield* _(
           client.Messages.sendMessages({
+            headers: commonHeaders,
             payload: {
               data: [
                 yield* _(

--- a/apps/chat-service/src/__tests__/routes/updateInbox.test.ts
+++ b/apps/chat-service/src/__tests__/routes/updateInbox.test.ts
@@ -3,6 +3,7 @@ import {type MessageCypher} from '@vexl-next/domain/src/general/messaging'
 import {setAuthHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
 import {Effect} from 'effect'
 import {
+  commonHeaders,
   createMockedUser,
   makeTestCommonAndSecurityHeaders,
   type MockedUser,
@@ -39,6 +40,7 @@ beforeAll(async () => {
       yield* _(setAuthHeaders(user2.authHeaders))
       yield* _(
         client.Inboxes.approveRequest({
+          headers: commonHeaders,
           payload: yield* _(
             user2.inbox1.addChallenge({
               message: 'someMessage2' as MessageCypher,

--- a/apps/chat-service/src/metrics.ts
+++ b/apps/chat-service/src/metrics.ts
@@ -50,7 +50,8 @@ export const reportRequestCanceled = (
   )
 
 export const reportRequestApproved = (
-  number: number
+  number: number,
+  attributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
@@ -58,6 +59,7 @@ export const reportRequestApproved = (
       value: number,
       timestamp: new Date(),
       name: REQUEST_APPROVED,
+      attributes,
     })
   )
 

--- a/apps/chat-service/src/metrics.ts
+++ b/apps/chat-service/src/metrics.ts
@@ -3,6 +3,7 @@
 import {SqlClient, SqlSchema} from '@effect/sql'
 import {generateUuid} from '@vexl-next/domain/src/utility/Uuid.brand'
 import {shouldDisableMetrics} from '@vexl-next/server-utils/src/commonConfigs'
+import {type CommonMetricAttributes} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {MetricsMessage} from '@vexl-next/server-utils/src/metrics/domain'
 import {type MetricsClientService} from '@vexl-next/server-utils/src/metrics/MetricsClientService'
 import {reportMetricForked} from '@vexl-next/server-utils/src/metrics/reportMetricForked'
@@ -81,7 +82,8 @@ export const reportChatClosed = (
   )
 
 export const reportMessageSent = (
-  number: number
+  number: number,
+  attributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
@@ -89,6 +91,7 @@ export const reportMessageSent = (
       value: number,
       timestamp: new Date(),
       name: MESSAGE_SENT,
+      attributes,
     })
   )
 

--- a/apps/chat-service/src/metrics.ts
+++ b/apps/chat-service/src/metrics.ts
@@ -36,7 +36,8 @@ export const reportRequestSent = (
   )
 
 export const reportRequestCanceled = (
-  number: number
+  number: number,
+  attributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
@@ -44,6 +45,7 @@ export const reportRequestCanceled = (
       value: number,
       timestamp: new Date(),
       name: REQUEST_CANCEL,
+      attributes,
     })
   )
 

--- a/apps/chat-service/src/metrics.ts
+++ b/apps/chat-service/src/metrics.ts
@@ -78,7 +78,8 @@ export const reportRequestRejected = (
   )
 
 export const reportChatClosed = (
-  number: number
+  number: number,
+  attributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
@@ -86,6 +87,7 @@ export const reportChatClosed = (
       value: number,
       timestamp: new Date(),
       name: CHAT_CLOSED,
+      attributes,
     })
   )
 

--- a/apps/chat-service/src/metrics.ts
+++ b/apps/chat-service/src/metrics.ts
@@ -22,7 +22,8 @@ const REQUEST_REJECTED = 'REQUEST_REJECTED'
 const CHAT_CLOSED = 'CHAT_CLOSED'
 
 export const reportRequestSent = (
-  number: number
+  number: number,
+  attributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
@@ -30,6 +31,7 @@ export const reportRequestSent = (
       value: number,
       timestamp: new Date(),
       name: REQUEST_SENT,
+      attributes,
     })
   )
 

--- a/apps/chat-service/src/metrics.ts
+++ b/apps/chat-service/src/metrics.ts
@@ -64,7 +64,8 @@ export const reportRequestApproved = (
   )
 
 export const reportRequestRejected = (
-  number: number
+  number: number,
+  attributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
@@ -72,6 +73,7 @@ export const reportRequestRejected = (
       value: number,
       timestamp: new Date(),
       name: REQUEST_REJECTED,
+      attributes,
     })
   )
 

--- a/apps/chat-service/src/routes/inbox/approveReqest.ts
+++ b/apps/chat-service/src/routes/inbox/approveReqest.ts
@@ -7,6 +7,7 @@ import {
 } from '@vexl-next/rest-api/src/services/chat/contracts'
 import {ChatApiSpecification} from '@vexl-next/rest-api/src/services/chat/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {validateChallengeInBody} from '@vexl-next/server-utils/src/services/challenge/utils/validateChallengeInBody'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
 import {Effect} from 'effect'
@@ -123,7 +124,9 @@ export const approveRequest = HttpApiBuilder.handler(
         req.payload.publicKeyToConfirm
       ),
       withDbTransaction,
-      Effect.zipLeft(reportMessageSent(1)),
+      Effect.zipLeft(
+        reportMessageSent(1, commonMetricAttributesFromHeaders(req.headers))
+      ),
       makeEndpointEffect
     )
 )

--- a/apps/chat-service/src/routes/inbox/approveReqest.ts
+++ b/apps/chat-service/src/routes/inbox/approveReqest.ts
@@ -29,6 +29,9 @@ export const approveRequest = HttpApiBuilder.handler(
   'approveRequest',
   (req) =>
     Effect.gen(function* (_) {
+      const commonMetricAttributes = commonMetricAttributesFromHeaders(
+        req.headers
+      )
       yield* _(validateChallengeInBody(req.payload))
 
       // from the point of view of the one that sent the request
@@ -76,7 +79,7 @@ export const approveRequest = HttpApiBuilder.handler(
           })
         )
 
-        yield* _(reportRequestApproved(1))
+        yield* _(reportRequestApproved(1, commonMetricAttributes))
       } else {
         // Not approved
         yield* _(

--- a/apps/chat-service/src/routes/inbox/approveReqest.ts
+++ b/apps/chat-service/src/routes/inbox/approveReqest.ts
@@ -96,7 +96,7 @@ export const approveRequest = HttpApiBuilder.handler(
             sender: receiverInbox.publicKey,
           })
         )
-        yield* _(reportRequestRejected(0))
+        yield* _(reportRequestRejected(0, commonMetricAttributes))
       }
 
       const encryptedSenderPublicKey = yield* _(

--- a/apps/chat-service/src/routes/inbox/cancelRequest.ts
+++ b/apps/chat-service/src/routes/inbox/cancelRequest.ts
@@ -74,7 +74,7 @@ export const cancelRequest = HttpApiBuilder.handler(
       )
 
       yield* _(reportMessageSent(1, commonMetricAttributes))
-      yield* _(reportRequestCanceled(1))
+      yield* _(reportRequestCanceled(1, commonMetricAttributes))
 
       return {
         ...messageRecordToServerMessage({
@@ -152,7 +152,7 @@ export const cancelRequestV2 = HttpApiBuilder.handler(
       )
 
       yield* _(reportMessageSent(1, commonMetricAttributes))
-      yield* _(reportRequestCanceled(1))
+      yield* _(reportRequestCanceled(1, commonMetricAttributes))
 
       return {
         ...messageRecordToServerMessage({

--- a/apps/chat-service/src/routes/inbox/cancelRequest.ts
+++ b/apps/chat-service/src/routes/inbox/cancelRequest.ts
@@ -6,6 +6,7 @@ import {
 } from '@vexl-next/rest-api/src/services/chat/contracts'
 import {ChatApiSpecification} from '@vexl-next/rest-api/src/services/chat/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {validateChallengeInBody} from '@vexl-next/server-utils/src/services/challenge/utils/validateChallengeInBody'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
 import {Effect} from 'effect'
@@ -23,6 +24,9 @@ export const cancelRequest = HttpApiBuilder.handler(
   'cancelRequestApproval',
   (req) =>
     Effect.gen(function* (_) {
+      const commonMetricAttributes = commonMetricAttributesFromHeaders(
+        req.headers
+      )
       const security = yield* _(CurrentSecurity)
 
       const {receiverInbox, senderInbox} = yield* _(
@@ -69,7 +73,7 @@ export const cancelRequest = HttpApiBuilder.handler(
         })
       )
 
-      yield* _(reportMessageSent(1))
+      yield* _(reportMessageSent(1, commonMetricAttributes))
       yield* _(reportRequestCanceled(1))
 
       return {
@@ -98,6 +102,9 @@ export const cancelRequestV2 = HttpApiBuilder.handler(
   'cancelRequestApprovalV2',
   (req) =>
     Effect.gen(function* (_) {
+      const commonMetricAttributes = commonMetricAttributesFromHeaders(
+        req.headers
+      )
       yield* _(validateChallengeInBody(req.payload))
 
       const {receiverInbox, senderInbox} = yield* _(
@@ -144,7 +151,7 @@ export const cancelRequestV2 = HttpApiBuilder.handler(
         })
       )
 
-      yield* _(reportMessageSent(1))
+      yield* _(reportMessageSent(1, commonMetricAttributes))
       yield* _(reportRequestCanceled(1))
 
       return {

--- a/apps/chat-service/src/routes/inbox/leaveChat.ts
+++ b/apps/chat-service/src/routes/inbox/leaveChat.ts
@@ -2,6 +2,7 @@ import {HttpApiBuilder} from '@effect/platform/index'
 import {type CancelApprovalResponse} from '@vexl-next/rest-api/src/services/chat/contracts'
 import {ChatApiSpecification} from '@vexl-next/rest-api/src/services/chat/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {validateChallengeInBody} from '@vexl-next/server-utils/src/services/challenge/utils/validateChallengeInBody'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
 import {Effect, Option} from 'effect'
@@ -71,7 +72,10 @@ export const leaveChat = HttpApiBuilder.handler(
           type: 'DELETE_CHAT',
         })
       )
-      yield* _(reportMessageSent(1))
+      const commonMetricAttributes = commonMetricAttributesFromHeaders(
+        req.headers
+      )
+      yield* _(reportMessageSent(1, commonMetricAttributes))
       yield* _(reportChatClosed(1))
 
       return {

--- a/apps/chat-service/src/routes/inbox/leaveChat.ts
+++ b/apps/chat-service/src/routes/inbox/leaveChat.ts
@@ -76,7 +76,7 @@ export const leaveChat = HttpApiBuilder.handler(
         req.headers
       )
       yield* _(reportMessageSent(1, commonMetricAttributes))
-      yield* _(reportChatClosed(1))
+      yield* _(reportChatClosed(1, commonMetricAttributes))
 
       return {
         ...messageRecordToServerMessage({

--- a/apps/chat-service/src/routes/inbox/requestApproval.ts
+++ b/apps/chat-service/src/routes/inbox/requestApproval.ts
@@ -119,7 +119,7 @@ export const requestApproval = HttpApiBuilder.handler(
       )
 
       yield* _(reportMessageSent(1, commonMetricAttributes))
-      yield* _(reportRequestSent(1))
+      yield* _(reportRequestSent(1, commonMetricAttributes))
 
       return {
         ...messageRecordToServerMessage({
@@ -187,7 +187,7 @@ export const requestApprovalV2 = HttpApiBuilder.handler(
       )
 
       yield* _(reportMessageSent(1, commonMetricAttributes))
-      yield* _(reportRequestSent(1))
+      yield* _(reportRequestSent(1, commonMetricAttributes))
 
       return {
         ...messageRecordToServerMessage({

--- a/apps/chat-service/src/routes/inbox/requestApproval.ts
+++ b/apps/chat-service/src/routes/inbox/requestApproval.ts
@@ -7,6 +7,7 @@ import {
 } from '@vexl-next/rest-api/src/services/chat/contracts'
 import {ChatApiSpecification} from '@vexl-next/rest-api/src/services/chat/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {validateChallengeInBody} from '@vexl-next/server-utils/src/services/challenge/utils/validateChallengeInBody'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
 import dayjs from 'dayjs'
@@ -73,6 +74,9 @@ export const requestApproval = HttpApiBuilder.handler(
   'requestApproval',
   (req) =>
     Effect.gen(function* (_) {
+      const commonMetricAttributes = commonMetricAttributesFromHeaders(
+        req.headers
+      )
       const security = yield* _(CurrentSecurity)
 
       const {receiverInbox, senderInbox} = yield* _(
@@ -114,7 +118,7 @@ export const requestApproval = HttpApiBuilder.handler(
         })
       )
 
-      yield* _(reportMessageSent(1))
+      yield* _(reportMessageSent(1, commonMetricAttributes))
       yield* _(reportRequestSent(1))
 
       return {
@@ -137,6 +141,9 @@ export const requestApprovalV2 = HttpApiBuilder.handler(
   'requestApprovalV2',
   (req) =>
     Effect.gen(function* (_) {
+      const commonMetricAttributes = commonMetricAttributesFromHeaders(
+        req.headers
+      )
       yield* _(validateChallengeInBody(req.payload))
 
       const {receiverInbox, senderInbox} = yield* _(
@@ -179,7 +186,7 @@ export const requestApprovalV2 = HttpApiBuilder.handler(
         })
       )
 
-      yield* _(reportMessageSent(1))
+      yield* _(reportMessageSent(1, commonMetricAttributes))
       yield* _(reportRequestSent(1))
 
       return {

--- a/apps/chat-service/src/routes/messages/sendMessage.ts
+++ b/apps/chat-service/src/routes/messages/sendMessage.ts
@@ -3,6 +3,7 @@ import {type SendMessageResponse} from '@vexl-next/rest-api/src/services/chat/co
 import {ChatApiSpecification} from '@vexl-next/rest-api/src/services/chat/specification'
 import {ForbiddenMessageTyperror} from '@vexl-next/rest-api/src/services/contact/contracts'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {validateChallengeInBody} from '@vexl-next/server-utils/src/services/challenge/utils/validateChallengeInBody'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
 import {Effect, Option} from 'effect'
@@ -69,7 +70,9 @@ export const sendMessage = HttpApiBuilder.handler(
     }).pipe(
       withInboxActionRedisLock(req.payload.receiverPublicKey),
       withDbTransaction,
-      Effect.zipLeft(reportMessageSent(1)),
+      Effect.zipLeft(
+        reportMessageSent(1, commonMetricAttributesFromHeaders(req.headers))
+      ),
       makeEndpointEffect
     )
 )

--- a/apps/chat-service/src/routes/messages/sendMessages.ts
+++ b/apps/chat-service/src/routes/messages/sendMessages.ts
@@ -19,6 +19,10 @@ import {
 import {type ServerCrypto} from '@vexl-next/server-utils/src/ServerCrypto'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
 import {type MetricsClientService} from '@vexl-next/server-utils/src/metrics/MetricsClientService'
+import {
+  commonMetricAttributesFromHeaders,
+  type CommonMetricAttributes,
+} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {validateChallengeInBody} from '@vexl-next/server-utils/src/services/challenge/utils/validateChallengeInBody'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
 import {Array, Effect, Option, pipe, type ConfigError} from 'effect'
@@ -35,7 +39,8 @@ import {messageRecordToServerMessage} from './messageRecordToServerMessage'
 
 const sendMessage = (
   senderPublicKey: PublicKeyPemBase64,
-  message: MessageInBatch
+  message: MessageInBatch,
+  commonMetricAttributes: CommonMetricAttributes
 ): Effect.Effect<
   SendMessageResponse,
   | ReceiverInboxDoesNotExistError
@@ -83,7 +88,7 @@ const sendMessage = (
     } satisfies SendMessageResponse
   }).pipe(
     withInboxActionRedisLock(message.receiverPublicKey),
-    Effect.zipLeft(reportMessageSent(1))
+    Effect.zipLeft(reportMessageSent(1, commonMetricAttributes))
   ) // TODO lock two inboxes
 
 export const sendMessages = HttpApiBuilder.handler(
@@ -119,7 +124,11 @@ export const sendMessages = HttpApiBuilder.handler(
           const result = yield* _(
             oneMessage.messages,
             Array.map((message) =>
-              sendMessage(oneMessage.senderPublicKey, message)
+              sendMessage(
+                oneMessage.senderPublicKey,
+                message,
+                commonMetricAttributesFromHeaders(req.headers)
+              )
             ),
             Effect.all
           )

--- a/apps/contact-service/src/__tests__/routes/user/refreshUser.test.ts
+++ b/apps/contact-service/src/__tests__/routes/user/refreshUser.test.ts
@@ -13,6 +13,7 @@ import {UserNotFoundError} from '@vexl-next/rest-api/src/services/contact/contra
 import {hashPhoneNumber} from '@vexl-next/server-utils/src/generateUserAuthData'
 import {createDummyAuthHeadersForUser} from '@vexl-next/server-utils/src/tests/createDummyAuthHeaders'
 import {expectErrorResponse} from '@vexl-next/server-utils/src/tests/expectErrorResponse'
+import {mockedReportMetric} from '@vexl-next/server-utils/src/tests/mockedMetricsClientService'
 import {setAuthHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
 import {
   clearEnqueuedNotifications,
@@ -68,6 +69,7 @@ describe('Refresh user', () => {
   it('Refreshses user in database (refreshedAt clientVersion, and countryPrefix)', async () => {
     await runPromiseInMockedEnvironment(
       Effect.gen(function* (_) {
+        mockedReportMetric.mockClear()
         const sql = yield* _(SqlClient.SqlClient)
         yield* _(sql`
           UPDATE users
@@ -90,7 +92,7 @@ describe('Refresh user', () => {
         const testCommonHeaders = Schema.decodeSync(CommonHeaders)({
           'user-agent': 'Vexl/2 (1.0.0) ANDROID',
           'vexl-app-meta':
-            '{"appSource":"Some test123", "versionCode": 2, "platform":"ANDROID", "semver": "1.0.0", "language": "en", "isDeveloper": false}',
+            '{"appSource":"Some test123", "versionCode": 2, "platform":"ANDROID", "semver": "1.0.0", "language": "en", "isDeveloper": false, "prefix": 420}',
         })
 
         const commonAndSecurityHeaders = makeCommonAndSecurityHeaders(
@@ -123,6 +125,19 @@ describe('Refresh user', () => {
         expect(userInDb[0]).toHaveProperty('clientVersion', 2)
         expect(userInDb[0]).toHaveProperty('refreshedAt', expect.any(Date))
         expect(userInDb[0]).toHaveProperty('appSource', 'Some test123')
+        expect(userInDb[0]).toHaveProperty('countryPrefix', 420)
+        expect(mockedReportMetric).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'USER_REFRESH',
+            attributes: {
+              appVersion: '1.0.0',
+              appVersionCode: 2,
+              appPlatform: 'ANDROID',
+              appSource: 'Some test123',
+              clientCountryPrefix: 420,
+            },
+          })
+        )
       })
     )
   })

--- a/apps/contact-service/src/metrics.ts
+++ b/apps/contact-service/src/metrics.ts
@@ -103,7 +103,8 @@ export const reportClubReported = (
   )
 
 export const reportClubDeactivated = (
-  number: number
+  number: number,
+  attributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
@@ -111,6 +112,7 @@ export const reportClubDeactivated = (
       value: number,
       timestamp: new Date(),
       name: CLUB_DEACTIVATED,
+      attributes,
     })
   )
 

--- a/apps/contact-service/src/metrics.ts
+++ b/apps/contact-service/src/metrics.ts
@@ -4,6 +4,7 @@ import {type ClubUuid} from '@vexl-next/domain/src/general/clubs'
 import {generateUuid} from '@vexl-next/domain/src/utility/Uuid.brand'
 import {shouldDisableMetrics} from '@vexl-next/server-utils/src/commonConfigs'
 import {type MetricsClientService} from '@vexl-next/server-utils/src/metrics/MetricsClientService'
+import {type CommonMetricAttributes} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {MetricsMessage} from '@vexl-next/server-utils/src/metrics/domain'
 import {reportMetricForked} from '@vexl-next/server-utils/src/metrics/reportMetricForked'
 import {Effect, Layer} from 'effect'
@@ -60,16 +61,15 @@ export const reportCountOfConnections = (
     })
   )
 
-export const reportUserRefresh = (): Effect.Effect<
-  void,
-  never,
-  MetricsClientService
-> =>
+export const reportUserRefresh = (
+  attributes: CommonMetricAttributes
+): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
       uuid: generateUuid(),
       timestamp: new Date(),
       name: USER_REFRESH,
+      attributes,
     })
   )
 

--- a/apps/contact-service/src/metrics.ts
+++ b/apps/contact-service/src/metrics.ts
@@ -89,7 +89,8 @@ export const reportNewAppUser = (
   )
 
 export const reportClubReported = (
-  number: number
+  number: number,
+  attributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
@@ -97,6 +98,7 @@ export const reportClubReported = (
       value: number,
       timestamp: new Date(),
       name: CLUB_REPORTED,
+      attributes,
     })
   )
 

--- a/apps/contact-service/src/routes/clubs/member/reportClub.ts
+++ b/apps/contact-service/src/routes/clubs/member/reportClub.ts
@@ -118,7 +118,7 @@ export const reportClub = HttpApiBuilder.handler(
         reportedClub.value.report >= club.reportLimit
       ) {
         yield* _(deactivateAndClearClubs)
-        yield* _(reportClubDeactivated(1))
+        yield* _(reportClubDeactivated(1, commonMetricAttributes))
       }
 
       return {}

--- a/apps/contact-service/src/routes/clubs/member/reportClub.ts
+++ b/apps/contact-service/src/routes/clubs/member/reportClub.ts
@@ -9,6 +9,7 @@ import {CurrentSecurity} from '@vexl-next/rest-api/src/apiSecurity'
 import {ReportClubLimitReachedError} from '@vexl-next/rest-api/src/services/contact/contracts'
 import {ContactApiSpecification} from '@vexl-next/rest-api/src/services/contact/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {validateChallengeInBody} from '@vexl-next/server-utils/src/services/challenge/utils/validateChallengeInBody'
 import {Effect, Option, Schema} from 'effect'
 import {clubReportLimistCount} from '../../../configs'
@@ -24,6 +25,9 @@ export const reportClub = HttpApiBuilder.handler(
   'reportClub',
   (req) =>
     Effect.gen(function* (_) {
+      const commonMetricAttributes = commonMetricAttributesFromHeaders(
+        req.headers
+      )
       yield* _(validateChallengeInBody(req.payload))
       const security = yield* _(CurrentSecurity)
 
@@ -105,7 +109,7 @@ export const reportClub = HttpApiBuilder.handler(
         })
       )
 
-      yield* _(reportClubReported(1))
+      yield* _(reportClubReported(1, commonMetricAttributes))
 
       const reportedClub = yield* _(clubsDb.findClubByUuid({uuid: club.uuid}))
 

--- a/apps/contact-service/src/routes/user/refreshUser.ts
+++ b/apps/contact-service/src/routes/user/refreshUser.ts
@@ -3,6 +3,7 @@ import {CurrentSecurity} from '@vexl-next/rest-api/src/apiSecurity'
 import {UserNotFoundError} from '@vexl-next/rest-api/src/services/contact/contracts'
 import {ContactApiSpecification} from '@vexl-next/rest-api/src/services/contact/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
 import {Array, Effect} from 'effect'
 import {contactActiveWindowDaysConfig} from '../../configs'
@@ -38,7 +39,9 @@ export const refreshUser = HttpApiBuilder.handler(
       Effect.bind('serverHash', (s) => serverHashPhoneNumber(s.hash)),
       Effect.flatMap((security) =>
         Effect.gen(function* (_) {
-          yield* _(reportUserRefresh())
+          yield* _(
+            reportUserRefresh(commonMetricAttributesFromHeaders(req.headers))
+          )
           const userDb = yield* _(UserDbService)
           const contactDb = yield* _(ContactDbService)
           const contactActiveWindowDays = yield* _(

--- a/apps/metrics-service/src/routes/reportNotificationInteraction.ts
+++ b/apps/metrics-service/src/routes/reportNotificationInteraction.ts
@@ -1,6 +1,7 @@
 import {HttpApiBuilder} from '@effect/platform/index'
 import {MetricsApiSpecification} from '@vexl-next/rest-api/src/services/metrics/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {Effect, Option} from 'effect/index'
 import {MetricsDbService} from '../db/MetricsDbService'
 
@@ -11,6 +12,7 @@ export const reportNotificationInteraction = HttpApiBuilder.handler(
   ({headers, urlParams: query}) =>
     Effect.gen(function* (_) {
       const dataToSave = {
+        ...commonMetricAttributesFromHeaders(headers),
         clientVersion: Option.getOrElse(
           headers.clientVersionOrNone,
           () => 'UNKNOWN'

--- a/apps/offer-service/src/metrics.ts
+++ b/apps/offer-service/src/metrics.ts
@@ -3,6 +3,7 @@ import {CountryPrefix} from '@vexl-next/domain/src/general/CountryPrefix.brand'
 import {type OfferId} from '@vexl-next/domain/src/general/offers'
 import {generateUuid} from '@vexl-next/domain/src/utility/Uuid.brand'
 import {shouldDisableMetrics} from '@vexl-next/server-utils/src/commonConfigs'
+import {type CommonMetricAttributes} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {MetricsMessage} from '@vexl-next/server-utils/src/metrics/domain'
 import {type MetricsClientService} from '@vexl-next/server-utils/src/metrics/MetricsClientService'
 import {reportMetricForked} from '@vexl-next/server-utils/src/metrics/reportMetricForked'
@@ -62,14 +63,15 @@ export const reportOfferModified = (): Effect.Effect<
   )
 
 export const reportOfferCreated = (
-  countryPrefix: CountryPrefix
+  countryPrefix: CountryPrefix,
+  commonMetricAttributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
       uuid: generateUuid(),
       timestamp: new Date(),
       name: OFFER_CREATED,
-      attributes: {countryPrefix},
+      attributes: {...commonMetricAttributes, countryPrefix},
     })
   )
 

--- a/apps/offer-service/src/metrics.ts
+++ b/apps/offer-service/src/metrics.ts
@@ -49,16 +49,15 @@ export const reportOfferPublicPartDeleted = (): Effect.Effect<
     })
   )
 
-export const reportOfferModified = (): Effect.Effect<
-  void,
-  never,
-  MetricsClientService
-> =>
+export const reportOfferModified = (
+  attributes: CommonMetricAttributes
+): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
       uuid: generateUuid(),
       timestamp: new Date(),
       name: OFFER_MODIFIED,
+      attributes,
     })
   )
 

--- a/apps/offer-service/src/metrics.ts
+++ b/apps/offer-service/src/metrics.ts
@@ -75,26 +75,28 @@ export const reportOfferCreated = (
   )
 
 export const reportOfferReported = (
-  offerId: OfferId
+  offerId: OfferId,
+  commonMetricAttributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
       uuid: generateUuid(),
       timestamp: new Date(),
       name: OFFER_REPORTED,
-      attributes: {offerId},
+      attributes: {...commonMetricAttributes, offerId},
     })
   )
 
 export const reportClubOfferReported = (
-  offerId: OfferId
+  offerId: OfferId,
+  commonMetricAttributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
       uuid: generateUuid(),
       timestamp: new Date(),
       name: OFFER_REPORTED,
-      attributes: {offerId},
+      attributes: {...commonMetricAttributes, offerId},
     })
   )
 

--- a/apps/offer-service/src/routes/createNewOffer.ts
+++ b/apps/offer-service/src/routes/createNewOffer.ts
@@ -4,6 +4,7 @@ import {newOfferId} from '@vexl-next/domain/src/general/offers'
 import {CurrentSecurity} from '@vexl-next/rest-api/src/apiSecurity'
 import {OfferApiSpecification} from '@vexl-next/rest-api/src/services/offer/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
 import {Effect, Option} from 'effect'
 import {OfferDbService} from '../db/OfferDbService'
@@ -78,7 +79,12 @@ export const createNewOffer = HttpApiBuilder.handler(
       withDbTransaction,
       withOfferAdminActionRedisLock(req.payload.adminId),
       Effect.withSpan('createNewOffer'),
-      Effect.zipLeft(reportOfferCreated(req.payload.countryPrefix)),
+      Effect.zipLeft(
+        reportOfferCreated(
+          req.payload.countryPrefix,
+          commonMetricAttributesFromHeaders(req.headers)
+        )
+      ),
       makeEndpointEffect
     )
 )

--- a/apps/offer-service/src/routes/reportClubOffer.ts
+++ b/apps/offer-service/src/routes/reportClubOffer.ts
@@ -4,6 +4,7 @@ import {CurrentSecurity} from '@vexl-next/rest-api/src/apiSecurity'
 import {ReportOfferLimitReachedError} from '@vexl-next/rest-api/src/services/offer/contracts'
 import {OfferApiSpecification} from '@vexl-next/rest-api/src/services/offer/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {validateChallengeInBody} from '@vexl-next/server-utils/src/services/challenge/utils/validateChallengeInBody'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
 import {Effect, Option} from 'effect'
@@ -67,7 +68,12 @@ export const reportClubOffer = HttpApiBuilder.handler(
         offerId: req.payload.offerId,
       }),
       withDbTransaction,
-      Effect.zipLeft(reportClubOfferReported(req.payload.offerId)),
+      Effect.zipLeft(
+        reportClubOfferReported(
+          req.payload.offerId,
+          commonMetricAttributesFromHeaders(req.headers)
+        )
+      ),
       makeEndpointEffect
     )
 )

--- a/apps/offer-service/src/routes/reportOffer.ts
+++ b/apps/offer-service/src/routes/reportOffer.ts
@@ -5,6 +5,7 @@ import {ReportOfferLimitReachedError} from '@vexl-next/rest-api/src/services/off
 import {OfferApiSpecification} from '@vexl-next/rest-api/src/services/offer/specification'
 import {withRedisLockFromEffect} from '@vexl-next/server-utils/src/RedisService'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {Effect, Option} from 'effect'
 import {reportLimitCountConfig} from '../configs'
 import {OfferDbService} from '../db/OfferDbService'
@@ -62,7 +63,12 @@ export const reportOffer = HttpApiBuilder.handler(
         ),
         500
       ),
-      Effect.zipLeft(reportOfferReported(req.payload.offerId)),
+      Effect.zipLeft(
+        reportOfferReported(
+          req.payload.offerId,
+          commonMetricAttributesFromHeaders(req.headers)
+        )
+      ),
       makeEndpointEffect
     )
 )

--- a/apps/offer-service/src/routes/updateOffer.ts
+++ b/apps/offer-service/src/routes/updateOffer.ts
@@ -6,6 +6,7 @@ import {
 import {CurrentSecurity} from '@vexl-next/rest-api/src/apiSecurity'
 import {OfferApiSpecification} from '@vexl-next/rest-api/src/services/offer/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
 import {Array, Effect} from 'effect'
 import {OfferDbService} from '../db/OfferDbService'
@@ -84,7 +85,9 @@ export const updateOffer = HttpApiBuilder.handler(
     }).pipe(
       withDbTransaction,
       withOfferAdminActionRedisLock(req.payload.adminId),
-      Effect.zipLeft(reportOfferModified()),
+      Effect.zipLeft(
+        reportOfferModified(commonMetricAttributesFromHeaders(req.headers))
+      ),
       makeEndpointEffect
     )
 )

--- a/docs/backend_stats.md
+++ b/docs/backend_stats.md
@@ -1,0 +1,86 @@
+# Backend metrics
+
+All backend services report metrics as `MetricsMessage`s pushed to a BullMQ queue. The metrics service consumes the queue and inserts each message into the `metrics` table (`name`, `uuid`, `value`, `timestamp`, `type`, `attributes` jsonb). The only exception is the notification interaction endpoint, which the metrics service writes to the table directly.
+
+- `type` is `Increment` (event counter, `value` defaults to 1) or `Total` (gauge — absolute value at report time).
+- Gauges are reported periodically by a background loop in each service.
+
+**Keep this document in sync**: when a metric or its attributes change, or a new one is added, update this file.
+
+## Common attributes
+
+Frontend-triggered metrics include attributes extracted from the request's common headers (`commonMetricAttributesFromHeaders` in `packages/server-utils`):
+
+| Attribute | Value | Fallback |
+| --- | --- | --- |
+| `appVersion` | client semver, e.g. `1.2.3` | `unknown` |
+| `appVersionCode` | client version code number | `unknown` |
+| `appPlatform` | `ANDROID` / `IOS` / `CLI` / `WEB` | `unknown` |
+| `appSource` | store the app was installed from | `unknown` |
+| `clientCountryPrefix` | phone country prefix of the user | `none` |
+
+These are referred to as *common* in the tables below.
+
+## user-service
+
+| Metric | Type | Attributes | Reported when |
+| --- | --- | --- | --- |
+| `USER_LOGGED_IN` | Increment | `countryPrefix` | User completes phone number verification (login). |
+| `NUMBER_OF_USERS_BY_COUNTRY` | Total | `countryPrefix` (`none` if unknown) | Gauge, every 60 s; count of rows in `users` per country. |
+| `NUMBER_OF_USERS` | Total | — | Gauge, every 60 s; total count of users across all countries. |
+
+## contact-service
+
+| Metric | Type | Attributes | Reported when |
+| --- | --- | --- | --- |
+| `USER_REFRESH` | Increment | common | User refresh endpoint is called (app foregrounded / periodic refresh). |
+| `COUNT_OF_UNIQUE_USERS` | Total | — | Gauge, every 60 s; users that have imported at least one contact. |
+| `COUNT_OF_UNIQUE_CONTACTS` | Total | — | Gauge, every 60 s; distinct imported contacts. ⚠️ Also (mis)used by the inactivity notification job to report the number of inactive users under this same name. |
+| `COUNT_OF_CONNECTIONS` | Total | — | Gauge, every 60 s; total user⇄contact connections. |
+| `USER_JOINED_CLUB_AND_IMPORTED_CONTACTS` | Increment | `clubUUid`, `contactsImported` | User joins a club (attribute says whether they imported contacts). |
+| `CLUB_REPORTED` | Increment | common | Club member reports a club. |
+| `CLUB_DEACTIVATED` | Increment | common | A report pushes a club over its report limit and it gets deactivated. |
+| `NEW_APP_USER_NOTIFICATIONS_SENT` | Increment | `trackingId`, `metricVersion` | Currently unused — reporter exists but has no callers. |
+
+## offer-service
+
+| Metric | Type | Attributes | Reported when |
+| --- | --- | --- | --- |
+| `OFFER_CREATED` | Increment | common + `countryPrefix` (the offer's country) | New offer is created. |
+| `OFFER_MODIFIED` | Increment | common | Offer is updated. |
+| `OFFER_REPORTED` | Increment | common + `offerId` | Offer is reported — both the contact-network and the club report endpoints report under this name. |
+| `OFFER_PUBLIC_PART_DELETED` | Increment | — | Offer is deleted. |
+| `TOTAL_BUY_OFFERS`, `TOTAL_SELL_OFFERS` | Total | `countryPrefix` (`none` if unknown) | Gauge, every 10 min; active offers (refreshed within last 30 days) per country. |
+| `TOTAL_BUY_OFFERS_ACROSS_ALL`, `TOTAL_SELL_OFFERS_ACROSS_ALL`, `TOTAL_OFFERS_ACROSS_ALL` | Total | — | Gauge, every 10 min; sums of the above across countries. |
+| `TOTAL_BUY_OFFERS_EXPIRED`, `TOTAL_SELL_OFFERS_EXPIRED` | Total | `countryPrefix` (`none` if unknown) | Gauge, every 10 min; offers not refreshed within the expiration period, per country. |
+| `TOTAL_BUY_OFFERS_EXPIRED_ACROSS_ALL`, `TOTAL_SELL_OFFERS_EXPIRED_ACROSS_ALL`, `TOTAL_OFFERS_EXPIRED_ACROSS_ALL` | Total | — | Gauge, every 10 min; sums of the above across countries. |
+| `TOTAL_OFFERS_FLAGGED_ACROSS_ALL` | Total | — | Gauge, every 10 min; non-expired offers with reports at or above the report threshold. |
+| `MEAN_OFFER_VISIBILITY_PER_COUNTRY`, `MEDIAN_OFFER_VISIBILITY_PER_COUNTRY` | Increment (value = mean/median) | `countryPrefix` | Gauge-like, every 10 min; mean/median number of users an active offer is visible to (private parts per offer). |
+
+## chat-service
+
+| Metric | Type | Attributes | Reported when |
+| --- | --- | --- | --- |
+| `MESSAGE_SENT` | Increment | common | A message is stored into an inbox — direct message, batch send, messaging request/cancel/approve/disapprove, or leave-chat message. |
+| `REQUEST_SENT` | Increment | common | Messaging request is sent (V1 and V2 endpoints). |
+| `REQUEST_CANCELED` | Increment | common | Messaging request is canceled (V1 and V2 endpoints). |
+| `REQUEST_APPROVED` | Increment | common | Messaging request is approved. |
+| `REQUEST_REJECTED` | Increment (value 0) | common | Messaging request is disapproved. ⚠️ Reported with value 0, so it records the event but never increments. |
+| `CHAT_CLOSED` | Increment | common | User leaves a chat. |
+| `MESSAGE_FETCHED_AND_REMOVED` | Increment (value = count) | — | Client confirms pulled messages, which deletes them from the inbox. |
+| `MESSAGE_EXPIRED` | Increment (value = count) | — | Expired-messages cleanup task deletes old undelivered messages. |
+| `TOTAL_INBOXES` | Total | — | Gauge, every 60 s; total inboxes. |
+| `TOTAL_INBOXES_WITH_UNREAD_MESSAGES` | Total | — | Gauge, every 60 s; inboxes that have undelivered messages waiting. |
+
+## notification-service
+
+| Metric | Type | Attributes | Reported when |
+| --- | --- | --- | --- |
+| `NOTIFICATION_SENT` | Increment | `trackingId`, `clientVersion`, `clientPlatform`, `systemNotificationSent`, `sentAt` | A push notification is issued to a device. |
+| `NOTIFICATION_PROCESSED` | Increment | `trackingId`, `processedAt` | Client reports it processed a received notification. |
+
+## metrics-service
+
+| Metric | Type | Attributes | Reported when |
+| --- | --- | --- | --- |
+| `NOTIFICATION_INTERACTION_<notificationType>_<type>` | Increment (value = reported count) | common + `clientVersion`, `clientPlatform`, and optional `notificationsEnabled`, `backgroundTaskEnabled`, `trackingId`, `isVisible`, `systemNotificationSent` | Client reports a notification interaction. `notificationType` is `Chat` or `Network`; `type` is `ChatMessageReceived`, `BackgroundMessageReceived`, `NewConnectionsReceived`, or `UINotificationReceived`. Inserted into the db directly (not via the queue). |

--- a/packages/rest-api/src/services/chat/index.ts
+++ b/packages/rest-api/src/services/chat/index.ts
@@ -162,7 +162,10 @@ export function api({
       ) =>
         addChallenge(requestApprovalV2Request).pipe(
           Effect.flatMap((body) =>
-            client.Inboxes.requestApprovalV2({payload: body})
+            client.Inboxes.requestApprovalV2({
+              payload: body,
+              headers: commonHeaders,
+            })
           )
         ),
       /** @deprecated use `cancelRequestApprovalV2` */
@@ -178,7 +181,10 @@ export function api({
       ) =>
         addChallenge(cancelApprovalV2Request).pipe(
           Effect.flatMap((body) =>
-            client.Inboxes.cancelRequestApprovalV2({payload: body})
+            client.Inboxes.cancelRequestApprovalV2({
+              payload: body,
+              headers: commonHeaders,
+            })
           )
         ),
       approveRequest: (
@@ -186,7 +192,10 @@ export function api({
       ) =>
         addChallenge(approveRequestRequest).pipe(
           Effect.flatMap((body) =>
-            client.Inboxes.approveRequest({payload: body})
+            client.Inboxes.approveRequest({
+              payload: body,
+              headers: commonHeaders,
+            })
           )
         ),
       deleteInboxes: (deleteInboxesRequest: DeleteInboxesRequest) =>
@@ -195,7 +204,9 @@ export function api({
         leaveChatRequest: RequestWithGeneratableChallenge<LeaveChatRequest>
       ) =>
         addChallenge(leaveChatRequest).pipe(
-          Effect.flatMap((body) => client.Inboxes.leaveChat({payload: body}))
+          Effect.flatMap((body) =>
+            client.Inboxes.leaveChat({payload: body, headers: commonHeaders})
+          )
         ),
       // ----------------------
       // 👇 Message
@@ -218,11 +229,15 @@ export function api({
           Effect.flatMap((body) =>
             client.Messages.sendMessage({
               payload: body,
+              headers: commonHeaders,
             })
           )
         ),
       sendMessages: (sendMessagesRequest: SendMessagesRequest) =>
-        client.Messages.sendMessages({payload: sendMessagesRequest}),
+        client.Messages.sendMessages({
+          payload: sendMessagesRequest,
+          headers: commonHeaders,
+        }),
       // ----------------------
       // 👇 Challenge
       // ----------------------

--- a/packages/rest-api/src/services/chat/specification.ts
+++ b/packages/rest-api/src/services/chat/specification.ts
@@ -130,6 +130,7 @@ export const RequestApprovalV2Endpoint = HttpApiEndpoint.post(
   'requestApprovalV2',
   '/api/v2/inboxes/approval/request'
 )
+  .setHeaders(CommonHeaders)
   .setPayload(RequestApprovalV2Request)
   .addSuccess(RequestApprovalResponse)
   .addError(ReceiverInboxDoesNotExistError, {status: 404})
@@ -156,6 +157,7 @@ export const CancelRequestApprovalV2Endpoint = HttpApiEndpoint.post(
   'cancelRequestApprovalV2',
   '/api/v2/inboxes/approval/cancel'
 )
+  .setHeaders(CommonHeaders)
   .setPayload(CancelApprovalV2Request)
   .addSuccess(CancelApprovalResponse)
   .addError(RequestNotPendingError, {status: 400})
@@ -168,6 +170,7 @@ export const ApproveRequestEndpoint = HttpApiEndpoint.post(
   'approveRequest',
   '/api/v1/inboxes/approval/confirm'
 )
+  .setHeaders(CommonHeaders)
   .setPayload(ApproveRequestRequest)
   .addSuccess(ApproveRequestResponse)
   .addError(InvalidChallengeError, {status: 401})
@@ -193,6 +196,7 @@ export const LeaveChatEndpoint = HttpApiEndpoint.post(
   'leaveChat',
   '/api/v1/inboxes/leave-chat'
 )
+  .setHeaders(CommonHeaders)
   .setPayload(LeaveChatRequest)
   .addSuccess(LeaveChatResponse)
   .addError(InvalidChallengeError, {status: 401})
@@ -216,6 +220,7 @@ export const SendMessageEndpoint = HttpApiEndpoint.post(
   'sendMessage',
   '/api/v1/inboxes/messages'
 )
+  .setHeaders(CommonHeaders)
   .setPayload(SendMessageRequest)
   .addSuccess(SendMessageResponse)
   .addError(ReceiverInboxDoesNotExistError, {status: 404})
@@ -230,6 +235,7 @@ export const SendMessagesEndpoint = HttpApiEndpoint.post(
   '/api/v1/inboxes/messages/batch'
 )
   .annotate(OpenApi.Deprecated, true)
+  .setHeaders(CommonHeaders)
   .setPayload(SendMessagesRequest)
   .addSuccess(SendMessagesResponse)
   .addError(ReceiverInboxDoesNotExistError, {status: 404})

--- a/packages/server-utils/src/metrics/commonMetricAttributesFromHeaders.test.ts
+++ b/packages/server-utils/src/metrics/commonMetricAttributesFromHeaders.test.ts
@@ -1,0 +1,42 @@
+import {CommonHeaders} from '@vexl-next/rest-api/src/commonHeaders'
+import {Schema} from 'effect'
+import {commonMetricAttributesFromHeaders} from './commonMetricAttributesFromHeaders'
+
+describe('commonMetricAttributesFromHeaders', () => {
+  it('extracts common metric attributes from the Vexl app metadata header', () => {
+    const headers = Schema.decodeSync(CommonHeaders)({
+      'user-agent': 'Vexl/580 (1.2.3) ANDROID',
+      'vexl-app-meta': JSON.stringify({
+        appSource: 'com.android.vending',
+        versionCode: 580,
+        platform: 'ANDROID',
+        semver: '1.2.3',
+        language: 'en',
+        isDeveloper: false,
+        prefix: 420,
+      }),
+    })
+
+    expect(commonMetricAttributesFromHeaders(headers)).toEqual({
+      appVersion: '1.2.3',
+      appVersionCode: 580,
+      appPlatform: 'ANDROID',
+      appSource: 'com.android.vending',
+      clientCountryPrefix: 420,
+    })
+  })
+
+  it('uses fallbacks when the metadata is unavailable', () => {
+    const headers = Schema.decodeSync(CommonHeaders)({
+      'user-agent': undefined,
+    })
+
+    expect(commonMetricAttributesFromHeaders(headers)).toEqual({
+      appVersion: 'unknown',
+      appVersionCode: 'unknown',
+      appPlatform: 'unknown',
+      appSource: 'unknown',
+      clientCountryPrefix: 'none',
+    })
+  })
+})

--- a/packages/server-utils/src/metrics/commonMetricAttributesFromHeaders.ts
+++ b/packages/server-utils/src/metrics/commonMetricAttributesFromHeaders.ts
@@ -1,0 +1,24 @@
+import {type CommonHeaders} from '@vexl-next/rest-api/src/commonHeaders'
+import {Option} from 'effect'
+
+export interface CommonMetricAttributes {
+  readonly [key: string]: string | number | boolean
+  readonly appVersion: string
+  readonly appVersionCode: number | 'unknown'
+  readonly appPlatform: string
+  readonly appSource: string
+  readonly clientCountryPrefix: number | 'none'
+}
+
+export const commonMetricAttributesFromHeaders = (
+  headers: CommonHeaders
+): CommonMetricAttributes => ({
+  appVersion: Option.getOrElse(headers.clientSemverOrNone, () => 'unknown'),
+  appVersionCode: Option.getOrElse(
+    headers.clientVersionOrNone,
+    () => 'unknown'
+  ),
+  appPlatform: Option.getOrElse(headers.clientPlatformOrNone, () => 'unknown'),
+  appSource: Option.getOrElse(headers.appSourceOrNone, () => 'unknown'),
+  clientCountryPrefix: Option.getOrElse(headers.prefixOrNone, () => 'none'),
+})


### PR DESCRIPTION
## Summary

- extract shared metric attributes from validated common request headers
- add app version, build code, platform, app source, and country prefix to frontend-originated offer, contact, chat, and notification interaction metrics
- leave server-originated and headerless endpoint metrics unchanged

## Impact

No mobile client or API contract changes are required. Missing header values use explicit `unknown`/`none` fallbacks. The added fields do not introduce a new stable user identifier.

## Validation

- `pnpm --filter @vexl-next/server-utils exec jest --runInBand src/metrics/commonMetricAttributesFromHeaders.test.ts`
- `pnpm --filter @vexl-next/contact-service exec jest --runInBand src/__tests__/routes/user/refreshUser.test.ts`
- `pnpm turbo:typecheck`
- `pnpm turbo:format`
- `pnpm turbo:lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics now include app, source, country, and related request context across chat, contact, offer, and notification activity.
  * Missing request metadata receives fallback values for consistent reporting.
  * Chat requests now support common metadata headers for enriched activity tracking.

* **Tests**
  * Added coverage for metadata extraction, fallback behavior, and enriched user-refresh metrics.
  * Updated chat request scenarios to include common metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->