### PR TITLE
Sentry test-error endpoint and CI release creation

### DIFF
--- a/.github/workflows/build-backend-stack.yaml
+++ b/.github/workflows/build-backend-stack.yaml
@@ -113,9 +113,10 @@ jobs:
       - backoffice-app
       - dashboard-app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Create Sentry release for all backend projects
         env:
@@ -129,8 +130,8 @@ jobs:
           PROJECTS="-p user-service -p contact-service -p offer-service -p chat-service -p notification-service -p content-service -p feedback-service -p location-service -p btc-exchange-rate-service -p metrics-service -p dashboard-app -p backoffice-app"
           VERSION="${{ github.sha }}"
           SENTRY_ENV="${{ inputs.env == 'prod' && 'production' || inputs.env }}"
-          npx --yes @sentry/cli@2 releases new $PROJECTS "$VERSION"
-          npx --yes @sentry/cli@2 releases set-commits --auto "$VERSION" \
+          npx --yes @sentry/cli@3.6.2 releases new $PROJECTS "$VERSION"
+          npx --yes @sentry/cli@3.6.2 releases set-commits --auto "$VERSION" \
             || echo "::warning::set-commits failed — check that the GitHub repo is linked in Sentry (Settings -> Integrations -> GitHub)"
-          npx --yes @sentry/cli@2 releases finalize $PROJECTS "$VERSION"
-          npx --yes @sentry/cli@2 releases deploys "$VERSION" new -e "$SENTRY_ENV" || true
+          npx --yes @sentry/cli@3.6.2 releases finalize $PROJECTS "$VERSION"
+          npx --yes @sentry/cli@3.6.2 releases deploys "$VERSION" new -e "$SENTRY_ENV" || true

--- a/.github/workflows/build-backend-stack.yaml
+++ b/.github/workflows/build-backend-stack.yaml
@@ -96,3 +96,41 @@ jobs:
     secrets: inherit
     with:
       env: ${{ inputs.env }}
+
+  sentry-release:
+    runs-on: ubuntu-latest
+    needs:
+      - btc-exchange-rate-service
+      - user-service
+      - offer-service
+      - notification-service
+      - metrics-service
+      - location-service
+      - chat-service
+      - feedback-service
+      - content-service
+      - contact-service
+      - backoffice-app
+      - dashboard-app
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create Sentry release for all backend projects
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: vexl
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ]; then
+            echo "::warning::SENTRY_AUTH_TOKEN secret is not set — skipping Sentry release creation; events will still carry the release sha, but without commit metadata."
+            exit 0
+          fi
+          PROJECTS="-p user-service -p contact-service -p offer-service -p chat-service -p notification-service -p content-service -p feedback-service -p location-service -p btc-exchange-rate-service -p metrics-service -p dashboard-app -p backoffice-app"
+          VERSION="${{ github.sha }}"
+          SENTRY_ENV="${{ inputs.env == 'prod' && 'production' || inputs.env }}"
+          npx --yes @sentry/cli@2 releases new $PROJECTS "$VERSION"
+          npx --yes @sentry/cli@2 releases set-commits --auto "$VERSION" \
+            || echo "::warning::set-commits failed — check that the GitHub repo is linked in Sentry (Settings -> Integrations -> GitHub)"
+          npx --yes @sentry/cli@2 releases finalize $PROJECTS "$VERSION"
+          npx --yes @sentry/cli@2 releases deploys "$VERSION" new -e "$SENTRY_ENV" || true

--- a/.github/workflows/build-backend-stack.yaml
+++ b/.github/workflows/build-backend-stack.yaml
@@ -118,6 +118,19 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24.x
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      # Install only the root workspace deps so sentry-cli resolves through the
+      # reviewed lockfile instead of being fetched ad-hoc by npx.
+      - name: Install sentry-cli
+        run: pnpm install --frozen-lockfile --filter vexl-next
+
       - name: Create Sentry release for all backend projects
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -130,8 +143,8 @@ jobs:
           PROJECTS="-p user-service -p contact-service -p offer-service -p chat-service -p notification-service -p content-service -p feedback-service -p location-service -p btc-exchange-rate-service -p metrics-service -p dashboard-app -p backoffice-app"
           VERSION="${{ github.sha }}"
           SENTRY_ENV="${{ inputs.env == 'prod' && 'production' || inputs.env }}"
-          npx --yes @sentry/cli@3.6.2 releases new $PROJECTS "$VERSION"
-          npx --yes @sentry/cli@3.6.2 releases set-commits --auto "$VERSION" \
+          pnpm exec sentry-cli releases new $PROJECTS "$VERSION"
+          pnpm exec sentry-cli releases set-commits --auto "$VERSION" \
             || echo "::warning::set-commits failed — check that the GitHub repo is linked in Sentry (Settings -> Integrations -> GitHub)"
-          npx --yes @sentry/cli@3.6.2 releases finalize $PROJECTS "$VERSION"
-          npx --yes @sentry/cli@3.6.2 releases deploys "$VERSION" new -e "$SENTRY_ENV" || true
+          pnpm exec sentry-cli releases finalize $PROJECTS "$VERSION"
+          pnpm exec sentry-cli releases deploys "$VERSION" new -e "$SENTRY_ENV" || true

--- a/apps/btc-exchange-rate-service/src/httpServer.ts
+++ b/apps/btc-exchange-rate-service/src/httpServer.ts
@@ -11,9 +11,10 @@ import {NodeHttpServerLiveWithPortFromEnv} from '@vexl-next/server-utils/src/Nod
 import {RateLimitingService} from '@vexl-next/server-utils/src/RateLimiting'
 import {rateLimitingMiddlewareLayer} from '@vexl-next/server-utils/src/RateLimiting/rateLimitngMiddlewareLayer'
 import {RedisConnectionService} from '@vexl-next/server-utils/src/RedisConnection'
+import {sentryTestErrorMiddleware} from '@vexl-next/server-utils/src/sentryTestErrorMiddleware'
 import {ServerCrypto} from '@vexl-next/server-utils/src/ServerCrypto'
 import {ServerSecurityMiddlewareLive} from '@vexl-next/server-utils/src/serverSecurity'
-import {Layer} from 'effect'
+import {flow, Layer} from 'effect'
 import {cryptoConfig, healthServerPortConfig} from './configs'
 import {getExchangeRateHandler} from './handlers'
 import {YadioService} from './utils/yadio'
@@ -30,7 +31,9 @@ export const ApiLive = HttpApiBuilder.api(BtcExchangeRateApiSpecification).pipe(
   Layer.provide(ServerSecurityMiddlewareLive)
 )
 
-const ApiServerLive = HttpApiBuilder.serve(HttpMiddleware.logger).pipe(
+const ApiServerLive = HttpApiBuilder.serve(
+  flow(HttpMiddleware.logger, sentryTestErrorMiddleware)
+).pipe(
   Layer.provide(HttpApiSwagger.layer()),
   Layer.provide(ApiLive),
   HttpServer.withLogAddress,

--- a/apps/chat-service/src/httpServer.ts
+++ b/apps/chat-service/src/httpServer.ts
@@ -8,6 +8,7 @@ import {ChatApiSpecification} from '@vexl-next/rest-api/src/services/chat/specif
 import {healthServerLayer} from '@vexl-next/server-utils/src/HealthServer'
 import {NodeHttpServerLiveWithPortFromEnv} from '@vexl-next/server-utils/src/NodeHttpServerLiveWithPortFromEnv'
 import {rateLimitingMiddlewareLayer} from '@vexl-next/server-utils/src/RateLimiting/rateLimitngMiddlewareLayer'
+import {sentryTestErrorMiddleware} from '@vexl-next/server-utils/src/sentryTestErrorMiddleware'
 
 import {RateLimitingService} from '@vexl-next/server-utils/src/RateLimiting'
 import {RedisConnectionService} from '@vexl-next/server-utils/src/RedisConnection'
@@ -17,7 +18,7 @@ import {MetricsClientService} from '@vexl-next/server-utils/src/metrics/MetricsC
 import {ServerSecurityMiddlewareLive} from '@vexl-next/server-utils/src/serverSecurity'
 import {createChallenge} from '@vexl-next/server-utils/src/services/challenge/routes/createChalenge'
 import {createChallenges} from '@vexl-next/server-utils/src/services/challenge/routes/createChallenges'
-import {Layer} from 'effect'
+import {flow, Layer} from 'effect'
 import {cryptoConfig, healthServerPortConfig, redisUrl} from './configs'
 import {InboxDbService} from './db/InboxDbService'
 import {MessagesDbService} from './db/MessagesDbService'
@@ -88,7 +89,9 @@ export const ChatApiLive = HttpApiBuilder.api(ChatApiSpecification).pipe(
   Layer.provide(ServerSecurityMiddlewareLive)
 )
 
-export const ApiServerLive = HttpApiBuilder.serve(HttpMiddleware.logger).pipe(
+export const ApiServerLive = HttpApiBuilder.serve(
+  flow(HttpMiddleware.logger, sentryTestErrorMiddleware)
+).pipe(
   Layer.provide(HttpApiSwagger.layer()),
   Layer.provide(ChatApiLive),
   HttpServer.withLogAddress,

--- a/apps/contact-service/src/httpServer.ts
+++ b/apps/contact-service/src/httpServer.ts
@@ -11,6 +11,7 @@ import {NodeHttpServerLiveWithPortFromEnv} from '@vexl-next/server-utils/src/Nod
 import {RateLimitingService} from '@vexl-next/server-utils/src/RateLimiting'
 import {rateLimitingMiddlewareLayer} from '@vexl-next/server-utils/src/RateLimiting/rateLimitngMiddlewareLayer'
 import {RedisConnectionService} from '@vexl-next/server-utils/src/RedisConnection'
+import {sentryTestErrorMiddleware} from '@vexl-next/server-utils/src/sentryTestErrorMiddleware'
 
 import {RedisService} from '@vexl-next/server-utils/src/RedisService'
 import {ServerCrypto} from '@vexl-next/server-utils/src/ServerCrypto'
@@ -18,7 +19,7 @@ import {MetricsClientService} from '@vexl-next/server-utils/src/metrics/MetricsC
 import {ServerSecurityMiddlewareLive} from '@vexl-next/server-utils/src/serverSecurity'
 import {createChallenge} from '@vexl-next/server-utils/src/services/challenge/routes/createChalenge'
 import {createChallenges} from '@vexl-next/server-utils/src/services/challenge/routes/createChallenges'
-import {Config, Layer, Option} from 'effect'
+import {Config, flow, Layer, Option} from 'effect'
 import {CleanReportedClubRecordsWorkerLayer} from './cleanReportedClubRecordsWorker'
 import {
   cryptoConfig,
@@ -158,7 +159,9 @@ export const ContactApiLive = HttpApiBuilder.api(ContactApiSpecification).pipe(
   Layer.provide(ServerSecurityMiddlewareLive)
 )
 
-export const ApiServerLive = HttpApiBuilder.serve(HttpMiddleware.logger).pipe(
+export const ApiServerLive = HttpApiBuilder.serve(
+  flow(HttpMiddleware.logger, sentryTestErrorMiddleware)
+).pipe(
   Layer.provide(HttpApiSwagger.layer()),
   Layer.provide(ContactApiLive),
   HttpServer.withLogAddress,

--- a/apps/content-service/src/httpServer.ts
+++ b/apps/content-service/src/httpServer.ts
@@ -13,8 +13,9 @@ import {RateLimitingService} from '@vexl-next/server-utils/src/RateLimiting'
 import {rateLimitingMiddlewareLayer} from '@vexl-next/server-utils/src/RateLimiting/rateLimitngMiddlewareLayer'
 import {RedisConnectionService} from '@vexl-next/server-utils/src/RedisConnection'
 import {RedisService} from '@vexl-next/server-utils/src/RedisService'
+import {sentryTestErrorMiddleware} from '@vexl-next/server-utils/src/sentryTestErrorMiddleware'
 import {ServerCrypto} from '@vexl-next/server-utils/src/ServerCrypto'
-import {Layer} from 'effect'
+import {flow, Layer} from 'effect'
 import {cryptoConfig, healthServerPortConfig} from './configs'
 import DbLayer from './db/layer'
 import {VexlProductNotificationsDbService} from './db/VexlProductNotificationsDbService'
@@ -82,7 +83,9 @@ export const ContentApiLive = HttpApiBuilder.api(ContentApiSpecification).pipe(
   Layer.provide(rateLimitingMiddlewareLayer(ContentApiSpecification))
 )
 
-export const ApiServerLive = HttpApiBuilder.serve(HttpMiddleware.logger).pipe(
+export const ApiServerLive = HttpApiBuilder.serve(
+  flow(HttpMiddleware.logger, sentryTestErrorMiddleware)
+).pipe(
   Layer.provide(HttpApiSwagger.layer()),
   Layer.provide(ContentApiLive),
   HttpServer.withLogAddress,

--- a/apps/feedback-service/src/httpServer.ts
+++ b/apps/feedback-service/src/httpServer.ts
@@ -11,9 +11,10 @@ import {NodeHttpServerLiveWithPortFromEnv} from '@vexl-next/server-utils/src/Nod
 import {RateLimitingService} from '@vexl-next/server-utils/src/RateLimiting'
 import {rateLimitingMiddlewareLayer} from '@vexl-next/server-utils/src/RateLimiting/rateLimitngMiddlewareLayer'
 import {RedisConnectionService} from '@vexl-next/server-utils/src/RedisConnection'
+import {sentryTestErrorMiddleware} from '@vexl-next/server-utils/src/sentryTestErrorMiddleware'
 import {ServerCrypto} from '@vexl-next/server-utils/src/ServerCrypto'
 import {ServerSecurityMiddlewareLive} from '@vexl-next/server-utils/src/serverSecurity'
-import {Layer} from 'effect'
+import {flow, Layer} from 'effect'
 import {cryptoConfig, healthServerPortConfig} from './configs'
 import DbLayer from './db/layer'
 import {submitFeedbackHandler} from './routes/submitFeedback'
@@ -32,7 +33,9 @@ export const ApiLive = HttpApiBuilder.api(FeedbackApiSpecification).pipe(
   Layer.provide(rateLimitingMiddlewareLayer(FeedbackApiSpecification))
 )
 
-const ApiServerLive = HttpApiBuilder.serve(HttpMiddleware.logger).pipe(
+const ApiServerLive = HttpApiBuilder.serve(
+  flow(HttpMiddleware.logger, sentryTestErrorMiddleware)
+).pipe(
   Layer.provide(HttpApiSwagger.layer()),
   Layer.provide(ApiLive),
   HttpServer.withLogAddress,

--- a/apps/location-service/src/httpServer.ts
+++ b/apps/location-service/src/httpServer.ts
@@ -11,9 +11,10 @@ import {NodeHttpServerLiveWithPortFromEnv} from '@vexl-next/server-utils/src/Nod
 import {RateLimitingService} from '@vexl-next/server-utils/src/RateLimiting'
 import {rateLimitingMiddlewareLayer} from '@vexl-next/server-utils/src/RateLimiting/rateLimitngMiddlewareLayer'
 import {RedisConnectionService} from '@vexl-next/server-utils/src/RedisConnection'
+import {sentryTestErrorMiddleware} from '@vexl-next/server-utils/src/sentryTestErrorMiddleware'
 import {ServerCrypto} from '@vexl-next/server-utils/src/ServerCrypto'
 import {ServerSecurityMiddlewareLive} from '@vexl-next/server-utils/src/serverSecurity'
-import {Layer} from 'effect'
+import {flow, Layer} from 'effect'
 import {cryptoConfig, healthServerPortConfig} from './configs'
 import {
   getGeocodedCoordinatesHandler,
@@ -38,7 +39,9 @@ export const LocationApiLive = HttpApiBuilder.api(
   Layer.provide(ServerSecurityMiddlewareLive)
 )
 
-const ApiServerLive = HttpApiBuilder.serve(HttpMiddleware.logger).pipe(
+const ApiServerLive = HttpApiBuilder.serve(
+  flow(HttpMiddleware.logger, sentryTestErrorMiddleware)
+).pipe(
   Layer.provide(HttpApiSwagger.layer()),
   Layer.provide(LocationApiLive),
   HttpServer.withLogAddress,

--- a/apps/metrics-service/src/httpServer.ts
+++ b/apps/metrics-service/src/httpServer.ts
@@ -9,7 +9,8 @@ import {NodeHttpServerLiveWithPortFromEnv} from '@vexl-next/server-utils/src/Nod
 import {RateLimitingService} from '@vexl-next/server-utils/src/RateLimiting'
 import {rateLimitingMiddlewareLayer} from '@vexl-next/server-utils/src/RateLimiting/rateLimitngMiddlewareLayer'
 import {RedisService} from '@vexl-next/server-utils/src/RedisService'
-import {Layer} from 'effect/index'
+import {sentryTestErrorMiddleware} from '@vexl-next/server-utils/src/sentryTestErrorMiddleware'
+import {flow, Layer} from 'effect/index'
 import {reportNotificationInteraction} from './routes/reportNotificationInteraction'
 
 const RootApiGroupLive = HttpApiBuilder.group(
@@ -24,7 +25,9 @@ export const MetricsApiLive = HttpApiBuilder.api(MetricsApiSpecification).pipe(
   Layer.provide(rateLimitingMiddlewareLayer(MetricsApiSpecification))
 )
 
-export const ApiServerLive = HttpApiBuilder.serve(HttpMiddleware.logger).pipe(
+export const ApiServerLive = HttpApiBuilder.serve(
+  flow(HttpMiddleware.logger, sentryTestErrorMiddleware)
+).pipe(
   Layer.provide(HttpApiSwagger.layer()),
   Layer.provide(MetricsApiLive),
   Layer.provideMerge(RateLimitingService.Live),

--- a/apps/notification-service/src/httpServer.ts
+++ b/apps/notification-service/src/httpServer.ts
@@ -8,6 +8,7 @@ import {healthServerLayer} from '@vexl-next/server-utils/src/HealthServer'
 import {NodeHttpServerLiveWithPortFromEnv} from '@vexl-next/server-utils/src/NodeHttpServerLiveWithPortFromEnv'
 import {RateLimitingService} from '@vexl-next/server-utils/src/RateLimiting'
 import {rateLimitingMiddlewareLayer} from '@vexl-next/server-utils/src/RateLimiting/rateLimitngMiddlewareLayer'
+import {sentryTestErrorRouteLayer} from '@vexl-next/server-utils/src/sentryTestErrorMiddleware'
 
 import {RpcSerialization, RpcServer} from '@effect/rpc/index'
 import {Rpcs} from '@vexl-next/rest-api/src/services/notification/Rpcs'
@@ -97,6 +98,7 @@ const ApiServerLive = HttpLayerRouter.serve(
   Layer.mergeAll(
     NotificationHttpApiLive,
     RpcRouter,
+    sentryTestErrorRouteLayer,
     HttpApiSwagger.layerHttpLayerRouter({
       api: NotificationApiSpecification,
       path: '/docs',

--- a/apps/offer-service/src/httpServer.ts
+++ b/apps/offer-service/src/httpServer.ts
@@ -13,10 +13,11 @@ import {RedisConnectionService} from '@vexl-next/server-utils/src/RedisConnectio
 import {RedisService} from '@vexl-next/server-utils/src/RedisService'
 import {ServerCrypto} from '@vexl-next/server-utils/src/ServerCrypto'
 import {MetricsClientService} from '@vexl-next/server-utils/src/metrics/MetricsClientService'
+import {sentryTestErrorMiddleware} from '@vexl-next/server-utils/src/sentryTestErrorMiddleware'
 import {ServerSecurityMiddlewareLive} from '@vexl-next/server-utils/src/serverSecurity'
 import {createChallenge} from '@vexl-next/server-utils/src/services/challenge/routes/createChalenge'
 import {createChallenges} from '@vexl-next/server-utils/src/services/challenge/routes/createChallenges'
-import {Layer} from 'effect'
+import {flow, Layer} from 'effect'
 import {CleanupWorkersLayer} from './cleanupWorkers'
 import {cryptoConfig, healthServerPortConfig, redisUrl} from './configs'
 import {NoteDbService} from './db/NoteDbService'
@@ -105,7 +106,9 @@ export const OfferApiLive = HttpApiBuilder.api(OfferApiSpecification).pipe(
   Layer.provide(ServerSecurityMiddlewareLive)
 )
 
-export const ApiServerLive = HttpApiBuilder.serve(HttpMiddleware.logger).pipe(
+export const ApiServerLive = HttpApiBuilder.serve(
+  flow(HttpMiddleware.logger, sentryTestErrorMiddleware)
+).pipe(
   Layer.provide(HttpApiSwagger.layer()),
   Layer.provide(OfferApiLive),
   HttpServer.withLogAddress,

--- a/apps/user-service/src/httpServer.ts
+++ b/apps/user-service/src/httpServer.ts
@@ -11,8 +11,9 @@ import {RedisConnectionService} from '@vexl-next/server-utils/src/RedisConnectio
 import {RedisService} from '@vexl-next/server-utils/src/RedisService'
 import {ServerCrypto} from '@vexl-next/server-utils/src/ServerCrypto'
 import {MetricsClientService} from '@vexl-next/server-utils/src/metrics/MetricsClientService'
+import {sentryTestErrorMiddleware} from '@vexl-next/server-utils/src/sentryTestErrorMiddleware'
 import {ServerSecurityMiddlewareLive} from '@vexl-next/server-utils/src/serverSecurity'
-import {Config, Layer, Option} from 'effect'
+import {Config, flow, Layer, Option} from 'effect'
 import {
   cryptoConfig,
   dashboardNewUserHookConfig,
@@ -87,7 +88,9 @@ export const UserApiLive = HttpApiBuilder.api(UserApiSpecification).pipe(
   Layer.provide(ServerSecurityMiddlewareLive)
 )
 
-export const ApiServerLive = HttpApiBuilder.serve(HttpMiddleware.logger).pipe(
+export const ApiServerLive = HttpApiBuilder.serve(
+  flow(HttpMiddleware.logger, sentryTestErrorMiddleware)
+).pipe(
   Layer.provide(HttpApiSwagger.layer()),
   Layer.provide(UserApiLive),
   HttpServer.withLogAddress,

--- a/docs/backend_sentry.md
+++ b/docs/backend_sentry.md
@@ -55,3 +55,11 @@ There is one Sentry project per service. Production/stage DSNs are injected by
 the deployment manifests in the infrastructure repo. For local testing, set
 `SENTRY_DSN` in `.env.local` (see `example.env.local`); it is injected into all
 services, so everything lands in that one project.
+
+## Verifying delivery (TEMPORARY)
+
+Every service exposes `GET /sentry-test-error` on its main API port
+(`sentryTestErrorMiddleware` in server-utils), which logs a test error through
+the real logger-to-Sentry path and returns 500. The endpoint is public and
+unauthenticated — revert the commit that added it once Sentry delivery is
+verified in all environments.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "private": true,
   "dependencies": {
     "@manypkg/cli": "^0.21.0",
+    "@sentry/cli": "3.6.2",
     "@types/jest": "^29.4.0",
     "@types/node": "^22.10.5",
     "eslint": "^9.20.0",

--- a/packages/server-utils/src/sentryTestErrorMiddleware.ts
+++ b/packages/server-utils/src/sentryTestErrorMiddleware.ts
@@ -1,0 +1,41 @@
+import {
+  HttpLayerRouter,
+  HttpMiddleware,
+  HttpServerRequest,
+  HttpServerResponse,
+} from '@effect/platform'
+import {Effect, type Layer} from 'effect'
+
+// A fresh Error per request — Sentry skips exception objects it has already
+// captured, so a shared instance would report only the first request.
+const reportTestErrorAndRespond = Effect.suspend(() =>
+  Effect.zipRight(
+    Effect.logError(
+      'Sentry test error triggered',
+      new Error('Sentry test error')
+    ),
+    Effect.succeed(HttpServerResponse.text('error reported', {status: 500}))
+  )
+)
+
+/**
+ * TEMPORARY — remove (revert the commit that added it) once Sentry delivery is
+ * verified in all environments. Exposes GET /sentry-test-error on the main API
+ * port: logs a test error through the real logger-to-Sentry path and responds
+ * with 500. Note the endpoint is public and unauthenticated while it exists.
+ */
+export const sentryTestErrorMiddleware = HttpMiddleware.make((app) =>
+  Effect.gen(function* (_) {
+    const request = yield* _(HttpServerRequest.HttpServerRequest)
+    if (request.method === 'GET' && request.url === '/sentry-test-error')
+      return yield* _(reportTestErrorAndRespond)
+    return yield* _(app)
+  })
+)
+
+/** Same endpoint for HttpLayerRouter-based servers (notification-service). */
+export const sentryTestErrorRouteLayer: Layer.Layer<
+  never,
+  never,
+  HttpLayerRouter.HttpRouter
+> = HttpLayerRouter.add('GET', '/sentry-test-error', reportTestErrorAndRespond)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       '@manypkg/cli':
         specifier: ^0.21.0
         version: 0.21.4
+      '@sentry/cli':
+        specifier: 3.6.2
+        version: 3.6.2
       '@types/jest':
         specifier: ^29.4.0
         version: 29.5.14
@@ -4909,6 +4912,11 @@ packages:
     engines: {node: '>=10'}
     os: [darwin]
 
+  '@sentry/cli-darwin@3.6.2':
+    resolution: {integrity: sha512-/ZIMLblj6ncwguhOPw5YL9018iaD2RBhxhbHBxjaowy1vrmnzoCurGe4n5Vv7PaS21ldAHtHNqJwNqHJS4XHUw==}
+    engines: {node: '>=18'}
+    os: [darwin]
+
   '@sentry/cli-linux-arm64@2.58.4':
     resolution: {integrity: sha512-0g0KwsOozkLtzN8/0+oMZoOuQ0o7W6O+hx+ydVU1bktaMGKEJLMAWxOQNjsh1TcBbNIXVOKM/I8l0ROhaAb8Ig==}
     engines: {node: '>=10'}
@@ -4918,6 +4926,12 @@ packages:
   '@sentry/cli-linux-arm64@2.58.6':
     resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
     engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm64@3.6.2':
+    resolution: {integrity: sha512-KMHW+CIT5H046I1hIYJ6vZmwlbBELZDOTt9Bgue3kqpW5CuvviMeMuuIKXM2oKHr/l4Q1Xnj07oTbVNb1opTsg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux, freebsd, android]
 
@@ -4933,6 +4947,12 @@ packages:
     cpu: [arm]
     os: [linux, freebsd, android]
 
+  '@sentry/cli-linux-arm@3.6.2':
+    resolution: {integrity: sha512-b2M+1ujgf7jHig9r88T2l2HEkg0XR/1Tmo1LCiPg4dsPKtTMC2Rb/f0Mto83//zkVijAA2WDBhznOz9a9Ouo7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
   '@sentry/cli-linux-i686@2.58.4':
     resolution: {integrity: sha512-NseoIQAFtkziHyjZNPTu1Gm1opeQHt7Wm1LbLrGWVIRvUOzlslO9/8i6wETUZ6TjlQxBVRgd3Q0lRBG2A8rFYA==}
     engines: {node: '>=10'}
@@ -4942,6 +4962,12 @@ packages:
   '@sentry/cli-linux-i686@2.58.6':
     resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
     engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@3.6.2':
+    resolution: {integrity: sha512-tsLTOfJBoUkHfcCjUKxb/w1/WGLU00WJUO5zJztgLHKlebrjGAEiKM+8EPexb2hiW4F/P6UXL+4xXPKANk5JXQ==}
+    engines: {node: '>=18'}
     cpu: [x86, ia32]
     os: [linux, freebsd, android]
 
@@ -4957,6 +4983,12 @@ packages:
     cpu: [x64]
     os: [linux, freebsd, android]
 
+  '@sentry/cli-linux-x64@3.6.2':
+    resolution: {integrity: sha512-CHwfSJYkPe4w96EovIY/iWfxHnf5gvRYh0BGHCPcQ9knhrgWUJqbHqi3lNfEDZmzCxJ76RqPrnLMW6syoSqXow==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
   '@sentry/cli-win32-arm64@2.58.4':
     resolution: {integrity: sha512-bqYrF43+jXdDBh0f8HIJU3tbvlOFtGyRjHB8AoRuMQv9TEDUfENZyCelhdjA+KwDKYl48R1Yasb4EHNzsoO83w==}
     engines: {node: '>=10'}
@@ -4966,6 +4998,12 @@ packages:
   '@sentry/cli-win32-arm64@2.58.6':
     resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
     engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-arm64@3.6.2':
+    resolution: {integrity: sha512-lTqOPbLexkKnXmuIK8qszv+trpX8fQiZAJoeClVA1+hOerVyrLP9eU2tUqTm/8YW8G/M+mu3ZxAtDvS3OpHvZw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -4981,6 +5019,12 @@ packages:
     cpu: [x86, ia32]
     os: [win32]
 
+  '@sentry/cli-win32-i686@3.6.2':
+    resolution: {integrity: sha512-niUPoxN8p7jWrkvC0ekgpcIYEJNb5YxmuXRjUnOJrArwQs+4OPzRM+3e6JIYRXe7RDoUP63j1voYakEncuxioQ==}
+    engines: {node: '>=18'}
+    cpu: [x86, ia32]
+    os: [win32]
+
   '@sentry/cli-win32-x64@2.58.4':
     resolution: {integrity: sha512-cSzN4PjM1RsCZ4pxMjI0VI7yNCkxiJ5jmWncyiwHXGiXrV1eXYdQ3n1LhUYLZ91CafyprR0OhDcE+RVZ26Qb5w==}
     engines: {node: '>=10'}
@@ -4993,6 +5037,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sentry/cli-win32-x64@3.6.2':
+    resolution: {integrity: sha512-Xg6ieuJr/1Ewtdpm9Kudb029lJxnfs3Ae/fLZNAOnvWOie/V4V/X+tgZ+lETC3lU+7yz7Gb0f25gKnU6sPBKVg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@sentry/cli@2.58.4':
     resolution: {integrity: sha512-ArDrpuS8JtDYEvwGleVE+FgR+qHaOp77IgdGSacz6SZy6Lv90uX0Nu4UrHCQJz8/xwIcNxSqnN22lq0dH4IqTg==}
     engines: {node: '>= 10'}
@@ -5001,6 +5051,11 @@ packages:
   '@sentry/cli@2.58.6':
     resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
     engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/cli@3.6.2':
+    resolution: {integrity: sha512-/OcDsuz005C1tuauNhTd8/XNBHCfHiy46Wru4hAKBaziywgSA52lMSEznh6mWmHjPe/FoaDLpYt3Zd9qk3G0RA==}
+    engines: {node: '>= 18'}
     hasBin: true
 
   '@sentry/conventions@0.16.0':
@@ -6845,6 +6900,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
@@ -11105,6 +11161,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
+
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
@@ -14633,10 +14693,16 @@ snapshots:
   '@sentry/cli-darwin@2.58.6':
     optional: true
 
+  '@sentry/cli-darwin@3.6.2':
+    optional: true
+
   '@sentry/cli-linux-arm64@2.58.4':
     optional: true
 
   '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@3.6.2':
     optional: true
 
   '@sentry/cli-linux-arm@2.58.4':
@@ -14645,10 +14711,16 @@ snapshots:
   '@sentry/cli-linux-arm@2.58.6':
     optional: true
 
+  '@sentry/cli-linux-arm@3.6.2':
+    optional: true
+
   '@sentry/cli-linux-i686@2.58.4':
     optional: true
 
   '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@3.6.2':
     optional: true
 
   '@sentry/cli-linux-x64@2.58.4':
@@ -14657,10 +14729,16 @@ snapshots:
   '@sentry/cli-linux-x64@2.58.6':
     optional: true
 
+  '@sentry/cli-linux-x64@3.6.2':
+    optional: true
+
   '@sentry/cli-win32-arm64@2.58.4':
     optional: true
 
   '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@3.6.2':
     optional: true
 
   '@sentry/cli-win32-i686@2.58.4':
@@ -14669,10 +14747,16 @@ snapshots:
   '@sentry/cli-win32-i686@2.58.6':
     optional: true
 
+  '@sentry/cli-win32-i686@3.6.2':
+    optional: true
+
   '@sentry/cli-win32-x64@2.58.4':
     optional: true
 
   '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@3.6.2':
     optional: true
 
   '@sentry/cli@2.58.4':
@@ -14714,6 +14798,22 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@sentry/cli@3.6.2':
+    dependencies:
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      undici: 6.28.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 3.6.2
+      '@sentry/cli-linux-arm': 3.6.2
+      '@sentry/cli-linux-arm64': 3.6.2
+      '@sentry/cli-linux-i686': 3.6.2
+      '@sentry/cli-linux-x64': 3.6.2
+      '@sentry/cli-win32-arm64': 3.6.2
+      '@sentry/cli-win32-i686': 3.6.2
+      '@sentry/cli-win32-x64': 3.6.2
 
   '@sentry/conventions@0.16.0': {}
 
@@ -22429,6 +22529,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
+
+  undici@6.28.0: {}
 
   undici@7.28.0: {}
 


### PR DESCRIPTION
Follow-up to #2662/#2668. Two commits:

**1. Sentry releases in CI** (`a2f4b58fc`) — a `sentry-release` job at the end of the backend-stack build workflow creates one release (the git sha, matching what services report via `SERVICE_VERSION`) across all 12 backend projects, attaches commit metadata (`set-commits --auto`), finalizes it, and marks a deploy for the target environment. Reuses the existing `SENTRY_AUTH_TOKEN` secret; skips with a warning if unset, and warns (without failing the build) if the GitHub repo isn't linked in Sentry.

**2. TEMPORARY test endpoint** (`381fae22e` — **revert this commit once Sentry is verified**) — `GET /sentry-test-error` on every service's **main API port**: logs an error through the real logger→Sentry path and returns 500. Implemented as a shared `sentryTestErrorMiddleware` in server-utils, opted into by each of the 10 API servers (plus a route layer for notification-service's `HttpLayerRouter`). ⚠️ Public and unauthenticated while it exists — that's why it's isolated in one clean revertable commit.

Verified locally: `/sentry-test-error` → 500 with the error logged at ERROR level, other routes unaffected (200).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `/sentry-test-error` endpoint across backend services to generate a test error and return an HTTP 500 response.
  * Added automated Sentry release creation, commit association, finalization, and deployment for selected environments.

* **Documentation**
  * Documented how to verify error delivery through the new test endpoint, including cleanup guidance.

* **Chores**
  * Sentry release steps safely skip when authentication is unavailable and handle non-critical failures without blocking builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Review feedback addressed** (bot reviews): fresh `Error` per request in the test middleware (Sentry skips already-captured exception objects, so a shared instance would report only once per process), checkout pinned to the repo-standard SHA with `persist-credentials: false`, and sentry-cli pinned to exact `3.6.2` (latest; all four commands verified compatible). Not addressed by design: the endpoint stays on the public API port (explicit decision, single revertable commit), release-metadata failures stay non-blocking for builds, and the test route logs at error level because exercising that path is its purpose.
