### PR TITLE
Enqueue inactivity notifications concurrently

### DIFF
--- a/apps/contact-service/src/services/UserNotificationService.ts
+++ b/apps/contact-service/src/services/UserNotificationService.ts
@@ -423,7 +423,7 @@ export class UserNotificationService extends Context.Tag(
                   )
                 )
               ),
-              Effect.all,
+              Effect.allWith({concurrency: 'unbounded'}),
               Effect.withSpan(
                 'Enqueue inactivity notifications via VexlNotificationToken',
                 {


### PR DESCRIPTION
The inactivity-notification enqueue loop in `notifyUsersAboutInactivity` ran `Effect.all` with the default sequential concurrency, so each MQ entry was enqueued one round-trip at a time. The first run after deploying the new inactivity cadence can select every long-inactive user at once, which would serialize thousands of enqueues for no reason.

Switch to `Effect.allWith({concurrency: 'unbounded'})`, matching the `NewUserNotificationMqEntry` enqueue loop earlier in the same file. Per-entry failures are already caught and logged individually, so concurrent execution doesn't change error behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Inactivity notifications are now processed concurrently, helping them be queued more quickly when many notifications need to be sent.
  - Existing individual notification error handling remains unchanged, so one failed notification does not prevent others from being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->