### PR TITLE
Metrics improvements

### DIFF
--- a/apps/chat-service/src/__tests__/routes/deletePulledMessages.test.ts
+++ b/apps/chat-service/src/__tests__/routes/deletePulledMessages.test.ts
@@ -7,6 +7,7 @@ import {CommonHeaders} from '@vexl-next/rest-api/src/commonHeaders'
 import {type SendMessageRequest} from '@vexl-next/rest-api/src/services/chat/contracts'
 import {InboxDoesNotExistError} from '@vexl-next/rest-api/src/services/contact/contracts'
 import {expectErrorResponse} from '@vexl-next/server-utils/src/tests/expectErrorResponse'
+import {mockedReportMetric} from '@vexl-next/server-utils/src/tests/mockedMetricsClientService'
 import {
   clearTestAuthHeaders,
   setAuthHeaders,
@@ -98,11 +99,22 @@ describe('Delete pulled messages', () => {
           })
         )
 
+        mockedReportMetric.mockClear()
         yield* _(setAuthHeaders(user1.authHeaders))
         yield* _(
           client.Inboxes.deletePulledMessages({
             headers: commonHeaders,
             payload: yield* _(user1.addChallengeForMainInbox({})),
+          })
+        )
+
+        expect(mockedReportMetric).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'MESSAGE_FETCHED_AND_REMOVED',
+            value: messagesForUser1Before.messages.length,
+            attributes: expect.objectContaining({
+              messageAgeSeconds: expect.any(Number),
+            }),
           })
         )
 

--- a/apps/chat-service/src/db/MessagesDbService/index.ts
+++ b/apps/chat-service/src/db/MessagesDbService/index.ts
@@ -4,7 +4,10 @@ import {type InboxRecordId} from '../InboxDbService/domain'
 import {type MessageRecord, type MessageRecordId} from './domain'
 import {createDeleteAllMessagesByInboxId} from './query/createDeleteAllMessagesByInboxId'
 import {createDeleteExpiredMessages} from './query/createDeleteExpiredMessages'
-import {createDeletePulledMessagesMessagesByInboxId} from './query/createDeletePulledMessagesByInboxId'
+import {
+  createDeletePulledMessagesMessagesByInboxId,
+  type DeletedPulledMessagesSummary,
+} from './query/createDeletePulledMessagesByInboxId'
 import {createFindMessagesByInboxId} from './query/createFindMessagesByInboxId'
 import {
   createInsertMessageForInbox,
@@ -19,7 +22,7 @@ export interface MessagesDbOperations {
 
   deletePulledMessagesByInboxId: (
     args: InboxRecordId
-  ) => Effect.Effect<number, UnexpectedServerError>
+  ) => Effect.Effect<DeletedPulledMessagesSummary, UnexpectedServerError>
 
   deleteExpiredMessages: () => Effect.Effect<number, UnexpectedServerError>
 

--- a/apps/chat-service/src/db/MessagesDbService/query/createDeletePulledMessagesByInboxId.ts
+++ b/apps/chat-service/src/db/MessagesDbService/query/createDeletePulledMessagesByInboxId.ts
@@ -4,12 +4,20 @@ import {UnexpectedServerError} from '@vexl-next/domain/src/general/commonErrors'
 import {Effect, flow, Option, Schema} from 'effect'
 import {InboxRecordId} from '../../InboxDbService/domain'
 
+export interface DeletedPulledMessagesSummary {
+  count: number
+  avgMessageAgeSeconds: Option.Option<number>
+}
+
 export const createDeletePulledMessagesMessagesByInboxId = Effect.gen(
   function* (_) {
     const sql = yield* _(PgClient.PgClient)
 
     const query = SqlSchema.findOne({
-      Result: Schema.Struct({count: Schema.NumberFromString}),
+      Result: Schema.Struct({
+        count: Schema.NumberFromString,
+        avgAgeSeconds: Schema.NullOr(Schema.Number),
+      }),
       Request: InboxRecordId,
       execute: (params) => sql`
         WITH
@@ -18,9 +26,22 @@ export const createDeletePulledMessagesMessagesByInboxId = Effect.gen(
             WHERE
               inbox_id = ${params}
               AND pulled = TRUE
+            RETURNING
+              received_by_server_at
           )
         SELECT
-          count(*) AS COUNT
+          count(*) AS COUNT,
+          round(
+            avg(
+              EXTRACT(
+                EPOCH
+                FROM
+                  now() - received_by_server_at
+              )
+            )
+          )::int AS "avgAgeSeconds"
+        FROM
+          deleted
       `,
     })
 
@@ -28,8 +49,18 @@ export const createDeletePulledMessagesMessagesByInboxId = Effect.gen(
       query,
       Effect.map(
         flow(
-          Option.map((r) => r.count),
-          Option.getOrElse(() => 0)
+          Option.map(
+            (r): DeletedPulledMessagesSummary => ({
+              count: r.count,
+              avgMessageAgeSeconds: Option.fromNullable(r.avgAgeSeconds),
+            })
+          ),
+          Option.getOrElse(
+            (): DeletedPulledMessagesSummary => ({
+              count: 0,
+              avgMessageAgeSeconds: Option.none(),
+            })
+          )
         )
       ),
       Effect.catchAll((e) =>

--- a/apps/chat-service/src/metrics.ts
+++ b/apps/chat-service/src/metrics.ts
@@ -107,7 +107,8 @@ export const reportMessageSent = (
 
 export const reportMessageFetchedAndRemoved = (
   number: number,
-  attributes: CommonMetricAttributes
+  messageAgeSeconds: number | 'unknown',
+  commonMetricAttributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
@@ -115,7 +116,7 @@ export const reportMessageFetchedAndRemoved = (
       uuid: generateUuid(),
       timestamp: new Date(),
       name: MESSAGE_FETCHED_AND_REMOVED,
-      attributes,
+      attributes: {...commonMetricAttributes, messageAgeSeconds},
     })
   )
 

--- a/apps/chat-service/src/routes/inbox/deletePulledMessages.ts
+++ b/apps/chat-service/src/routes/inbox/deletePulledMessages.ts
@@ -5,7 +5,7 @@ import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect
 import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {validateChallengeInBody} from '@vexl-next/server-utils/src/services/challenge/utils/validateChallengeInBody'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
-import {Effect} from 'effect'
+import {Effect, Option} from 'effect'
 import {InboxDbService} from '../../db/InboxDbService'
 import {MessagesDbService} from '../../db/MessagesDbService'
 import {hashPublicKey} from '../../db/domain'
@@ -35,9 +35,13 @@ export const deletePulledMessages = HttpApiBuilder.handler(
       const messagesService = yield* _(MessagesDbService)
       yield* _(
         messagesService.deletePulledMessagesByInboxId(inboxRecord.id),
-        Effect.tap((count) =>
+        Effect.tap(({count, avgMessageAgeSeconds}) =>
           reportMessageFetchedAndRemoved(
             count,
+            Option.getOrElse(
+              avgMessageAgeSeconds,
+              (): number | 'unknown' => 'unknown'
+            ),
             commonMetricAttributesFromHeaders(req.headers)
           )
         )

--- a/apps/contact-service/src/__tests__/metrics.test.ts
+++ b/apps/contact-service/src/__tests__/metrics.test.ts
@@ -18,12 +18,12 @@ describe('Active and inactive user gauges', () => {
         // (.env.test). pk1 and pk2 are active; pk2, pk3 and pk4 are inactive.
         yield* _(sql`
           INSERT INTO
-            users (public_key, hash, refreshed_at)
+            users (public_key, hash, refreshed_at, country_prefix)
           VALUES
-            ('pk1', 'h1', CURRENT_DATE),
-            ('pk2', 'h2', CURRENT_DATE - 10),
-            ('pk3', 'h3', CURRENT_DATE - 40),
-            ('pk4', 'h4', NULL)
+            ('pk1', 'h1', CURRENT_DATE, 420),
+            ('pk2', 'h2', CURRENT_DATE - 10, 420),
+            ('pk3', 'h3', CURRENT_DATE - 40, 421),
+            ('pk4', 'h4', NULL, NULL)
         `)
 
         mockedReportMetric.mockClear()
@@ -41,11 +41,20 @@ describe('Active and inactive user gauges', () => {
         )
         expect(mockedReportMetric).toHaveBeenCalledWith(
           expect.objectContaining({
+            name: 'COUNT_OF_ACTIVE_USERS_BY_COUNTRY',
+            value: 2,
+            attributes: {countryPrefix: 420},
+            type: 'Total',
+          })
+        )
+        expect(mockedReportMetric).toHaveBeenCalledWith(
+          expect.objectContaining({
             name: 'COUNT_OF_INACTIVE_USERS',
             value: 3,
             type: 'Total',
           })
         )
+        expect(mockedReportMetric).toHaveBeenCalledTimes(3)
       })
     )
   })

--- a/apps/contact-service/src/__tests__/metrics.test.ts
+++ b/apps/contact-service/src/__tests__/metrics.test.ts
@@ -1,0 +1,52 @@
+import {SqlClient} from '@effect/sql'
+import {mockedReportMetric} from '@vexl-next/server-utils/src/tests/mockedMetricsClientService'
+import {Effect} from 'effect'
+import {
+  queryAndReportNumberOfActiveUsers,
+  queryAndReportNumberOfInactiveUsers,
+} from '../metrics'
+import {runPromiseInMockedEnvironment} from './utils/runPromiseInMockedEnvironment'
+
+describe('Active and inactive user gauges', () => {
+  it('Reports counts of active and inactive users', async () => {
+    await runPromiseInMockedEnvironment(
+      Effect.gen(function* (_) {
+        const sql = yield* _(SqlClient.SqlClient)
+        yield* _(sql`DELETE FROM user_contact`)
+        yield* _(sql`DELETE FROM users`)
+        // Active window is 30 days (default), inactivity threshold is 2 days
+        // (.env.test). pk1 and pk2 are active; pk2, pk3 and pk4 are inactive.
+        yield* _(sql`
+          INSERT INTO
+            users (public_key, hash, refreshed_at)
+          VALUES
+            ('pk1', 'h1', CURRENT_DATE),
+            ('pk2', 'h2', CURRENT_DATE - 10),
+            ('pk3', 'h3', CURRENT_DATE - 40),
+            ('pk4', 'h4', NULL)
+        `)
+
+        mockedReportMetric.mockClear()
+        yield* _(queryAndReportNumberOfActiveUsers)
+        yield* _(queryAndReportNumberOfInactiveUsers)
+        // reports are forked into the background
+        yield* _(Effect.sleep(200))
+
+        expect(mockedReportMetric).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'COUNT_OF_ACTIVE_USERS',
+            value: 2,
+            type: 'Total',
+          })
+        )
+        expect(mockedReportMetric).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'COUNT_OF_INACTIVE_USERS',
+            value: 3,
+            type: 'Total',
+          })
+        )
+      })
+    )
+  })
+})

--- a/apps/contact-service/src/__tests__/routes/user/createUser.test.ts
+++ b/apps/contact-service/src/__tests__/routes/user/createUser.test.ts
@@ -11,6 +11,7 @@ import {ExpoNotificationToken} from '@vexl-next/domain/src/utility/ExpoNotificat
 import {CommonHeaders} from '@vexl-next/rest-api/src/commonHeaders'
 import {hashPhoneNumber} from '@vexl-next/server-utils/src/generateUserAuthData'
 import {createDummyAuthHeadersForUser} from '@vexl-next/server-utils/src/tests/createDummyAuthHeaders'
+import {mockedReportMetric} from '@vexl-next/server-utils/src/tests/mockedMetricsClientService'
 import {setAuthHeaders} from '@vexl-next/server-utils/src/tests/nodeTestingApp'
 import {serverHashPhoneNumber} from '../../../utils/serverHashContact'
 import {makeTestCommonAndSecurityHeaders} from '../contacts/utils'
@@ -43,6 +44,7 @@ describe('create user', () => {
           testCommonHeaders
         )
 
+        mockedReportMetric.mockClear()
         yield* _(
           app.User.createUser({
             payload: {
@@ -54,6 +56,21 @@ describe('create user', () => {
               publicKeyV2: Option.none(),
             },
             headers: commonAndSecurityHeaders,
+          })
+        )
+
+        expect(mockedReportMetric).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'USER_LOGGED_IN',
+            attributes: {
+              appVersion: '1.0.0',
+              appVersionCode: 1,
+              appPlatform: 'ANDROID',
+              appSource: 'googlePlay',
+              clientCountryPrefix: 'none',
+              countryPrefix: 'none',
+              numberExists: false,
+            },
           })
         )
 
@@ -163,6 +180,7 @@ describe('create user', () => {
         const commonAndSecurityHeaders2 =
           makeTestCommonAndSecurityHeaders(authHeaders2)
 
+        mockedReportMetric.mockClear()
         yield* _(
           app.User.createUser({
             payload: {
@@ -174,6 +192,15 @@ describe('create user', () => {
               publicKeyV2: Option.none(),
             },
             headers: commonAndSecurityHeaders2,
+          })
+        )
+
+        expect(mockedReportMetric).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'USER_LOGGED_IN',
+            attributes: expect.objectContaining({
+              numberExists: true,
+            }),
           })
         )
 

--- a/apps/contact-service/src/__tests__/routes/user/refreshUser.test.ts
+++ b/apps/contact-service/src/__tests__/routes/user/refreshUser.test.ts
@@ -381,6 +381,7 @@ describe('Refresh user', () => {
         `)
 
         yield* _(clearEnqueuedNotifications)
+        mockedReportMetric.mockClear()
         yield* _(setAuthHeaders(firstUserAuthHeaders))
         yield* _(
           app.User.refreshUser({
@@ -392,6 +393,19 @@ describe('Refresh user', () => {
           })
         )
         yield* _(Effect.sleep(200))
+
+        expect(mockedReportMetric).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'USER_REACTIVATED',
+            attributes: {
+              appVersion: '1.0.0',
+              appVersionCode: 1,
+              appPlatform: 'ANDROID',
+              appSource: 'unknown',
+              clientCountryPrefix: 'none',
+            },
+          })
+        )
 
         const notifications = yield* _(getEnqueuedNotifications)
         const newUserNotifications = notifications.filter(

--- a/apps/contact-service/src/configs.ts
+++ b/apps/contact-service/src/configs.ts
@@ -83,6 +83,14 @@ export const deactivateAndClearClubsCronConfig = Config.string(
   'DEACTIVATE_AND_CLEAR_CLUBS_CRON'
 ).pipe(Config.withDefault('0 9 * * *'))
 
+export const reportActiveUsersCronConfig = Config.string(
+  'REPORT_ACTIVE_USERS_CRON'
+).pipe(Config.withDefault('30 0 * * *'))
+
+export const activeUserWindowDaysConfig = Config.number(
+  'ACTIVE_USER_WINDOW_DAYS'
+).pipe(Config.withDefault(30))
+
 export const secretSaltForServerContact = Config.string(
   'SECRET_SALT_FOR_SERVER_CONTACTS'
 )

--- a/apps/contact-service/src/metrics.ts
+++ b/apps/contact-service/src/metrics.ts
@@ -1,5 +1,5 @@
-import {SqlClient} from '@effect/sql'
-import {type CountryPrefix} from '@vexl-next/domain/src/general/CountryPrefix.brand'
+import {SqlClient, SqlSchema} from '@effect/sql'
+import {CountryPrefix} from '@vexl-next/domain/src/general/CountryPrefix.brand'
 import {type NotificationTrackingId} from '@vexl-next/domain/src/general/NotificationTrackingId.brand'
 import {type ClubUuid} from '@vexl-next/domain/src/general/clubs'
 import {generateUuid} from '@vexl-next/domain/src/utility/Uuid.brand'
@@ -8,7 +8,7 @@ import {type MetricsClientService} from '@vexl-next/server-utils/src/metrics/Met
 import {type CommonMetricAttributes} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {MetricsMessage} from '@vexl-next/server-utils/src/metrics/domain'
 import {reportMetricForked} from '@vexl-next/server-utils/src/metrics/reportMetricForked'
-import {Effect, Layer} from 'effect'
+import {Array, Effect, Layer, pipe, Schema} from 'effect'
 import {
   activeUserWindowDaysConfig,
   inactivityNotificationAfterDaysConfig,
@@ -19,6 +19,8 @@ const COUNT_OF_UNIQUE_CONTACTS = 'COUNT_OF_UNIQUE_CONTACTS' as const
 const COUNT_OF_CONNECTIONS = 'COUNT_OF_CONNECTIONS' as const
 const COUNT_OF_INACTIVE_USERS = 'COUNT_OF_INACTIVE_USERS' as const
 const COUNT_OF_ACTIVE_USERS = 'COUNT_OF_ACTIVE_USERS' as const
+const COUNT_OF_ACTIVE_USERS_BY_COUNTRY =
+  'COUNT_OF_ACTIVE_USERS_BY_COUNTRY' as const
 const USER_LOGGED_IN = 'USER_LOGGED_IN' as const
 const USER_REFRESH = 'USER_REFRESH' as const
 const USER_REACTIVATED = 'USER_REACTIVATED' as const
@@ -83,14 +85,35 @@ export const reportCountOfInactiveUsers = (
   )
 
 export const reportCountOfActiveUsers = (
-  count: number
+  count: number,
+  timestamp: Date = new Date()
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
       uuid: generateUuid(),
-      timestamp: new Date(),
+      timestamp,
       name: COUNT_OF_ACTIVE_USERS,
       value: count,
+      type: 'Total',
+    })
+  )
+
+export const reportCountOfActiveUsersByCountry = ({
+  count,
+  countryPrefix,
+  timestamp,
+}: {
+  count: number
+  countryPrefix: CountryPrefix | 'none'
+  timestamp: Date
+}): Effect.Effect<void, never, MetricsClientService> =>
+  reportMetricForked(
+    new MetricsMessage({
+      uuid: generateUuid(),
+      timestamp,
+      name: COUNT_OF_ACTIVE_USERS_BY_COUNTRY,
+      value: count,
+      attributes: {countryPrefix},
       type: 'Total',
     })
   )
@@ -326,24 +349,56 @@ export const queryAndReportNumberOfInactiveUsers = Effect.gen(function* (_) {
   )
 })
 
+const ActiveUsersByCountryQueryResult = Schema.Struct({
+  count: Schema.NumberFromString,
+  countryPrefix: Schema.Union(CountryPrefix, Schema.Null),
+})
+
 export const queryAndReportNumberOfActiveUsers = Effect.gen(function* (_) {
   const activeUserWindowDays = yield* _(activeUserWindowDaysConfig)
   const sql = yield* _(SqlClient.SqlClient)
+
+  const activeUsersByCountry = yield* _(
+    SqlSchema.findAll({
+      Request: Schema.Null,
+      Result: ActiveUsersByCountryQueryResult,
+      execute: () => sql`
+        SELECT
+          count(*) AS "count",
+          country_prefix AS "countryPrefix"
+        FROM
+          users
+        WHERE
+          refreshed_at >= now() - interval '1 day' * ${activeUserWindowDays}
+        GROUP BY
+          country_prefix
+      `,
+    })(null)
+  )
+
+  const totalActiveUsers = pipe(
+    activeUsersByCountry,
+    Array.map(({count}) => count),
+    Array.reduce(0, (sum, count) => sum + count)
+  )
+  const snapshotTimestamp = new Date()
+
+  const reportEffects = pipe(
+    activeUsersByCountry,
+    Array.map(({count, countryPrefix}) =>
+      reportCountOfActiveUsersByCountry({
+        count,
+        countryPrefix: countryPrefix ?? 'none',
+        timestamp: snapshotTimestamp,
+      })
+    ),
+    Array.prepend(reportCountOfActiveUsers(totalActiveUsers, snapshotTimestamp))
+  )
+
   yield* _(
-    sql`
-      SELECT
-        count(*)
-      FROM
-        users
-      WHERE
-        refreshed_at >= now() - interval '1 day' * ${activeUserWindowDays}
-    `,
-    Effect.map((one) => Number(one[0].count)),
-    Effect.flatMap((v) =>
-      Effect.zipRight(
-        Effect.logInfo(`Reporting number of active users: ${v}`),
-        reportCountOfActiveUsers(v)
-      )
+    Effect.all(reportEffects, {concurrency: 'unbounded'}),
+    Effect.zipLeft(
+      Effect.logInfo(`Reported ${totalActiveUsers} active users by country`)
     ),
     Effect.withSpan('Query number of active users')
   )

--- a/apps/contact-service/src/metrics.ts
+++ b/apps/contact-service/src/metrics.ts
@@ -1,4 +1,5 @@
 import {SqlClient} from '@effect/sql'
+import {type CountryPrefix} from '@vexl-next/domain/src/general/CountryPrefix.brand'
 import {type NotificationTrackingId} from '@vexl-next/domain/src/general/NotificationTrackingId.brand'
 import {type ClubUuid} from '@vexl-next/domain/src/general/clubs'
 import {generateUuid} from '@vexl-next/domain/src/utility/Uuid.brand'
@@ -14,6 +15,7 @@ const CONT_OF_UNIQUE_USERS = 'COUNT_OF_UNIQUE_USERS' as const
 const COUNT_OF_UNIQUE_CONTACTS = 'COUNT_OF_UNIQUE_CONTACTS' as const
 const COUNT_OF_CONNECTIONS = 'COUNT_OF_CONNECTIONS' as const
 const COUNT_OF_INACTIVE_USERS = 'COUNT_OF_INACTIVE_USERS' as const
+const USER_LOGGED_IN = 'USER_LOGGED_IN' as const
 const USER_REFRESH = 'USER_REFRESH' as const
 const USER_REACTIVATED = 'USER_REACTIVATED' as const
 const NEW_APP_USER_NOTIFICATIONS_SENT =
@@ -73,6 +75,24 @@ export const reportCountOfInactiveUsers = (
       name: COUNT_OF_INACTIVE_USERS,
       value: count,
       type: 'Total',
+    })
+  )
+
+export const reportUserLoggedIn = ({
+  countryPrefix,
+  numberExists,
+  commonMetricAttributes,
+}: {
+  countryPrefix: CountryPrefix | 'none'
+  numberExists: boolean
+  commonMetricAttributes: CommonMetricAttributes
+}): Effect.Effect<void, never, MetricsClientService> =>
+  reportMetricForked(
+    new MetricsMessage({
+      uuid: generateUuid(),
+      timestamp: new Date(),
+      name: USER_LOGGED_IN,
+      attributes: {...commonMetricAttributes, countryPrefix, numberExists},
     })
   )
 

--- a/apps/contact-service/src/metrics.ts
+++ b/apps/contact-service/src/metrics.ts
@@ -13,6 +13,7 @@ import {inactivityNotificationAfterDaysConfig} from './configs'
 const CONT_OF_UNIQUE_USERS = 'COUNT_OF_UNIQUE_USERS' as const
 const COUNT_OF_UNIQUE_CONTACTS = 'COUNT_OF_UNIQUE_CONTACTS' as const
 const COUNT_OF_CONNECTIONS = 'COUNT_OF_CONNECTIONS' as const
+const COUNT_OF_INACTIVE_USERS = 'COUNT_OF_INACTIVE_USERS' as const
 const USER_REFRESH = 'USER_REFRESH' as const
 const NEW_APP_USER_NOTIFICATIONS_SENT =
   'NEW_APP_USER_NOTIFICATIONS_SENT' as const
@@ -56,6 +57,19 @@ export const reportCountOfConnections = (
       uuid: generateUuid(),
       timestamp: new Date(),
       name: COUNT_OF_CONNECTIONS,
+      value: count,
+      type: 'Total',
+    })
+  )
+
+export const reportCountOfInactiveUsers = (
+  count: number
+): Effect.Effect<void, never, MetricsClientService> =>
+  reportMetricForked(
+    new MetricsMessage({
+      uuid: generateUuid(),
+      timestamp: new Date(),
+      name: COUNT_OF_INACTIVE_USERS,
       value: count,
       type: 'Total',
     })
@@ -232,27 +246,32 @@ export const reportGaguesLayer = Layer.effectDiscard(
   })
 )
 
-export const queryAndReportNumberOfInnactiveUsers = Effect.gen(function* (_) {
+export const queryAndReportNumberOfInactiveUsers = Effect.gen(function* (_) {
   const inactivityNotificationAfterDays = yield* _(
     inactivityNotificationAfterDaysConfig
   )
   const sql = yield* _(SqlClient.SqlClient)
-  return sql`
-    SELECT
-      count(*)
-    FROM
-      users
-    WHERE
-      refreshed_at IS NULL
-      OR refreshed_at < now() - interval '${inactivityNotificationAfterDays} day'
-  `.pipe(
+  yield* _(
+    sql`
+      SELECT
+        count(*)
+      FROM
+        users
+      WHERE
+        refreshed_at IS NULL
+        OR refreshed_at < now() - interval '${inactivityNotificationAfterDays} day'
+    `,
     Effect.map((one) => Number(one[0].count)),
     Effect.flatMap((v) =>
       Effect.zipRight(
-        Effect.logInfo(`Reporting number of innactive users: ${v}`),
-        reportCountOfUniqueContacts(v)
+        Effect.logInfo(`Reporting number of inactive users: ${v}`),
+        reportCountOfInactiveUsers(v)
       )
     ),
+    Effect.tapError((e) =>
+      Effect.logError('Error reporting number of inactive users', e)
+    ),
+    Effect.ignore,
     Effect.withSpan('Query number of inactive users')
   )
 })

--- a/apps/contact-service/src/metrics.ts
+++ b/apps/contact-service/src/metrics.ts
@@ -9,12 +9,16 @@ import {type CommonMetricAttributes} from '@vexl-next/server-utils/src/metrics/c
 import {MetricsMessage} from '@vexl-next/server-utils/src/metrics/domain'
 import {reportMetricForked} from '@vexl-next/server-utils/src/metrics/reportMetricForked'
 import {Effect, Layer} from 'effect'
-import {inactivityNotificationAfterDaysConfig} from './configs'
+import {
+  activeUserWindowDaysConfig,
+  inactivityNotificationAfterDaysConfig,
+} from './configs'
 
 const CONT_OF_UNIQUE_USERS = 'COUNT_OF_UNIQUE_USERS' as const
 const COUNT_OF_UNIQUE_CONTACTS = 'COUNT_OF_UNIQUE_CONTACTS' as const
 const COUNT_OF_CONNECTIONS = 'COUNT_OF_CONNECTIONS' as const
 const COUNT_OF_INACTIVE_USERS = 'COUNT_OF_INACTIVE_USERS' as const
+const COUNT_OF_ACTIVE_USERS = 'COUNT_OF_ACTIVE_USERS' as const
 const USER_LOGGED_IN = 'USER_LOGGED_IN' as const
 const USER_REFRESH = 'USER_REFRESH' as const
 const USER_REACTIVATED = 'USER_REACTIVATED' as const
@@ -73,6 +77,19 @@ export const reportCountOfInactiveUsers = (
       uuid: generateUuid(),
       timestamp: new Date(),
       name: COUNT_OF_INACTIVE_USERS,
+      value: count,
+      type: 'Total',
+    })
+  )
+
+export const reportCountOfActiveUsers = (
+  count: number
+): Effect.Effect<void, never, MetricsClientService> =>
+  reportMetricForked(
+    new MetricsMessage({
+      uuid: generateUuid(),
+      timestamp: new Date(),
+      name: COUNT_OF_ACTIVE_USERS,
       value: count,
       type: 'Total',
     })
@@ -292,7 +309,7 @@ export const queryAndReportNumberOfInactiveUsers = Effect.gen(function* (_) {
         users
       WHERE
         refreshed_at IS NULL
-        OR refreshed_at < now() - interval '${inactivityNotificationAfterDays} day'
+        OR refreshed_at < now() - interval '1 day' * ${inactivityNotificationAfterDays}
     `,
     Effect.map((one) => Number(one[0].count)),
     Effect.flatMap((v) =>
@@ -306,5 +323,28 @@ export const queryAndReportNumberOfInactiveUsers = Effect.gen(function* (_) {
     ),
     Effect.ignore,
     Effect.withSpan('Query number of inactive users')
+  )
+})
+
+export const queryAndReportNumberOfActiveUsers = Effect.gen(function* (_) {
+  const activeUserWindowDays = yield* _(activeUserWindowDaysConfig)
+  const sql = yield* _(SqlClient.SqlClient)
+  yield* _(
+    sql`
+      SELECT
+        count(*)
+      FROM
+        users
+      WHERE
+        refreshed_at >= now() - interval '1 day' * ${activeUserWindowDays}
+    `,
+    Effect.map((one) => Number(one[0].count)),
+    Effect.flatMap((v) =>
+      Effect.zipRight(
+        Effect.logInfo(`Reporting number of active users: ${v}`),
+        reportCountOfActiveUsers(v)
+      )
+    ),
+    Effect.withSpan('Query number of active users')
   )
 })

--- a/apps/contact-service/src/metrics.ts
+++ b/apps/contact-service/src/metrics.ts
@@ -15,6 +15,7 @@ const COUNT_OF_UNIQUE_CONTACTS = 'COUNT_OF_UNIQUE_CONTACTS' as const
 const COUNT_OF_CONNECTIONS = 'COUNT_OF_CONNECTIONS' as const
 const COUNT_OF_INACTIVE_USERS = 'COUNT_OF_INACTIVE_USERS' as const
 const USER_REFRESH = 'USER_REFRESH' as const
+const USER_REACTIVATED = 'USER_REACTIVATED' as const
 const NEW_APP_USER_NOTIFICATIONS_SENT =
   'NEW_APP_USER_NOTIFICATIONS_SENT' as const
 
@@ -83,6 +84,18 @@ export const reportUserRefresh = (
       uuid: generateUuid(),
       timestamp: new Date(),
       name: USER_REFRESH,
+      attributes,
+    })
+  )
+
+export const reportUserReactivated = (
+  attributes: CommonMetricAttributes
+): Effect.Effect<void, never, MetricsClientService> =>
+  reportMetricForked(
+    new MetricsMessage({
+      uuid: generateUuid(),
+      timestamp: new Date(),
+      name: USER_REACTIVATED,
       attributes,
     })
   )

--- a/apps/contact-service/src/routes/user/createUser.ts
+++ b/apps/contact-service/src/routes/user/createUser.ts
@@ -1,12 +1,15 @@
 import {HttpApiBuilder} from '@effect/platform/index'
+import {type CountryPrefix} from '@vexl-next/domain/src/general/CountryPrefix.brand'
 import {type UnexpectedServerError} from '@vexl-next/domain/src/general/commonErrors'
 import {CurrentSecurity} from '@vexl-next/rest-api/src/apiSecurity'
 import {ContactApiSpecification} from '@vexl-next/rest-api/src/services/contact/specification'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
+import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
 import {Effect, Option} from 'effect'
 import {ContactDbService} from '../../db/ContactDbService'
 import {UserDbService} from '../../db/UserDbService'
+import {reportUserLoggedIn} from '../../metrics'
 import {
   serverHashPhoneNumber,
   type ServerHashedNumber,
@@ -16,7 +19,7 @@ import {withUserActionRedisLock} from '../../utils/withUserActionRedisLock'
 const deleteIfExists = (
   hash: ServerHashedNumber
 ): Effect.Effect<
-  void,
+  boolean,
   UnexpectedServerError,
   UserDbService | ContactDbService
 > =>
@@ -27,7 +30,7 @@ const deleteIfExists = (
     const user = yield* _(userDb.findUserByHash(hash))
     if (Option.isNone(user)) {
       yield* _(Effect.logInfo('No existing user found. Db is clean.'))
-      return
+      return false
     }
 
     yield* _(Effect.log('Removing existing user from database', user.value))
@@ -39,6 +42,7 @@ const deleteIfExists = (
         hash: user.value.hash,
       })
     )
+    return true
   }).pipe(Effect.withSpan('Check and delete existing user'))
 
 export const createUser = HttpApiBuilder.handler(
@@ -51,7 +55,20 @@ export const createUser = HttpApiBuilder.handler(
       Effect.flatMap((security) =>
         Effect.gen(function* (_) {
           const userDb = yield* _(UserDbService)
-          yield* _(deleteIfExists(security.serverHash))
+          const numberExists = yield* _(deleteIfExists(security.serverHash))
+
+          yield* _(
+            reportUserLoggedIn({
+              countryPrefix: Option.getOrElse(
+                req.headers.prefixOrNone,
+                (): CountryPrefix | 'none' => 'none'
+              ),
+              numberExists,
+              commonMetricAttributes: commonMetricAttributesFromHeaders(
+                req.headers
+              ),
+            })
+          )
 
           yield* _(
             userDb.insertUser({

--- a/apps/contact-service/src/routes/user/refreshUser.ts
+++ b/apps/contact-service/src/routes/user/refreshUser.ts
@@ -9,7 +9,7 @@ import {Array, Effect} from 'effect'
 import {contactActiveWindowDaysConfig} from '../../configs'
 import {ContactDbService} from '../../db/ContactDbService'
 import {UserDbService} from '../../db/UserDbService'
-import {reportUserRefresh} from '../../metrics'
+import {reportUserReactivated, reportUserRefresh} from '../../metrics'
 import {serverHashPhoneNumber} from '../../utils/serverHashContact'
 import {withUserActionRedisLock} from '../../utils/withUserActionRedisLock'
 import {notifyOthersAboutNewUserForked} from '../contacts/utils/notifyOthersAboutNewUser'
@@ -39,9 +39,10 @@ export const refreshUser = HttpApiBuilder.handler(
       Effect.bind('serverHash', (s) => serverHashPhoneNumber(s.hash)),
       Effect.flatMap((security) =>
         Effect.gen(function* (_) {
-          yield* _(
-            reportUserRefresh(commonMetricAttributesFromHeaders(req.headers))
+          const commonMetricAttributes = commonMetricAttributesFromHeaders(
+            req.headers
           )
+          yield* _(reportUserRefresh(commonMetricAttributes))
           const userDb = yield* _(UserDbService)
           const contactDb = yield* _(ContactDbService)
           const contactActiveWindowDays = yield* _(
@@ -76,6 +77,10 @@ export const refreshUser = HttpApiBuilder.handler(
               publicKeyV2: security.publicKeyV2,
             })
           )
+
+          if (wasInactiveBeforeRefresh) {
+            yield* _(reportUserReactivated(commonMetricAttributes))
+          }
 
           const importedHashes = wasInactiveBeforeRefresh
             ? yield* _(

--- a/apps/contact-service/src/scheduledTaskWorkers.ts
+++ b/apps/contact-service/src/scheduledTaskWorkers.ts
@@ -5,9 +5,11 @@ import {
   deleteInactiveClubMembersCronConfig,
   processNewContentNotificationCronConfig,
   processUserInactivityCronConfig,
+  reportActiveUsersCronConfig,
 } from './configs'
 import {checkForInactiveUsers} from './internalServer/routes/checkForInactiveUsers'
 import {deactivateAndClearClubs} from './internalServer/routes/deactivateAndClearClubs'
+import {queryAndReportNumberOfActiveUsers} from './metrics'
 import {UserNotificationService} from './services/UserNotificationService'
 
 const processUserInactivityLayer = makeRepeatingTaskLayer({
@@ -50,9 +52,19 @@ const deactivateAndClearClubsLayer = makeRepeatingTaskLayer({
   task: deactivateAndClearClubs,
 })
 
+const reportActiveUsersLayer = makeRepeatingTaskLayer({
+  queueName: 'contact-service-report-active-users',
+  jobName: 'report_active_users',
+  cronPattern: reportActiveUsersCronConfig,
+  lockResource: 'contactService:reportActiveUsers',
+  lockDuration: '5 minutes',
+  task: queryAndReportNumberOfActiveUsers,
+})
+
 export const ScheduledTaskWorkersLayer = Layer.mergeAll(
   processUserInactivityLayer,
   processNewContentNotificationLayer,
   deleteInactiveClubMembersLayer,
-  deactivateAndClearClubsLayer
+  deactivateAndClearClubsLayer,
+  reportActiveUsersLayer
 )

--- a/apps/contact-service/src/services/UserNotificationService.ts
+++ b/apps/contact-service/src/services/UserNotificationService.ts
@@ -1,5 +1,4 @@
 import {type SqlClient} from '@effect/sql/SqlClient'
-import {type MetricsClientService} from '@vexl-next/server-utils/src/metrics/MetricsClientService'
 import {
   type PublicKeyPemBase64,
   type PublicKeyV2,
@@ -8,6 +7,7 @@ import {type ClubUuid} from '@vexl-next/domain/src/general/clubs'
 import {UnexpectedServerError} from '@vexl-next/domain/src/general/commonErrors'
 import {type VexlNotificationToken} from '@vexl-next/domain/src/general/notifications/VexlNotificationToken'
 import {type ExpoNotificationToken} from '@vexl-next/domain/src/utility/ExpoNotificationToken.brand'
+import {type MetricsClientService} from '@vexl-next/server-utils/src/metrics/MetricsClientService'
 import {
   ClubExpiredNotificationMqEntry,
   ClubFlaggedNotificationMqEntry,

--- a/apps/contact-service/src/services/UserNotificationService.ts
+++ b/apps/contact-service/src/services/UserNotificationService.ts
@@ -1,4 +1,5 @@
 import {type SqlClient} from '@effect/sql/SqlClient'
+import {type MetricsClientService} from '@vexl-next/server-utils/src/metrics/MetricsClientService'
 import {
   type PublicKeyPemBase64,
   type PublicKeyV2,
@@ -31,7 +32,7 @@ import {ClubsDbService} from '../db/ClubsDbService'
 import {type ClubRecordId} from '../db/ClubsDbService/domain'
 import {UserDbService} from '../db/UserDbService'
 import {NotificationsTokensEquivalence} from '../db/UserDbService/domain'
-import {queryAndReportNumberOfInnactiveUsers} from '../metrics'
+import {queryAndReportNumberOfInactiveUsers} from '../metrics'
 import {type ServerHashedNumber} from '../utils/serverHashContact'
 
 export interface UserNotificationServiceOperations {
@@ -49,7 +50,7 @@ export interface UserNotificationServiceOperations {
   notifyUsersAboutInactivity: () => Effect.Effect<
     void,
     UnexpectedServerError,
-    SqlClient
+    SqlClient | MetricsClientService
   >
   notifyUsersAboutFlaggedClub: (
     id: ClubRecordId,
@@ -386,7 +387,7 @@ export class UserNotificationService extends Context.Tag(
             )
 
             yield* _(Effect.logInfo('Reporting number of inactive users'))
-            yield* _(queryAndReportNumberOfInnactiveUsers)
+            yield* _(queryAndReportNumberOfInactiveUsers)
           }).pipe(
             Effect.tapError((e) =>
               Effect.logError('Error processing user inactivity', e)

--- a/apps/offer-service/src/metrics.ts
+++ b/apps/offer-service/src/metrics.ts
@@ -1,6 +1,9 @@
 import {SqlClient, SqlSchema} from '@effect/sql'
 import {CountryPrefix} from '@vexl-next/domain/src/general/CountryPrefix.brand'
-import {type OfferId} from '@vexl-next/domain/src/general/offers'
+import {
+  type OfferId,
+  type OfferType,
+} from '@vexl-next/domain/src/general/offers'
 import {generateUuid} from '@vexl-next/domain/src/utility/Uuid.brand'
 import {shouldDisableMetrics} from '@vexl-next/server-utils/src/commonConfigs'
 import {type CommonMetricAttributes} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
@@ -60,16 +63,21 @@ export const reportOfferModified = (
     })
   )
 
-export const reportOfferCreated = (
-  countryPrefix: CountryPrefix,
+export const reportOfferCreated = ({
+  countryPrefix,
+  offerType,
+  commonMetricAttributes,
+}: {
+  countryPrefix: CountryPrefix
+  offerType: OfferType
   commonMetricAttributes: CommonMetricAttributes
-): Effect.Effect<void, never, MetricsClientService> =>
+}): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
       uuid: generateUuid(),
       timestamp: new Date(),
       name: OFFER_CREATED,
-      attributes: {...commonMetricAttributes, countryPrefix},
+      attributes: {...commonMetricAttributes, countryPrefix, offerType},
     })
   )
 

--- a/apps/offer-service/src/routes/createNewOffer.ts
+++ b/apps/offer-service/src/routes/createNewOffer.ts
@@ -80,10 +80,13 @@ export const createNewOffer = HttpApiBuilder.handler(
       withOfferAdminActionRedisLock(req.payload.adminId),
       Effect.withSpan('createNewOffer'),
       Effect.zipLeft(
-        reportOfferCreated(
-          req.payload.countryPrefix,
-          commonMetricAttributesFromHeaders(req.headers)
-        )
+        reportOfferCreated({
+          countryPrefix: req.payload.countryPrefix,
+          offerType: req.payload.offerType,
+          commonMetricAttributes: commonMetricAttributesFromHeaders(
+            req.headers
+          ),
+        })
       ),
       makeEndpointEffect
     )

--- a/apps/user-service/src/__tests__/login/loginFlow.test.ts
+++ b/apps/user-service/src/__tests__/login/loginFlow.test.ts
@@ -76,9 +76,6 @@ describe('loginFlow', () => {
 
         const verifyChallenge = yield* _(
           client.Login.verifyChallenge({
-            headers: Schema.decodeSync(CommonHeaders)({
-              'user-agent': 'Vexl/2 (1.0.0) IOS',
-            }),
             payload: {
               userPublicKey: keypair.publicKeyPemBase64,
               signature: signedChallenge,

--- a/apps/user-service/src/__tests__/login/verifyChallenge.test.ts
+++ b/apps/user-service/src/__tests__/login/verifyChallenge.test.ts
@@ -77,9 +77,6 @@ describe('verify challenge', () => {
 
         const verifyChallenge = yield* _(
           client.Login.verifyChallenge({
-            headers: Schema.decodeSync(CommonHeaders)({
-              'user-agent': 'Vexl/2 (1.0.0) IOS',
-            }),
             payload: {
               userPublicKey: keypair.publicKeyPemBase64,
               signature: signedChallenge,

--- a/apps/user-service/src/metrics.ts
+++ b/apps/user-service/src/metrics.ts
@@ -2,29 +2,14 @@ import {SqlClient, SqlSchema} from '@effect/sql'
 import {CountryPrefix} from '@vexl-next/domain/src/general/CountryPrefix.brand'
 import {generateUuid} from '@vexl-next/domain/src/utility/Uuid.brand'
 import {shouldDisableMetrics} from '@vexl-next/server-utils/src/commonConfigs'
-import {type CommonMetricAttributes} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {MetricsMessage} from '@vexl-next/server-utils/src/metrics/domain'
 import {type MetricsClientService} from '@vexl-next/server-utils/src/metrics/MetricsClientService'
 import {reportMetricForked} from '@vexl-next/server-utils/src/metrics/reportMetricForked'
 import {Array, Effect, Layer, pipe, Schema} from 'effect'
 import {type ReadonlyArray} from 'effect/Array'
 
-const USER_LOGGED_IN = 'USER_LOGGED_IN' as const
 const NUMBER_OF_USERS = 'NUMBER_OF_USERS_BY_COUNTRY' as const
 const NUMBER_OF_USERS_ALL_COUNTRIES = 'NUMBER_OF_USERS' as const
-
-export const reportUserLoggedIn = (
-  countryPrefix: CountryPrefix,
-  commonMetricAttributes: CommonMetricAttributes
-): Effect.Effect<void, never, MetricsClientService> =>
-  reportMetricForked(
-    new MetricsMessage({
-      uuid: generateUuid(),
-      timestamp: new Date(),
-      name: USER_LOGGED_IN,
-      attributes: {...commonMetricAttributes, countryPrefix},
-    })
-  )
 
 export const reportTotalNumberOfUsers = (
   dataToReport: ReadonlyArray<{

--- a/apps/user-service/src/routes/login/handlers/verifyChallengeHandler.ts
+++ b/apps/user-service/src/routes/login/handlers/verifyChallengeHandler.ts
@@ -16,10 +16,8 @@ import {UserApiSpecification} from '@vexl-next/rest-api/src/services/user/specif
 import {DashboardReportsService} from '@vexl-next/server-utils/src/DashboardReportsService'
 import {generateUserAuthData} from '@vexl-next/server-utils/src/generateUserAuthData'
 import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect'
-import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {Effect} from 'effect'
 import {LoggedInUsersDbService} from '../../../db/loggedInUsersDb'
-import {reportUserLoggedIn} from '../../../metrics'
 import {VerificationStateDbService} from '../db/verificationStateDb'
 
 const insertUserIntoDb = (
@@ -87,13 +85,6 @@ export const verifyChallengeHandler = HttpApiBuilder.handler(
       )
       yield* _(
         loginDb.deleteChallengeVerificationState(req.payload.userPublicKey)
-      )
-
-      yield* _(
-        reportUserLoggedIn(
-          verificationState.countryPrefix,
-          commonMetricAttributesFromHeaders(req.headers)
-        )
       )
 
       return new VerifyChallengeResponse({

--- a/docs/backend_stats.md
+++ b/docs/backend_stats.md
@@ -38,6 +38,7 @@ These are referred to as *common* in the tables below.
 | `COUNT_OF_UNIQUE_USERS` | Total | — | Gauge, every 60 s; users that have imported at least one contact. |
 | `COUNT_OF_UNIQUE_CONTACTS` | Total | — | Gauge, every 60 s; distinct imported contacts. |
 | `COUNT_OF_INACTIVE_USERS` | Total | — | Reported by the user-inactivity notification job; users whose `refreshed_at` is older than the inactivity threshold (or null). |
+| `COUNT_OF_ACTIVE_USERS` | Total | — | Daily scheduled task (`REPORT_ACTIVE_USERS_CRON`, default 00:30 UTC); users refreshed within the active window (`ACTIVE_USER_WINDOW_DAYS`, default 30 days). |
 | `COUNT_OF_CONNECTIONS` | Total | — | Gauge, every 60 s; total user⇄contact connections. |
 | `USER_JOINED_CLUB_AND_IMPORTED_CONTACTS` | Increment | common + `clubUUid`, `contactsImported` | User joins a club (attribute says whether they imported contacts). |
 | `CLUB_REPORTED` | Increment | common | Club member reports a club. |

--- a/docs/backend_stats.md
+++ b/docs/backend_stats.md
@@ -25,7 +25,6 @@ These are referred to as *common* in the tables below.
 
 | Metric | Type | Attributes | Reported when |
 | --- | --- | --- | --- |
-| `USER_LOGGED_IN` | Increment | common + `countryPrefix` (of the verified number) | User completes phone number verification (login). |
 | `NUMBER_OF_USERS_BY_COUNTRY` | Total | `countryPrefix` (`none` if unknown) | Gauge, every 60 s; count of rows in `users` per country. |
 | `NUMBER_OF_USERS` | Total | — | Gauge, every 60 s; total count of users across all countries. |
 
@@ -33,6 +32,7 @@ These are referred to as *common* in the tables below.
 
 | Metric | Type | Attributes | Reported when |
 | --- | --- | --- | --- |
+| `USER_LOGGED_IN` | Increment | common + `countryPrefix`, `numberExists` | User registers with the contact service right after login. `numberExists` is true when a user with the same phone number already existed (login from a new device / re-login without account deletion). |
 | `USER_REFRESH` | Increment | common | User refresh endpoint is called (app foregrounded / periodic refresh). |
 | `USER_REACTIVATED` | Increment | common | An inactive user (per the contact active-window threshold) comes back — their refresh transitions them from inactive to active. |
 | `COUNT_OF_UNIQUE_USERS` | Total | — | Gauge, every 60 s; users that have imported at least one contact. |

--- a/docs/backend_stats.md
+++ b/docs/backend_stats.md
@@ -34,6 +34,7 @@ These are referred to as *common* in the tables below.
 | Metric | Type | Attributes | Reported when |
 | --- | --- | --- | --- |
 | `USER_REFRESH` | Increment | common | User refresh endpoint is called (app foregrounded / periodic refresh). |
+| `USER_REACTIVATED` | Increment | common | An inactive user (per the contact active-window threshold) comes back — their refresh transitions them from inactive to active. |
 | `COUNT_OF_UNIQUE_USERS` | Total | — | Gauge, every 60 s; users that have imported at least one contact. |
 | `COUNT_OF_UNIQUE_CONTACTS` | Total | — | Gauge, every 60 s; distinct imported contacts. |
 | `COUNT_OF_INACTIVE_USERS` | Total | — | Reported by the user-inactivity notification job; users whose `refreshed_at` is older than the inactivity threshold (or null). |

--- a/docs/backend_stats.md
+++ b/docs/backend_stats.md
@@ -35,7 +35,8 @@ These are referred to as *common* in the tables below.
 | --- | --- | --- | --- |
 | `USER_REFRESH` | Increment | common | User refresh endpoint is called (app foregrounded / periodic refresh). |
 | `COUNT_OF_UNIQUE_USERS` | Total | — | Gauge, every 60 s; users that have imported at least one contact. |
-| `COUNT_OF_UNIQUE_CONTACTS` | Total | — | Gauge, every 60 s; distinct imported contacts. ⚠️ Also (mis)used by the inactivity notification job to report the number of inactive users under this same name. |
+| `COUNT_OF_UNIQUE_CONTACTS` | Total | — | Gauge, every 60 s; distinct imported contacts. |
+| `COUNT_OF_INACTIVE_USERS` | Total | — | Reported by the user-inactivity notification job; users whose `refreshed_at` is older than the inactivity threshold (or null). |
 | `COUNT_OF_CONNECTIONS` | Total | — | Gauge, every 60 s; total user⇄contact connections. |
 | `USER_JOINED_CLUB_AND_IMPORTED_CONTACTS` | Increment | common + `clubUUid`, `contactsImported` | User joins a club (attribute says whether they imported contacts). |
 | `CLUB_REPORTED` | Increment | common | Club member reports a club. |

--- a/docs/backend_stats.md
+++ b/docs/backend_stats.md
@@ -39,6 +39,7 @@ These are referred to as *common* in the tables below.
 | `COUNT_OF_UNIQUE_CONTACTS` | Total | — | Gauge, every 60 s; distinct imported contacts. |
 | `COUNT_OF_INACTIVE_USERS` | Total | — | Reported by the user-inactivity notification job; users whose `refreshed_at` is older than the inactivity threshold (or null). |
 | `COUNT_OF_ACTIVE_USERS` | Total | — | Daily scheduled task (`REPORT_ACTIVE_USERS_CRON`, default 00:30 UTC); users refreshed within the active window (`ACTIVE_USER_WINDOW_DAYS`, default 30 days). |
+| `COUNT_OF_ACTIVE_USERS_BY_COUNTRY` | Total | `countryPrefix` (`none` if unknown) | Reported alongside `COUNT_OF_ACTIVE_USERS`; active users grouped by their phone country prefix. Rows from one report share a timestamp, and countries with no active users are omitted. |
 | `COUNT_OF_CONNECTIONS` | Total | — | Gauge, every 60 s; total user⇄contact connections. |
 | `USER_JOINED_CLUB_AND_IMPORTED_CONTACTS` | Increment | common + `clubUUid`, `contactsImported` | User joins a club (attribute says whether they imported contacts). |
 | `CLUB_REPORTED` | Increment | common | Club member reports a club. |

--- a/docs/backend_stats.md
+++ b/docs/backend_stats.md
@@ -48,7 +48,7 @@ These are referred to as *common* in the tables below.
 
 | Metric | Type | Attributes | Reported when |
 | --- | --- | --- | --- |
-| `OFFER_CREATED` | Increment | common + `countryPrefix` (the offer's country) | New offer is created. |
+| `OFFER_CREATED` | Increment | common + `countryPrefix` (the offer's country), `offerType` (`BUY`/`SELL`) | New offer is created. |
 | `OFFER_MODIFIED` | Increment | common | Offer is updated. |
 | `OFFER_REPORTED` | Increment | common + `offerId` | Offer is reported — both the contact-network and the club report endpoints report under this name. |
 | `OFFER_PUBLIC_PART_DELETED` | Increment | common | Offer is deleted. |

--- a/docs/backend_stats.md
+++ b/docs/backend_stats.md
@@ -69,7 +69,7 @@ These are referred to as *common* in the tables below.
 | `REQUEST_APPROVED` | Increment | common | Messaging request is approved. |
 | `REQUEST_REJECTED` | Increment (value 0) | common | Messaging request is disapproved. ⚠️ Reported with value 0, so it records the event but never increments. |
 | `CHAT_CLOSED` | Increment | common | User leaves a chat. |
-| `MESSAGE_FETCHED_AND_REMOVED` | Increment (value = count) | common | Client confirms pulled messages, which deletes them from the inbox. |
+| `MESSAGE_FETCHED_AND_REMOVED` | Increment (value = count) | common + `messageAgeSeconds` | Client confirms pulled messages, which deletes them from the inbox. `messageAgeSeconds` is the average age of the removed messages (seconds since the server accepted them); `unknown` for legacy rows without a received timestamp. |
 | `MESSAGE_EXPIRED` | Increment (value = count) | — | Expired-messages cleanup task deletes old undelivered messages. |
 | `TOTAL_INBOXES` | Total | — | Gauge, every 60 s; total inboxes. |
 | `TOTAL_INBOXES_WITH_UNREAD_MESSAGES` | Total | — | Gauge, every 60 s; inboxes that have undelivered messages waiting. |

--- a/packages/rest-api/src/services/user/index.ts
+++ b/packages/rest-api/src/services/user/index.ts
@@ -100,7 +100,7 @@ export function api({
       verifyPhoneNumber: (body: VerifyPhoneNumberRequest) =>
         client.Login.verifyCode({payload: body}),
       verifyChallenge: (body: VerifyChallengeRequest) =>
-        client.Login.verifyChallenge({payload: body, headers: commonHeaders}),
+        client.Login.verifyChallenge({payload: body}),
       deleteUser: () =>
         withSecurityHeaders((headers) => client.logoutUser({headers})),
       getVersionServiceInfo: () =>

--- a/packages/rest-api/src/services/user/specification.ts
+++ b/packages/rest-api/src/services/user/specification.ts
@@ -79,7 +79,6 @@ export const VerifyChallengeEndpoint = HttpApiEndpoint.post(
   'verifyChallenge',
   '/api/v1/user/confirmation/challenge'
 )
-  .setHeaders(CommonHeaders)
   .setPayload(VerifyChallengeRequest)
   .addSuccess(VerifyChallengeResponse)
   .addError(InvalidSignatureError, {status: 400})


### PR DESCRIPTION
## Summary

Rolling PR for metrics improvements.

**Fix: inactive-user count was never reported.** `queryAndReportNumberOfInnactiveUsers` built the query effect but *returned* it from `Effect.gen` instead of yielding it, so the inactivity job logged "Reporting number of inactive users" without ever running the query. On top of that, the code piped the count into `reportCountOfUniqueContacts`, so had it run, it would have polluted the `COUNT_OF_UNIQUE_CONTACTS` gauge. Now the effect actually executes and reports under a dedicated `COUNT_OF_INACTIVE_USERS` metric (type Total). Reporting failures are logged and ignored so they can't fail the notification job. (Also fixes the "Innactive" typo in the function name.)

**New: `USER_REACTIVATED` metric.** Increment, emitted with the common client attributes when a user's refresh transitions them from inactive (per the contact active-window threshold) back to active — the same condition that triggers re-notifying their contacts.

**New: `messageAgeSeconds` attribute on `MESSAGE_FETCHED_AND_REMOVED`.** Average age of the removed messages, in seconds since the server accepted them (`received_by_server_at`); `unknown` for legacy rows that predate the column. Also fixes a pre-existing bug found along the way: the delete query's `WITH deleted AS (DELETE ...) SELECT count(*)` never referenced the CTE, so the metric's value was **always 1** regardless of how many messages were removed — the DELETE now uses `RETURNING` and reports the real count.

**Moved: `USER_LOGGED_IN` from user-service to contact-service.** Now reported when the user registers with the contact service right after login — the point where the phone hash is persisted. Keeps the common attributes and `countryPrefix`, and gains a `numberExists` attribute: true when a user with the same number already existed (login from a new device / re-login without account deletion), false for a brand-new number. user-service no longer reports it and the `CommonHeaders` declaration on `verifyChallenge` (only added for the metric) is reverted.

**New: `offerType` attribute on `OFFER_CREATED`.** `BUY` or `SELL`, taken from the request payload (the server already stores offer type in plaintext for the offer gauges).

**New: daily `COUNT_OF_ACTIVE_USERS` metric.** A new scheduled task in contact-service reports the number of users refreshed within the active window (`ACTIVE_USER_WINDOW_DAYS` env var, default 30 days), on `REPORT_ACTIVE_USERS_CRON` (default 00:30 UTC — adjust to land 30 min after the offer deactivation run). Along the way this caught another latent bug: the inactive-users query interpolated the day count *inside* the quoted interval literal (`interval '$1 day'`), which fails at runtime with a parameter-count mismatch — both queries now use `interval '1 day' * n` and are covered by a db-backed test.

`docs/backend_stats.md` updated for all of the above.

## Validation

- `pnpm turbo:typecheck`, `pnpm turbo:format`, `pnpm turbo:lint`
- contact-service suite (144 tests), chat-service suite (71 tests), and user-service suite (36 tests) passing, including new assertions for `USER_REACTIVATED`, the real deleted count, numeric `messageAgeSeconds`, and `numberExists` on fresh vs. repeated login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added analytics for sign-ins, including country information and whether an existing account was replaced.
  - Added tracking for active users, inactive users, and reactivated users.
  - Enhanced deleted-message reporting with message counts and average message age.
  - Added offer-type details to offer creation analytics.
  - Added scheduled reporting for active-user metrics.

- **Documentation**
  - Updated backend metrics documentation.

- **Bug Fixes**
  - Corrected inactive-user reporting and removed inaccurate contact-count usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

