### PR TITLE
Add messageAgeSeconds to MESSAGE_FETCHED_AND_REMOVED (and fix its count)

### DIFF
--- a/apps/chat-service/src/__tests__/routes/deletePulledMessages.test.ts
+++ b/apps/chat-service/src/__tests__/routes/deletePulledMessages.test.ts
@@ -7,6 +7,7 @@ import {CommonHeaders} from '@vexl-next/rest-api/src/commonHeaders'
 import {type SendMessageRequest} from '@vexl-next/rest-api/src/services/chat/contracts'
 import {InboxDoesNotExistError} from '@vexl-next/rest-api/src/services/contact/contracts'
 import {expectErrorResponse} from '@vexl-next/server-utils/src/tests/expectErrorResponse'
+import {mockedReportMetric} from '@vexl-next/server-utils/src/tests/mockedMetricsClientService'
 import {
   clearTestAuthHeaders,
   setAuthHeaders,
@@ -98,11 +99,22 @@ describe('Delete pulled messages', () => {
           })
         )
 
+        mockedReportMetric.mockClear()
         yield* _(setAuthHeaders(user1.authHeaders))
         yield* _(
           client.Inboxes.deletePulledMessages({
             headers: commonHeaders,
             payload: yield* _(user1.addChallengeForMainInbox({})),
+          })
+        )
+
+        expect(mockedReportMetric).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'MESSAGE_FETCHED_AND_REMOVED',
+            value: messagesForUser1Before.messages.length,
+            attributes: expect.objectContaining({
+              messageAgeSeconds: expect.any(Number),
+            }),
           })
         )
 

--- a/apps/chat-service/src/db/MessagesDbService/index.ts
+++ b/apps/chat-service/src/db/MessagesDbService/index.ts
@@ -4,7 +4,10 @@ import {type InboxRecordId} from '../InboxDbService/domain'
 import {type MessageRecord, type MessageRecordId} from './domain'
 import {createDeleteAllMessagesByInboxId} from './query/createDeleteAllMessagesByInboxId'
 import {createDeleteExpiredMessages} from './query/createDeleteExpiredMessages'
-import {createDeletePulledMessagesMessagesByInboxId} from './query/createDeletePulledMessagesByInboxId'
+import {
+  createDeletePulledMessagesMessagesByInboxId,
+  type DeletedPulledMessagesSummary,
+} from './query/createDeletePulledMessagesByInboxId'
 import {createFindMessagesByInboxId} from './query/createFindMessagesByInboxId'
 import {
   createInsertMessageForInbox,
@@ -19,7 +22,7 @@ export interface MessagesDbOperations {
 
   deletePulledMessagesByInboxId: (
     args: InboxRecordId
-  ) => Effect.Effect<number, UnexpectedServerError>
+  ) => Effect.Effect<DeletedPulledMessagesSummary, UnexpectedServerError>
 
   deleteExpiredMessages: () => Effect.Effect<number, UnexpectedServerError>
 

--- a/apps/chat-service/src/db/MessagesDbService/query/createDeletePulledMessagesByInboxId.ts
+++ b/apps/chat-service/src/db/MessagesDbService/query/createDeletePulledMessagesByInboxId.ts
@@ -4,12 +4,20 @@ import {UnexpectedServerError} from '@vexl-next/domain/src/general/commonErrors'
 import {Effect, flow, Option, Schema} from 'effect'
 import {InboxRecordId} from '../../InboxDbService/domain'
 
+export interface DeletedPulledMessagesSummary {
+  count: number
+  avgMessageAgeSeconds: Option.Option<number>
+}
+
 export const createDeletePulledMessagesMessagesByInboxId = Effect.gen(
   function* (_) {
     const sql = yield* _(PgClient.PgClient)
 
     const query = SqlSchema.findOne({
-      Result: Schema.Struct({count: Schema.NumberFromString}),
+      Result: Schema.Struct({
+        count: Schema.NumberFromString,
+        avgAgeSeconds: Schema.NullOr(Schema.Number),
+      }),
       Request: InboxRecordId,
       execute: (params) => sql`
         WITH
@@ -18,9 +26,22 @@ export const createDeletePulledMessagesMessagesByInboxId = Effect.gen(
             WHERE
               inbox_id = ${params}
               AND pulled = TRUE
+            RETURNING
+              received_by_server_at
           )
         SELECT
-          count(*) AS COUNT
+          count(*) AS COUNT,
+          round(
+            avg(
+              EXTRACT(
+                EPOCH
+                FROM
+                  now() - received_by_server_at
+              )
+            )
+          )::int AS "avgAgeSeconds"
+        FROM
+          deleted
       `,
     })
 
@@ -28,8 +49,18 @@ export const createDeletePulledMessagesMessagesByInboxId = Effect.gen(
       query,
       Effect.map(
         flow(
-          Option.map((r) => r.count),
-          Option.getOrElse(() => 0)
+          Option.map(
+            (r): DeletedPulledMessagesSummary => ({
+              count: r.count,
+              avgMessageAgeSeconds: Option.fromNullable(r.avgAgeSeconds),
+            })
+          ),
+          Option.getOrElse(
+            (): DeletedPulledMessagesSummary => ({
+              count: 0,
+              avgMessageAgeSeconds: Option.none(),
+            })
+          )
         )
       ),
       Effect.catchAll((e) =>

--- a/apps/chat-service/src/metrics.ts
+++ b/apps/chat-service/src/metrics.ts
@@ -107,7 +107,8 @@ export const reportMessageSent = (
 
 export const reportMessageFetchedAndRemoved = (
   number: number,
-  attributes: CommonMetricAttributes
+  messageAgeSeconds: number | 'unknown',
+  commonMetricAttributes: CommonMetricAttributes
 ): Effect.Effect<void, never, MetricsClientService> =>
   reportMetricForked(
     new MetricsMessage({
@@ -115,7 +116,7 @@ export const reportMessageFetchedAndRemoved = (
       uuid: generateUuid(),
       timestamp: new Date(),
       name: MESSAGE_FETCHED_AND_REMOVED,
-      attributes,
+      attributes: {...commonMetricAttributes, messageAgeSeconds},
     })
   )
 

--- a/apps/chat-service/src/routes/inbox/deletePulledMessages.ts
+++ b/apps/chat-service/src/routes/inbox/deletePulledMessages.ts
@@ -5,7 +5,7 @@ import {makeEndpointEffect} from '@vexl-next/server-utils/src/makeEndpointEffect
 import {commonMetricAttributesFromHeaders} from '@vexl-next/server-utils/src/metrics/commonMetricAttributesFromHeaders'
 import {validateChallengeInBody} from '@vexl-next/server-utils/src/services/challenge/utils/validateChallengeInBody'
 import {withDbTransaction} from '@vexl-next/server-utils/src/withDbTransaction'
-import {Effect} from 'effect'
+import {Effect, Option} from 'effect'
 import {InboxDbService} from '../../db/InboxDbService'
 import {MessagesDbService} from '../../db/MessagesDbService'
 import {hashPublicKey} from '../../db/domain'
@@ -35,9 +35,13 @@ export const deletePulledMessages = HttpApiBuilder.handler(
       const messagesService = yield* _(MessagesDbService)
       yield* _(
         messagesService.deletePulledMessagesByInboxId(inboxRecord.id),
-        Effect.tap((count) =>
+        Effect.tap(({count, avgMessageAgeSeconds}) =>
           reportMessageFetchedAndRemoved(
             count,
+            Option.getOrElse(
+              avgMessageAgeSeconds,
+              (): number | 'unknown' => 'unknown'
+            ),
             commonMetricAttributesFromHeaders(req.headers)
           )
         )

--- a/docs/backend_stats.md
+++ b/docs/backend_stats.md
@@ -67,7 +67,7 @@ These are referred to as *common* in the tables below.
 | `REQUEST_APPROVED` | Increment | common | Messaging request is approved. |
 | `REQUEST_REJECTED` | Increment (value 0) | common | Messaging request is disapproved. ⚠️ Reported with value 0, so it records the event but never increments. |
 | `CHAT_CLOSED` | Increment | common | User leaves a chat. |
-| `MESSAGE_FETCHED_AND_REMOVED` | Increment (value = count) | common | Client confirms pulled messages, which deletes them from the inbox. |
+| `MESSAGE_FETCHED_AND_REMOVED` | Increment (value = count) | common + `messageAgeSeconds` | Client confirms pulled messages, which deletes them from the inbox. `messageAgeSeconds` is the average age of the removed messages (seconds since the server accepted them); `unknown` for legacy rows without a received timestamp. |
 | `MESSAGE_EXPIRED` | Increment (value = count) | — | Expired-messages cleanup task deletes old undelivered messages. |
 | `TOTAL_INBOXES` | Total | — | Gauge, every 60 s; total inboxes. |
 | `TOTAL_INBOXES_WITH_UNREAD_MESSAGES` | Total | — | Gauge, every 60 s; inboxes that have undelivered messages waiting. |


### PR DESCRIPTION
## Summary

- `MESSAGE_FETCHED_AND_REMOVED` now carries a `messageAgeSeconds` attribute: the average age of the removed messages, in seconds since the server accepted them (`received_by_server_at`, which defaults to `clock_timestamp()` on insert). Falls back to `unknown` for legacy rows that predate the column.
- Fixes a pre-existing bug found while implementing this: the delete query's `WITH deleted AS (DELETE ...) SELECT count(*)` never referenced the CTE, so `count(*)` had no FROM clause and **always returned 1** — the metric's value never reflected the real number of removed messages. The DELETE now uses `RETURNING` and both the count and the average age are computed from the actual deleted rows.
- `docs/backend_stats.md` updated.

## Validation

- `pnpm turbo:typecheck`, `pnpm turbo:format`, `pnpm turbo:lint`
- chat-service test suite (71 tests) passing, including new assertions that the metric reports the real deleted count and a numeric `messageAgeSeconds`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved reporting when pulled messages are deleted, including the number removed and their average age.
  * Records message age when available, or marks it as unknown for older records.

* **Documentation**
  * Updated metric documentation to describe the removal count and message-age information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->