### PR TITLE
Enrich remaining frontend-triggered metrics with client metadata

### DIFF
--- a/apps/chat-service/src/__tests__/routes/deletePulledMessages.test.ts
+++ b/apps/chat-service/src/__tests__/routes/deletePulledMessages.test.ts
@@ -101,6 +101,7 @@ describe('Delete pulled messages', () => {
         yield* _(setAuthHeaders(user1.authHeaders))
         yield* _(
           client.Inboxes.deletePulledMessages({
+            headers: commonHeaders,
             payload: yield* _(user1.addChallengeForMainInbox({})),
           })
         )
@@ -141,6 +142,7 @@ describe('Delete pulled messages', () => {
 
         const errorResponse = yield* _(
           client.Inboxes.deletePulledMessages({
+            headers: commonHeaders,
             payload: yield* _(
               addChallengeForKey(generatePrivateKey(), user1.authHeaders)({})
             ),

--- a/apps/chat-service/src/metrics.ts
+++ b/apps/chat-service/src/metrics.ts
@@ -106,7 +106,8 @@ export const reportMessageSent = (
   )
 
 export const reportMessageFetchedAndRemoved = (
-  number: number
+  number: number,
+  attributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
@@ -114,6 +115,7 @@ export const reportMessageFetchedAndRemoved = (
       uuid: generateUuid(),
       timestamp: new Date(),
       name: MESSAGE_FETCHED_AND_REMOVED,
+      attributes,
     })
   )
 

--- a/apps/chat-service/src/routes/inbox/deletePulledMessages.ts
+++ b/apps/chat-service/src/routes/inbox/deletePulledMessages.ts
@@ -2,6 +2,7 @@ import {HttpApiBuilder} from '@effect/platform/index'
 import {ChatApiSpecification} from '@vexl-next/rest-api/src/services/chat/specification'
 import {InboxDoesNotExistError} from '@vexl-next/rest-api/src/services/contact/contracts'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {validateChallengeInBody} from '@vexl-next/server-utils/src/services/challenge/utils/validateChallengeInBody'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
 import {Effect} from 'effect'
@@ -34,7 +35,12 @@ export const deletePulledMessages = HttpApiBuilder.handler(
       const messagesService = yield* _(MessagesDbService)
       yield* _(
         messagesService.deletePulledMessagesByInboxId(inboxRecord.id),
-        Effect.tap(reportMessageFetchedAndRemoved)
+        Effect.tap((count) =>
+          reportMessageFetchedAndRemoved(
+            count,
+            commonMetricAttributesFromHeaders(req.headers)
+          )
+        )
       )
 
       return {}

--- a/apps/contact-service/src/__tests__/routes/clubs/member/getClubContacts.test.ts
+++ b/apps/contact-service/src/__tests__/routes/clubs/member/getClubContacts.test.ts
@@ -1,10 +1,9 @@
 import {SqlClient} from '@effect/sql'
 import {generateClubUuid} from '@vexl-next/domain/src/general/clubs'
-import {UriString} from '@vexl-next/domain/src/utility/UriString.brand'
-
 import {NotFoundError} from '@vexl-next/domain/src/general/commonErrors'
 import {type VexlNotificationToken} from '@vexl-next/domain/src/general/notifications/VexlNotificationToken'
 import {type ExpoNotificationToken} from '@vexl-next/domain/src/utility/ExpoNotificationToken.brand'
+import {UriString} from '@vexl-next/domain/src/utility/UriString.brand'
 import {InvalidChallengeError} from '@vexl-next/rest-api/src/challenges/contracts'
 import {CommonHeaders} from '@vexl-next/rest-api/src/commonHeaders'
 import {expectErrorResponse} from '@vexl-next/server-utils/src/tests/expectErrorResponse'
@@ -87,6 +86,7 @@ describe('Get club contacts', () => {
         // user1 joins the club
         yield* _(
           app.ClubsMember.joinClub({
+            headers: commonHeaders,
             payload: {
               code: inviteLink1.link.code,
               contactsImported: false,
@@ -115,6 +115,7 @@ describe('Get club contacts', () => {
         // user2 joins the club
         yield* _(
           app.ClubsMember.joinClub({
+            headers: commonHeaders,
             payload: {
               code: inviteLink2.link.code,
               contactsImported: false,
@@ -198,6 +199,7 @@ describe('Get club contacts', () => {
 
         yield* _(
           app.ClubsMember.joinClub({
+            headers: commonHeaders,
             payload: {
               code: inviteLink.link.code,
               contactsImported: false,
@@ -276,6 +278,7 @@ describe('Get club contacts', () => {
         // user1 joins the first club
         yield* _(
           app.ClubsMember.joinClub({
+            headers: commonHeaders,
             payload: {
               code: inviteLink1.link.code,
               contactsImported: false,
@@ -325,6 +328,7 @@ describe('Get club contacts', () => {
         // user2 joins the second club
         yield* _(
           app.ClubsMember.joinClub({
+            headers: commonHeaders,
             payload: {
               code: inviteLink2.link.code,
               contactsImported: false,
@@ -402,6 +406,7 @@ describe('Get club contacts', () => {
         // user1 joins the club
         yield* _(
           app.ClubsMember.joinClub({
+            headers: commonHeaders,
             payload: {
               code: inviteLink.link.code,
               contactsImported: false,
@@ -479,6 +484,7 @@ describe('Get club contacts', () => {
         // user1 joins the club
         yield* _(
           app.ClubsMember.joinClub({
+            headers: commonHeaders,
             payload: {
               code: inviteLink.link.code,
               contactsImported: false,

--- a/apps/contact-service/src/__tests__/routes/clubs/member/joinClub.test.ts
+++ b/apps/contact-service/src/__tests__/routes/clubs/member/joinClub.test.ts
@@ -9,6 +9,7 @@ import {type VexlNotificationToken} from '@vexl-next/domain/src/general/notifica
 import {type ExpoNotificationToken} from '@vexl-next/domain/src/utility/ExpoNotificationToken.brand'
 import {UriString} from '@vexl-next/domain/src/utility/UriString.brand'
 import {InvalidChallengeError} from '@vexl-next/rest-api/src/challenges/contracts'
+import {CommonHeaders} from '@vexl-next/rest-api/src/commonHeaders'
 import {
   ClubUserLimitExceededError,
   MemberAlreadyInClubError,
@@ -27,6 +28,10 @@ import {
 } from '../../../utils/mockEnqueueUserNotification'
 import {NodeTestingApp} from '../../../utils/NodeTestingApp'
 import {runPromiseInMockedEnvironment} from '../../../utils/runPromiseInMockedEnvironment'
+
+const testCommonHeaders = Schema.decodeSync(CommonHeaders)({
+  'user-agent': 'Vexl/1 (1.0.0) ANDROID',
+})
 
 const ADMIN_TOKEN = 'dev'
 const SOME_URL = Schema.decodeSync(UriString)('https://some.url')
@@ -99,6 +104,7 @@ describe('Join club', () => {
         const app = yield* _(NodeTestingApp)
         const joinedClub = yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(userKey))),
               code: INVITATION_CODE,
@@ -170,6 +176,7 @@ describe('Join club', () => {
 
         const joinedClub = yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(userKey))),
               code: inviteLink.link.code,
@@ -228,6 +235,7 @@ describe('Join club', () => {
 
         yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(userKey))),
               code: inviteLink.link.code,
@@ -245,6 +253,7 @@ describe('Join club', () => {
 
         const errorResponse = yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(generatePrivateKey()))),
               code: inviteLink.link.code,
@@ -272,6 +281,7 @@ describe('Join club', () => {
         const app = yield* _(NodeTestingApp)
         yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(user1))),
               code: INVITATION_CODE,
@@ -289,6 +299,7 @@ describe('Join club', () => {
 
         yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(user2))),
               code: INVITATION_CODE,
@@ -306,6 +317,7 @@ describe('Join club', () => {
 
         const failedResponse = yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(user3))),
               code: INVITATION_CODE,
@@ -336,6 +348,7 @@ describe('Join club', () => {
 
         const errorResponse = yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               signedChallenge: signedChallenge.signedChallenge,
               publicKey: invalidKey.publicKeyPemBase64,
@@ -362,6 +375,7 @@ describe('Join club', () => {
         const app = yield* _(NodeTestingApp)
         yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(userKey))),
               code: INVITATION_CODE,
@@ -379,6 +393,7 @@ describe('Join club', () => {
 
         const errorResponse = yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(userKey))),
               code: INVITATION_CODE,
@@ -404,6 +419,7 @@ describe('Join club', () => {
         const app = yield* _(NodeTestingApp)
         const errorResponse = yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(userKey))),
               code: '123445' as ClubCode,
@@ -473,6 +489,7 @@ describe('Join club', () => {
         const app = yield* _(NodeTestingApp)
         yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(userKey))),
               code: INVITATION_CODE,
@@ -576,6 +593,7 @@ describe('Join club', () => {
         const app = yield* _(NodeTestingApp)
         yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(userKey))),
               code: INVITATION_CODE,
@@ -656,6 +674,7 @@ describe('Join club', () => {
         // with a different user who has same token pattern
         yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(userKey))),
               code: INVITATION_CODE,
@@ -738,6 +757,7 @@ describe('Join club', () => {
         const app = yield* _(NodeTestingApp)
         yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(userKey))),
               code: INVITATION_CODE,
@@ -834,6 +854,7 @@ describe('Join club', () => {
         const app = yield* _(NodeTestingApp)
         yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               ...(yield* _(generateAndSignChallenge(userKey))),
               code: INVITATION_CODE,

--- a/apps/contact-service/src/__tests__/routes/clubs/moderator/deactivateClubJoinLink.test.ts
+++ b/apps/contact-service/src/__tests__/routes/clubs/moderator/deactivateClubJoinLink.test.ts
@@ -12,6 +12,7 @@ import {
   InvalidChallengeError,
   type SignedChallenge,
 } from '@vexl-next/rest-api/src/challenges/contracts'
+import {CommonHeaders} from '@vexl-next/rest-api/src/commonHeaders'
 import {
   InviteCodeNotFoundError,
   UserIsNotModeratorError,
@@ -25,6 +26,10 @@ import {type ClubRecordId} from '../../../../db/ClubsDbService/domain'
 import {generateAndSignChallenge} from '../../../utils/generateAndSignChallenge'
 import {NodeTestingApp} from '../../../utils/NodeTestingApp'
 import {runPromiseInMockedEnvironment} from '../../../utils/runPromiseInMockedEnvironment'
+
+const testCommonHeaders = Schema.decodeSync(CommonHeaders)({
+  'user-agent': 'Vexl/1 (1.0.0) ANDROID',
+})
 
 const ADMIN_TOKEN = 'dev'
 const SOME_URL = Schema.decodeSync(UriString)('https://some.url')
@@ -120,6 +125,7 @@ describe('Deactivate link', () => {
 
         const errorResponse = yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               code,
               notificationToken: Option.none(),

--- a/apps/contact-service/src/__tests__/routes/clubs/moderator/generateClubJoinLink.test.ts
+++ b/apps/contact-service/src/__tests__/routes/clubs/moderator/generateClubJoinLink.test.ts
@@ -9,6 +9,7 @@ import {
   InvalidChallengeError,
   type SignedChallenge,
 } from '@vexl-next/rest-api/src/challenges/contracts'
+import {CommonHeaders} from '@vexl-next/rest-api/src/commonHeaders'
 import {UserIsNotModeratorError} from '@vexl-next/rest-api/src/services/contact/contracts'
 import {expectErrorResponse} from '@vexl-next/server-utils/src/tests/expectErrorResponse'
 import {addTestHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
@@ -19,6 +20,10 @@ import {type ClubRecordId} from '../../../../db/ClubsDbService/domain'
 import {generateAndSignChallenge} from '../../../utils/generateAndSignChallenge'
 import {NodeTestingApp} from '../../../utils/NodeTestingApp'
 import {runPromiseInMockedEnvironment} from '../../../utils/runPromiseInMockedEnvironment'
+
+const testCommonHeaders = Schema.decodeSync(CommonHeaders)({
+  'user-agent': 'Vexl/1 (1.0.0) ANDROID',
+})
 
 const ADMIN_TOKEN = 'dev'
 const SOME_URL = Schema.decodeSync(UriString)('https://some.url')
@@ -102,6 +107,7 @@ describe('Generate club join link', () => {
 
         yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               code: joinLinkResponse.codeInfo.code,
               ...(yield* _(generateAndSignChallenge(user1))),

--- a/apps/contact-service/src/__tests__/routes/clubs/moderator/listClubLinks.test.ts
+++ b/apps/contact-service/src/__tests__/routes/clubs/moderator/listClubLinks.test.ts
@@ -9,6 +9,7 @@ import {
   InvalidChallengeError,
   type SignedChallenge,
 } from '@vexl-next/rest-api/src/challenges/contracts'
+import {CommonHeaders} from '@vexl-next/rest-api/src/commonHeaders'
 import {UserIsNotModeratorError} from '@vexl-next/rest-api/src/services/contact/contracts'
 import {expectErrorResponse} from '@vexl-next/server-utils/src/tests/expectErrorResponse'
 import {addTestHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
@@ -19,6 +20,10 @@ import {type ClubRecordId} from '../../../../db/ClubsDbService/domain'
 import {generateAndSignChallenge} from '../../../utils/generateAndSignChallenge'
 import {NodeTestingApp} from '../../../utils/NodeTestingApp'
 import {runPromiseInMockedEnvironment} from '../../../utils/runPromiseInMockedEnvironment'
+
+const testCommonHeaders = Schema.decodeSync(CommonHeaders)({
+  'user-agent': 'Vexl/1 (1.0.0) ANDROID',
+})
 
 const ADMIN_TOKEN = 'dev'
 const SOME_URL = Schema.decodeSync(UriString)('https://some.url')
@@ -272,6 +277,7 @@ describe('List club links', () => {
 
         yield* _(
           app.ClubsMember.joinClub({
+            headers: testCommonHeaders,
             payload: {
               code: adminInviteCodeForClub2.link.code,
               ...(yield* _(generateAndSignChallenge(user2))),

--- a/apps/contact-service/src/metrics.ts
+++ b/apps/contact-service/src/metrics.ts
@@ -120,17 +120,19 @@ export const reportUserJoinedClubAndImportedContacts = ({
   clubUUid,
   contactsImported,
   value,
+  commonMetricAttributes,
 }: {
   clubUUid: ClubUuid
   contactsImported: boolean
   value: number
+  commonMetricAttributes: CommonMetricAttributes
 }): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
       uuid: generateUuid(),
       timestamp: new Date(),
       name: USER_JOINED_CLUB_AND_IMPORTED_CONTACTS,
-      attributes: {clubUUid, contactsImported},
+      attributes: {...commonMetricAttributes, clubUUid, contactsImported},
       value,
     })
   )

--- a/apps/contact-service/src/routes/clubs/member/joinClub.ts
+++ b/apps/contact-service/src/routes/clubs/member/joinClub.ts
@@ -6,6 +6,7 @@ import {
 import {MemberAlreadyInClubError} from '@vexl-next/rest-api/src/services/contact/contracts'
 import {ContactApiSpecification} from '@vexl-next/rest-api/src/services/contact/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {validateChallengeInBody} from '@vexl-next/server-utils/src/services/challenge/utils/validateChallengeInBody'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
 import {Effect, Option} from 'effect'
@@ -125,6 +126,9 @@ export const joinClub = HttpApiBuilder.handler(
               clubUUid: club.uuid,
               contactsImported: req.payload.contactsImported,
               value: 1,
+              commonMetricAttributes: commonMetricAttributesFromHeaders(
+                req.headers
+              ),
             })
           )
 

--- a/apps/notification-service/src/metrics.ts
+++ b/apps/notification-service/src/metrics.ts
@@ -3,6 +3,7 @@ import {UnixMilliseconds} from '@vexl-next/domain/src/utility/UnixMilliseconds.b
 import {generateUuid} from '@vexl-next/domain/src/utility/Uuid.brand'
 import {VersionCode} from '@vexl-next/domain/src/utility/VersionCode.brand'
 import {PlatformName} from '@vexl-next/rest-api'
+import {type CommonMetricAttributes} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {MetricsMessage} from '@vexl-next/server-utils/src/metrics/domain'
 import {MetricsClientService} from '@vexl-next/server-utils/src/metrics/MetricsClientService'
 import {reportMetricForked} from '@vexl-next/server-utils/src/metrics/reportMetricForked'
@@ -31,6 +32,7 @@ export interface NotificationMetricsServiceOperations {
   reportNotificationProcessed: (args: {
     id: NotificationTrackingId
     processedAt: UnixMilliseconds
+    commonMetricAttributes: CommonMetricAttributes
   }) => Effect.Effect<void>
 }
 
@@ -65,13 +67,18 @@ export class NotificationMetricsService extends Context.Tag(
             })
           ).pipe(Effect.provideService(MetricsClientService, metricsClient)),
 
-        reportNotificationProcessed: ({id, processedAt}) =>
+        reportNotificationProcessed: ({
+          id,
+          processedAt,
+          commonMetricAttributes,
+        }) =>
           reportMetricForked(
             new MetricsMessage({
               uuid: generateUuid(),
               timestamp: new Date(),
               name: NOTIFICATION_PROCESSED,
               attributes: {
+                ...commonMetricAttributes,
                 trackingId: id,
                 processedAt,
               },

--- a/apps/notification-service/src/routes/reportNotificationProcessed.ts
+++ b/apps/notification-service/src/routes/reportNotificationProcessed.ts
@@ -2,6 +2,7 @@ import {HttpApiBuilder} from '@effect/platform/index'
 import {unixMillisecondsNow} from '@vexl-next/domain/src/utility/UnixMilliseconds.brand'
 import {NotificationApiSpecification} from '@vexl-next/rest-api/src/services/notification/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {Effect} from 'effect'
 import {NotificationMetricsService} from '../metrics'
 
@@ -17,6 +18,9 @@ export const reportNotificationProcessedHandler = HttpApiBuilder.handler(
           notificationMetrics.reportNotificationProcessed({
             id: req.payload.trackingId,
             processedAt: unixMillisecondsNow(),
+            commonMetricAttributes: commonMetricAttributesFromHeaders(
+              req.headers
+            ),
           })
         )
         return {}

--- a/apps/offer-service/src/__tests__/routes/deleteOffer.test.ts
+++ b/apps/offer-service/src/__tests__/routes/deleteOffer.test.ts
@@ -8,6 +8,7 @@ import {
   type PrivatePayloadEncrypted,
   type PublicPayloadEncrypted,
 } from '@vexl-next/domain/src/general/offers'
+import {CommonHeaders} from '@vexl-next/rest-api/src/commonHeaders'
 import {type CreateNewOfferRequest} from '@vexl-next/rest-api/src/services/offer/contracts'
 import {createDummyAuthHeadersForUser} from '@vexl-next/server-utils/src/tests/createDummyAuthHeaders'
 import {setAuthHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
@@ -15,6 +16,10 @@ import {Effect, Schema} from 'effect'
 import {makeTestCommonAndSecurityHeaders} from '../utils/createMockedUser'
 import {NodeTestingApp} from '../utils/NodeTestingApp'
 import {runPromiseInMockedEnvironment} from '../utils/runPromiseInMockedEnvironment'
+
+const testCommonHeaders = Schema.decodeSync(CommonHeaders)({
+  'user-agent': 'Vexl/1 (1.0.0) ANDROID',
+})
 
 type DummyAuthHeaders = Parameters<typeof makeTestCommonAndSecurityHeaders>[0]
 
@@ -106,6 +111,7 @@ describe('Delete offer', () => {
 
         yield* _(
           api.deleteOffer({
+            headers: testCommonHeaders,
             urlParams: {adminIds: [offer1.adminId, offer2.adminId]},
           })
         )
@@ -172,6 +178,7 @@ describe('Delete offer', () => {
 
         yield* _(
           api.deleteOffer({
+            headers: testCommonHeaders,
             urlParams: {adminIds: []},
           })
         )
@@ -221,6 +228,7 @@ describe('Delete offer', () => {
 
         yield* _(
           api.deleteOffer({
+            headers: testCommonHeaders,
             urlParams: {
               adminIds: [offer1.adminId, offer2.adminId, generateAdminId()],
             },

--- a/apps/offer-service/src/__tests__/routes/getClubOffers.test.ts
+++ b/apps/offer-service/src/__tests__/routes/getClubOffers.test.ts
@@ -12,6 +12,7 @@ import {
 } from '@vexl-next/domain/src/general/offers'
 import {objectToBase64UrlEncoded} from '@vexl-next/generic-utils/src/base64NextPageTokenEncoding'
 import {generateV2KeyPair} from '@vexl-next/generic-utils/src/effect-helpers/crypto'
+import {CommonHeaders} from '@vexl-next/rest-api/src/commonHeaders'
 import {
   type CreateNewOfferRequest,
   type CreateNewOfferResponse,
@@ -28,6 +29,10 @@ import {
 } from '../utils/createMockedUser'
 import {NodeTestingApp} from '../utils/NodeTestingApp'
 import {runPromiseInMockedEnvironment} from '../utils/runPromiseInMockedEnvironment'
+
+const testCommonHeaders = Schema.decodeSync(CommonHeaders)({
+  'user-agent': 'Vexl/1 (1.0.0) ANDROID',
+})
 
 let user1: MockedUser
 const clubKeypairForUser1 = generatePrivateKey()
@@ -698,6 +703,7 @@ describe('Get removed club offers', () => {
 
         yield* _(
           client.deleteOffer({
+            headers: testCommonHeaders,
             urlParams: {adminIds: [newOffer.adminId]},
           })
         )

--- a/apps/offer-service/src/__tests__/routes/getOffers.test.ts
+++ b/apps/offer-service/src/__tests__/routes/getOffers.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@vexl-next/domain/src/general/offers'
 import {objectToBase64UrlEncoded} from '@vexl-next/generic-utils/src/base64NextPageTokenEncoding'
 import {generateV2KeyPair} from '@vexl-next/generic-utils/src/effect-helpers/crypto'
+import {CommonHeaders} from '@vexl-next/rest-api/src/commonHeaders'
 import {
   type CreateNewOfferRequest,
   type CreateNewOfferResponse,
@@ -27,6 +28,10 @@ import {
 import {makeTestCommonAndSecurityHeadersWithPublicKeyV2} from '../utils/makeTestCommonAndSecurityHeadersWithPublicKeyV2'
 import {NodeTestingApp} from '../utils/NodeTestingApp'
 import {runPromiseInMockedEnvironment} from '../utils/runPromiseInMockedEnvironment'
+
+const testCommonHeaders = Schema.decodeSync(CommonHeaders)({
+  'user-agent': 'Vexl/1 (1.0.0) ANDROID',
+})
 
 let user1: MockedUser
 let user2: MockedUser
@@ -879,6 +884,7 @@ describe('Get removed offers', () => {
 
         yield* _(
           client.deleteOffer({
+            headers: testCommonHeaders,
             urlParams: {adminIds: [newOffer.adminId]},
           })
         )

--- a/apps/offer-service/src/metrics.ts
+++ b/apps/offer-service/src/metrics.ts
@@ -36,16 +36,15 @@ const MEAN_OFFER_VISIBILITY_PER_COUNTRY =
 const MEDIAN_OFFER_VISIBILITY_PER_COUNTRY =
   'MEDIAN_OFFER_VISIBILITY_PER_COUNTRY' as const
 
-export const reportOfferPublicPartDeleted = (): Effect.Effect<
-  void,
-  never,
-  MetricsClientService
-> =>
+export const reportOfferPublicPartDeleted = (
+  attributes: CommonMetricAttributes
+): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
       uuid: generateUuid(),
       timestamp: new Date(),
       name: OFFER_PUBLIC_PART_DELETED,
+      attributes,
     })
   )
 

--- a/apps/offer-service/src/routes/deleteOffer.ts
+++ b/apps/offer-service/src/routes/deleteOffer.ts
@@ -1,6 +1,7 @@
 import {HttpApiBuilder} from '@effect/platform/index'
 import {OfferApiSpecification} from '@vexl-next/rest-api/src/services/offer/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
 import {Effect} from 'effect'
 import {OfferDbService} from '../db/OfferDbService'
@@ -34,7 +35,11 @@ export const deleteOffer = HttpApiBuilder.handler(
         })
       )
 
-      yield* _(reportOfferPublicPartDeleted())
+      yield* _(
+        reportOfferPublicPartDeleted(
+          commonMetricAttributesFromHeaders(req.headers)
+        )
+      )
 
       return {}
     }).pipe(

--- a/apps/user-service/src/__tests__/login/loginFlow.test.ts
+++ b/apps/user-service/src/__tests__/login/loginFlow.test.ts
@@ -76,6 +76,9 @@ describe('loginFlow', () => {
 
         const verifyChallenge = yield* _(
           client.Login.verifyChallenge({
+            headers: Schema.decodeSync(CommonHeaders)({
+              'user-agent': 'Vexl/2 (1.0.0) IOS',
+            }),
             payload: {
               userPublicKey: keypair.publicKeyPemBase64,
               signature: signedChallenge,

--- a/apps/user-service/src/__tests__/login/verifyChallenge.test.ts
+++ b/apps/user-service/src/__tests__/login/verifyChallenge.test.ts
@@ -77,6 +77,9 @@ describe('verify challenge', () => {
 
         const verifyChallenge = yield* _(
           client.Login.verifyChallenge({
+            headers: Schema.decodeSync(CommonHeaders)({
+              'user-agent': 'Vexl/2 (1.0.0) IOS',
+            }),
             payload: {
               userPublicKey: keypair.publicKeyPemBase64,
               signature: signedChallenge,

--- a/apps/user-service/src/metrics.ts
+++ b/apps/user-service/src/metrics.ts
@@ -2,6 +2,7 @@ import {SqlClient, SqlSchema} from '@effect/sql'
 import {CountryPrefix} from '@vexl-next/domain/src/general/CountryPrefix.brand'
 import {generateUuid} from '@vexl-next/domain/src/utility/Uuid.brand'
 import {shouldDisableMetrics} from '@vexl-next/server-utils/src/commonConfigs'
+import {type CommonMetricAttributes} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {MetricsMessage} from '@vexl-next/server-utils/src/metrics/domain'
 import {type MetricsClientService} from '@vexl-next/server-utils/src/metrics/MetricsClientService'
 import {reportMetricForked} from '@vexl-next/server-utils/src/metrics/reportMetricForked'
@@ -13,14 +14,15 @@ const NUMBER_OF_USERS = 'NUMBER_OF_USERS_BY_COUNTRY' as const
 const NUMBER_OF_USERS_ALL_COUNTRIES = 'NUMBER_OF_USERS' as const
 
 export const reportUserLoggedIn = (
-  countryPrefix: CountryPrefix
+  countryPrefix: CountryPrefix,
+  commonMetricAttributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
       uuid: generateUuid(),
       timestamp: new Date(),
       name: USER_LOGGED_IN,
-      attributes: {countryPrefix},
+      attributes: {...commonMetricAttributes, countryPrefix},
     })
   )
 

--- a/apps/user-service/src/routes/login/handlers/verifyChallengeHandler.ts
+++ b/apps/user-service/src/routes/login/handlers/verifyChallengeHandler.ts
@@ -16,6 +16,7 @@ import {UserApiSpecification} from '@vexl-next/rest-api/src/services/user/specif
 import {DashboardReportsService} from '@vexl-next/server-utils/src/DashboardReportsService'
 import {generateUserAuthData} from '@vexl-next/server-utils/src/generateUserAuthData'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {Effect} from 'effect'
 import {LoggedInUsersDbService} from '../../../db/loggedInUsersDb'
 import {reportUserLoggedIn} from '../../../metrics'
@@ -88,7 +89,12 @@ export const verifyChallengeHandler = HttpApiBuilder.handler(
         loginDb.deleteChallengeVerificationState(req.payload.userPublicKey)
       )
 
-      yield* _(reportUserLoggedIn(verificationState.countryPrefix))
+      yield* _(
+        reportUserLoggedIn(
+          verificationState.countryPrefix,
+          commonMetricAttributesFromHeaders(req.headers)
+        )
+      )
 
       return new VerifyChallengeResponse({
         ...authData,

--- a/docs/backend_stats.md
+++ b/docs/backend_stats.md
@@ -67,7 +67,7 @@ These are referred to as *common* in the tables below.
 | `REQUEST_APPROVED` | Increment | common | Messaging request is approved. |
 | `REQUEST_REJECTED` | Increment (value 0) | common | Messaging request is disapproved. ⚠️ Reported with value 0, so it records the event but never increments. |
 | `CHAT_CLOSED` | Increment | common | User leaves a chat. |
-| `MESSAGE_FETCHED_AND_REMOVED` | Increment (value = count) | — | Client confirms pulled messages, which deletes them from the inbox. |
+| `MESSAGE_FETCHED_AND_REMOVED` | Increment (value = count) | common | Client confirms pulled messages, which deletes them from the inbox. |
 | `MESSAGE_EXPIRED` | Increment (value = count) | — | Expired-messages cleanup task deletes old undelivered messages. |
 | `TOTAL_INBOXES` | Total | — | Gauge, every 60 s; total inboxes. |
 | `TOTAL_INBOXES_WITH_UNREAD_MESSAGES` | Total | — | Gauge, every 60 s; inboxes that have undelivered messages waiting. |

--- a/docs/backend_stats.md
+++ b/docs/backend_stats.md
@@ -37,7 +37,7 @@ These are referred to as *common* in the tables below.
 | `COUNT_OF_UNIQUE_USERS` | Total | — | Gauge, every 60 s; users that have imported at least one contact. |
 | `COUNT_OF_UNIQUE_CONTACTS` | Total | — | Gauge, every 60 s; distinct imported contacts. ⚠️ Also (mis)used by the inactivity notification job to report the number of inactive users under this same name. |
 | `COUNT_OF_CONNECTIONS` | Total | — | Gauge, every 60 s; total user⇄contact connections. |
-| `USER_JOINED_CLUB_AND_IMPORTED_CONTACTS` | Increment | `clubUUid`, `contactsImported` | User joins a club (attribute says whether they imported contacts). |
+| `USER_JOINED_CLUB_AND_IMPORTED_CONTACTS` | Increment | common + `clubUUid`, `contactsImported` | User joins a club (attribute says whether they imported contacts). |
 | `CLUB_REPORTED` | Increment | common | Club member reports a club. |
 | `CLUB_DEACTIVATED` | Increment | common | A report pushes a club over its report limit and it gets deactivated. |
 | `NEW_APP_USER_NOTIFICATIONS_SENT` | Increment | `trackingId`, `metricVersion` | Currently unused — reporter exists but has no callers. |

--- a/docs/backend_stats.md
+++ b/docs/backend_stats.md
@@ -49,7 +49,7 @@ These are referred to as *common* in the tables below.
 | `OFFER_CREATED` | Increment | common + `countryPrefix` (the offer's country) | New offer is created. |
 | `OFFER_MODIFIED` | Increment | common | Offer is updated. |
 | `OFFER_REPORTED` | Increment | common + `offerId` | Offer is reported — both the contact-network and the club report endpoints report under this name. |
-| `OFFER_PUBLIC_PART_DELETED` | Increment | — | Offer is deleted. |
+| `OFFER_PUBLIC_PART_DELETED` | Increment | common | Offer is deleted. |
 | `TOTAL_BUY_OFFERS`, `TOTAL_SELL_OFFERS` | Total | `countryPrefix` (`none` if unknown) | Gauge, every 10 min; active offers (refreshed within last 30 days) per country. |
 | `TOTAL_BUY_OFFERS_ACROSS_ALL`, `TOTAL_SELL_OFFERS_ACROSS_ALL`, `TOTAL_OFFERS_ACROSS_ALL` | Total | — | Gauge, every 10 min; sums of the above across countries. |
 | `TOTAL_BUY_OFFERS_EXPIRED`, `TOTAL_SELL_OFFERS_EXPIRED` | Total | `countryPrefix` (`none` if unknown) | Gauge, every 10 min; offers not refreshed within the expiration period, per country. |

--- a/docs/backend_stats.md
+++ b/docs/backend_stats.md
@@ -25,7 +25,7 @@ These are referred to as *common* in the tables below.
 
 | Metric | Type | Attributes | Reported when |
 | --- | --- | --- | --- |
-| `USER_LOGGED_IN` | Increment | `countryPrefix` | User completes phone number verification (login). |
+| `USER_LOGGED_IN` | Increment | common + `countryPrefix` (of the verified number) | User completes phone number verification (login). |
 | `NUMBER_OF_USERS_BY_COUNTRY` | Total | `countryPrefix` (`none` if unknown) | Gauge, every 60 s; count of rows in `users` per country. |
 | `NUMBER_OF_USERS` | Total | — | Gauge, every 60 s; total count of users across all countries. |
 

--- a/docs/backend_stats.md
+++ b/docs/backend_stats.md
@@ -77,7 +77,7 @@ These are referred to as *common* in the tables below.
 | Metric | Type | Attributes | Reported when |
 | --- | --- | --- | --- |
 | `NOTIFICATION_SENT` | Increment | `trackingId`, `clientVersion`, `clientPlatform`, `systemNotificationSent`, `sentAt` | A push notification is issued to a device. |
-| `NOTIFICATION_PROCESSED` | Increment | `trackingId`, `processedAt` | Client reports it processed a received notification. |
+| `NOTIFICATION_PROCESSED` | Increment | common + `trackingId`, `processedAt` | Client reports it processed a received notification. |
 
 ## metrics-service
 

--- a/packages/rest-api/src/services/chat/index.ts
+++ b/packages/rest-api/src/services/chat/index.ts
@@ -140,7 +140,10 @@ export function api({
       ) =>
         addChallenge(deletePulledMessagesRequest).pipe(
           Effect.flatMap((body) =>
-            client.Inboxes.deletePulledMessages({payload: body})
+            client.Inboxes.deletePulledMessages({
+              payload: body,
+              headers: commonHeaders,
+            })
           )
         ),
       blockInbox: (

--- a/packages/rest-api/src/services/chat/specification.ts
+++ b/packages/rest-api/src/services/chat/specification.ts
@@ -96,6 +96,7 @@ export const DeletePulledMessagesEndpoint = HttpApiEndpoint.del(
   'deletePulledMessages',
   '/api/v1/inboxes/messages'
 )
+  .setHeaders(CommonHeaders)
   .setPayload(DeletePulledMessagesRequest)
   .addSuccess(DeletePulledMessagesResponse)
   .addError(InvalidChallengeError, {status: 401})

--- a/packages/rest-api/src/services/contact/index.ts
+++ b/packages/rest-api/src/services/contact/index.ts
@@ -175,6 +175,7 @@ export function api({
           Effect.flatMap((body) =>
             client.ClubsMember.joinClub({
               payload: body,
+              headers: commonHeaders,
             })
           )
         ),

--- a/packages/rest-api/src/services/contact/specification.ts
+++ b/packages/rest-api/src/services/contact/specification.ts
@@ -275,6 +275,7 @@ export const JoinClubEndpoint = HttpApiEndpoint.post(
   'joinClub',
   '/api/v1/clubs/member/join-club'
 )
+  .setHeaders(CommonHeaders)
   .setPayload(JoinClubRequest)
   .addSuccess(JoinClubResponse)
   .addError(MemberAlreadyInClubError, {status: 400})

--- a/packages/rest-api/src/services/notification/index.ts
+++ b/packages/rest-api/src/services/notification/index.ts
@@ -85,7 +85,7 @@ export function api({
         client.issueNotification({payload}),
       reportNotificationProcessed: (
         request: ReportNotificationProcessedRequest
-      ) => client.reportNotificationProcessed({payload: request}),
+      ) => client.reportNotificationProcessed({payload: request, headers}),
       createNotificationSecret: (payload: CreateNotificationSecretRequest) =>
         client.NotificationTokenGroup.CreateNotificationSecret({
           payload,

--- a/packages/rest-api/src/services/notification/specification.ts
+++ b/packages/rest-api/src/services/notification/specification.ts
@@ -50,6 +50,7 @@ export const ReportNotificationProcessedEndpoint = HttpApiEndpoint.post(
   'reportNotificationProcessed',
   '/report-notification'
 )
+  .setHeaders(CommonHeaders)
   .setPayload(ReportNotificationProcessedRequest)
   .addSuccess(NoContentResponse)
   .annotate(MaxExpectedDailyCall, 5000)

--- a/packages/rest-api/src/services/offer/index.ts
+++ b/packages/rest-api/src/services/offer/index.ts
@@ -140,7 +140,7 @@ export function api({
       refreshOffer: (body: RefreshOfferRequest) =>
         client.refreshOffer({payload: body}),
       deleteOffer: (req: DeleteOfferRequest) =>
-        client.deleteOffer({urlParams: req}),
+        client.deleteOffer({urlParams: req, headers: commonHeaders}),
       updateOffer: (body: UpdateOfferRequest) =>
         withSecurityHeaders((headers) =>
           client.updateOffer({payload: body, headers})

--- a/packages/rest-api/src/services/offer/specification.ts
+++ b/packages/rest-api/src/services/offer/specification.ts
@@ -15,6 +15,7 @@ import {
 } from '../../apiSecurity'
 import {InvalidChallengeError} from '../../challenges/contracts'
 import {ChallengeApiGroup} from '../../challenges/specification'
+import {CommonHeaders} from '../../commonHeaders'
 import {MaxExpectedDailyCall} from '../../MaxExpectedDailyCountAnnotation'
 import {RateLimitingMiddleware} from '../../rateLimititing'
 import {
@@ -106,6 +107,7 @@ export const DeleteOfferEndpoint = HttpApiEndpoint.del(
   '/api/v1/offers'
 )
   .annotate(OpenApi.Summary, 'Delete offer')
+  .setHeaders(CommonHeaders)
   .setUrlParams(DeleteOfferRequest)
   .addSuccess(DeleteOfferResponse)
   .annotate(MaxExpectedDailyCall, 50)

--- a/packages/rest-api/src/services/user/index.ts
+++ b/packages/rest-api/src/services/user/index.ts
@@ -100,7 +100,7 @@ export function api({
       verifyPhoneNumber: (body: VerifyPhoneNumberRequest) =>
         client.Login.verifyCode({payload: body}),
       verifyChallenge: (body: VerifyChallengeRequest) =>
-        client.Login.verifyChallenge({payload: body}),
+        client.Login.verifyChallenge({payload: body, headers: commonHeaders}),
       deleteUser: () =>
         withSecurityHeaders((headers) => client.logoutUser({headers})),
       getVersionServiceInfo: () =>

--- a/packages/rest-api/src/services/user/specification.ts
+++ b/packages/rest-api/src/services/user/specification.ts
@@ -79,6 +79,7 @@ export const VerifyChallengeEndpoint = HttpApiEndpoint.post(
   'verifyChallenge',
   '/api/v1/user/confirmation/challenge'
 )
+  .setHeaders(CommonHeaders)
   .setPayload(VerifyChallengeRequest)
   .addSuccess(VerifyChallengeResponse)
   .addError(InvalidSignatureError, {status: 400})


### PR DESCRIPTION
## Summary

Follow-up to #2653 — extends the common metric attributes (`appVersion`, `appVersionCode`, `appPlatform`, `appSource`, `clientCountryPrefix`) to the remaining frontend-triggered metrics that were still reported without them:

- `USER_LOGGED_IN` (user-service, phone verification) — keeps `countryPrefix` of the verified number alongside the common attributes
- `USER_JOINED_CLUB_AND_IMPORTED_CONTACTS` (contact-service, join club)
- `OFFER_PUBLIC_PART_DELETED` (offer-service, delete offer)
- `MESSAGE_FETCHED_AND_REMOVED` (chat-service, delete pulled messages)
- `NOTIFICATION_PROCESSED` (notification-service)

Each metric is a separate commit: endpoint spec now declares `CommonHeaders`, the client wrapper passes them (they were already sent on the wire by the shared HTTP client, so this is wire-compatible with all deployed clients), the handler extracts the attributes, and `docs/backend_stats.md` is updated.

Server-originated metrics (gauges, cleanup tasks, notification issuance) are intentionally unchanged.

## Validation

- `pnpm turbo:typecheck`, `pnpm turbo:format`, `pnpm turbo:lint`
- Test suites: user-service (36), contact-service (144), offer-service (81), chat-service deletePulledMessages, notification-service (25) — all passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added standard request headers to message deletion, club joining, offer deletion, login verification, and notification processing requests.
  * Improved service metrics by recording shared request context, such as client and platform details, across login, messaging, club, offer, and notification events.
* **Documentation**
  * Updated backend metrics documentation to describe the newly captured request attributes.
* **Tests**
  * Expanded coverage to validate requests with the required headers across affected workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->