### PR TITLE
Add SENTRY_ENVIRONMENT override for the Sentry environment label

### DIFF
--- a/apps/backoffice-app/instrumentation.ts
+++ b/apps/backoffice-app/instrumentation.ts
@@ -7,7 +7,7 @@ export async function register() {
   if (process.env.SENTRY_DSN) {
     Sentry.init({
       dsn: process.env.SENTRY_DSN,
-      environment: process.env.NODE_ENV,
+      environment: process.env.SENTRY_ENVIRONMENT ?? process.env.NODE_ENV,
       release: process.env.SERVICE_VERSION,
       sendDefaultPii: false,
       beforeBreadcrumb: () => null,

--- a/docs/backend_sentry.md
+++ b/docs/backend_sentry.md
@@ -46,7 +46,8 @@ not undermine that:
 | Env var | Meaning |
 | --- | --- |
 | `SENTRY_DSN` | Per-service Sentry project DSN. Unset = disabled. |
-| `NODE_ENV` | Used as the Sentry `environment`. |
+| `SENTRY_ENVIRONMENT` | Sentry `environment` label (`production`/`stage`). Set this in deployments — stage also runs with `NODE_ENV=production`, so the fallback cannot tell them apart. |
+| `NODE_ENV` | Fallback for the Sentry `environment` when `SENTRY_ENVIRONMENT` is unset. |
 | `SERVICE_VERSION` | Used as the Sentry `release` (git sha in CI builds). |
 | `GRAFANA_URL` | Optional base url of Grafana (`https://grafana.vexl.it`). When set, events include a `grafanaTraceUrl` link to the trace. |
 

--- a/packages/server-utils/src/commonConfigs.ts
+++ b/packages/server-utils/src/commonConfigs.ts
@@ -126,6 +126,15 @@ export const otlpTraceExporterUrlConfig = Config.option(
 export const sentryDsnConfig = Config.option(Config.redacted('SENTRY_DSN'))
 
 /**
+ * Sentry environment label (production/stage/...). Falls back to NODE_ENV,
+ * which cannot distinguish stage from production because stage also runs with
+ * NODE_ENV=production.
+ */
+export const sentryEnvironmentConfig = Config.option(
+  Config.string('SENTRY_ENVIRONMENT')
+)
+
+/**
  * Base url of the Grafana instance (e.g. https://grafana.vexl.it). When set,
  * Sentry events include a link to the trace in Grafana Explore.
  */

--- a/packages/server-utils/src/sentry.ts
+++ b/packages/server-utils/src/sentry.ts
@@ -18,6 +18,7 @@ import {
   grafanaUrlConfig,
   nodeEnvConfig,
   sentryDsnConfig,
+  sentryEnvironmentConfig,
   serviceVersionConfig,
 } from './commonConfigs'
 
@@ -132,7 +133,15 @@ export const sentryLayer: Layer.Layer<never, ConfigError.ConfigError> =
         return Layer.empty
       }
 
-      const environment = yield* _(nodeEnvConfig)
+      const environment = yield* _(
+        sentryEnvironmentConfig,
+        Effect.flatMap(
+          Option.match({
+            onNone: () => nodeEnvConfig,
+            onSome: Effect.succeed,
+          })
+        )
+      )
       const release = yield* _(serviceVersionConfig)
       const grafanaUrl = yield* _(grafanaUrlConfig)
 


### PR DESCRIPTION
Follow-up to #2662. Stage deployments run with `NODE_ENV=production`, so the `NODE_ENV`-based fallback labels stage events as `production` in Sentry. This adds an optional `SENTRY_ENVIRONMENT` env var (Effect services + backoffice-app) that takes precedence over `NODE_ENV`; deployment manifests in the infra repo set it to `stage`/`production` explicitly. Docs table updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the Sentry environment independently through `SENTRY_ENVIRONMENT`.
  * Sentry now falls back to `NODE_ENV` when no dedicated environment is configured.

* **Documentation**
  * Updated Sentry configuration guidance to describe the preferred environment setting and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->