### PR TITLE
Improve backend Sentry stack traces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,9 +74,10 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
 
 
 # --- Runner stage -----------------------------------------------------------
-# Slim runtime image: ships only the built dist/, the app's package.json
-# (needed for "type":"module" so Node treats dist/index.js as ESM) and the
-# production node_modules. No source, no tests, no devDependencies.
+# Slim runtime image: ships the built dist/, the app's package.json (needed
+# for "type":"module" so Node treats dist/index.js as ESM), the production
+# node_modules, and the pruned workspace TS sources (a few MB) so error
+# reporting can attach code snippets. No devDependencies.
 FROM node:24-slim as runner
 
 # ARGs do not cross build stages, so re-declare the ones this stage needs.
@@ -94,6 +95,13 @@ COPY --chown=node:node --from=prod-deps /app/node_modules /app/node_modules
 COPY --chown=node:node --from=prod-deps /app/package.json /app/package.json
 COPY --chown=node:node --from=builder /app/apps/${APP}/dist /app/apps/${APP}/dist
 COPY --chown=node:node --from=builder /app/apps/${APP}/package.json /app/apps/${APP}/package.json
+
+# Workspace sources referenced by the bundle's sourcemap: --enable-source-maps
+# rewrites stack frames to these paths and Sentry's contextLines integration
+# reads them from disk to attach code snippets to error events. Copied from the
+# pruner stage, which has no node_modules mixed into the package directories.
+COPY --chown=node:node --from=pruner /app/out/full/packages /app/packages
+COPY --chown=node:node --from=pruner /app/out/full/apps/${APP}/src /app/apps/${APP}/src
 
 WORKDIR /app/apps/${APP}
 

--- a/docs/backend_sentry.md
+++ b/docs/backend_sentry.md
@@ -21,6 +21,17 @@ All Effect backend services report errors to Sentry through shared code in
 - Events are grouped by error name + message + log message (not stack), because
   Effect tagged errors are constructed in shared helpers and stacks would
   collapse unrelated issues.
+- Stack traces: Effect errors only carry their construction site plus
+  fiber-runtime internals as a JS stack, so captured errors are passed through
+  `Cause.prettyErrors` first — it strips Effect-internal frames and appends the
+  enclosing Effect span stack as synthetic `at <spanName> (file:line)` frames.
+  The more `Effect.withSpan` / `Effect.fn` coverage around an operation, the
+  deeper its trace in Sentry.
+- Source maps need no Sentry upload: services run with
+  `node --enable-source-maps`, so frames already point at the original TS
+  files. The runtime image ships the pruned workspace sources (see
+  `Dockerfile`) so the SDK's `contextLines` integration can read them from
+  disk and attach code snippets to events.
 - Events are tagged with `trace_id`/`span_id` of the span active when the error
   was logged, so a Sentry event can be looked up in the tracing backend
   (Grafana/Tempo). Sentry itself receives no spans. When `GRAFANA_URL` is set,

--- a/packages/server-utils/src/__tests__/sentryTraceContext.test.ts
+++ b/packages/server-utils/src/__tests__/sentryTraceContext.test.ts
@@ -1,5 +1,9 @@
 import {Effect, Logger, Option, type FiberRefs} from 'effect'
-import {grafanaTraceUrl, traceContextFromFiberRefs} from '../sentry'
+import {
+  grafanaTraceUrl,
+  prettifyError,
+  traceContextFromFiberRefs,
+} from '../sentry'
 
 const runWithCapturingLogger = async (
   effect: Effect.Effect<void>
@@ -33,6 +37,55 @@ describe('traceContextFromFiberRefs', () => {
   it('returns none when no span is active', async () => {
     const fiberRefs = await runWithCapturingLogger(Effect.logError('boom'))
     expect(Option.isNone(traceContextFromFiberRefs(fiberRefs))).toBe(true)
+  })
+})
+
+describe('prettifyError', () => {
+  class TestError extends Error {
+    constructor(message: string, cause?: Error) {
+      super(message, {cause})
+      this.name = 'TestError'
+    }
+  }
+
+  it('appends span frames and strips effect-internal frames', async () => {
+    const error = await Effect.runPromise(
+      Effect.flip(
+        Effect.fail(new TestError('boom')).pipe(
+          Effect.withSpan('inner-span'),
+          Effect.withSpan('outer-span')
+        )
+      )
+    )
+
+    const pretty = prettifyError(error)
+    expect(pretty.name).toBe('TestError')
+    expect(pretty.message).toBe('boom')
+    expect(pretty.stack).toContain('at inner-span')
+    expect(pretty.stack).toContain('at outer-span')
+    expect(pretty.stack).not.toContain('internal/core')
+  })
+
+  it('prettifies the cause chain', async () => {
+    const error = await Effect.runPromise(
+      Effect.flip(
+        Effect.fail(new TestError('outer', new TestError('inner'))).pipe(
+          Effect.withSpan('some-span')
+        )
+      )
+    )
+
+    const pretty = prettifyError(error)
+    expect(pretty.cause).toBeInstanceOf(Error)
+    if (pretty.cause instanceof Error) {
+      expect(pretty.cause.message).toBe('inner')
+    }
+  })
+
+  it('returns errors without a span unchanged apart from the stack cleanup', () => {
+    const pretty = prettifyError(new TestError('plain'))
+    expect(pretty.name).toBe('TestError')
+    expect(pretty.message).toBe('plain')
   })
 })
 

--- a/packages/server-utils/src/sentry.ts
+++ b/packages/server-utils/src/sentry.ts
@@ -78,6 +78,16 @@ export const grafanaTraceUrl = (
 }
 
 /**
+ * Effect errors carry only their construction site plus fiber-runtime
+ * internals as a JS stack — the logical call path exists as the Effect span
+ * stack instead. `Cause.prettyErrors` rewrites the stack (recursively through
+ * `cause`): internal frames are stripped and span frames are appended, so
+ * Sentry shows a logical async trace.
+ */
+export const prettifyError = (error: Error): Error =>
+  Cause.prettyErrors(Cause.fail(error))[0] ?? error
+
+/**
  * Forwards every log at Error level and above to Sentry. All backend error
  * funnels (makeEndpointEffect, makeMiddlewareEffect, repeatingTask, MQ
  * consumers, runMainInNode) log unexpected errors, so hooking the logger
@@ -126,7 +136,7 @@ const makeSentryCaptureLogger = (
 
     const level = toSentryLevel(logLevel)
     if (error !== undefined) {
-      Sentry.captureException(error, {
+      Sentry.captureException(prettifyError(error), {
         level,
         extra,
         ...traceTags,


### PR DESCRIPTION
## What

Backend Sentry events showed stack traces consisting only of the error's construction site plus Effect fiber-runtime internals (`fiberRuntime.ts`, `core.ts`, ...), because Effect errors don't carry the logical call path as a JS stack — Effect tracks it as the span stack instead.

Two changes:

### 1. Prettify captured errors with `Cause.prettyErrors`

The Sentry capture logger now passes errors through `Cause.prettyErrors` before `Sentry.captureException`. This rewrites the stack:

- Effect-internal frames are stripped
- the enclosing Effect span stack is appended as synthetic `at <spanName> (file:line)` frames (HTTP request spans, `@effect/sql` query spans, any `Effect.withSpan`)
- the `cause` chain is prettified recursively, so the linked exceptions (e.g. `UnexpectedServerError` → `SqlError` → pg error) get clean stacks too

`Effect.fail` attaches the active span to the error value itself, so this works both for errors logged as message parts (`Effect.logError('msg', error)` — what all the funnels do) and for errors in the log cause.

Issue grouping is unaffected: the fingerprint is error name + message, not the stack.

### 2. Ship workspace TS sources in the runtime image

Frames already point at original TS paths (esbuild `sourcemap: true` + `node --enable-source-maps`), so no sourcemap upload to Sentry is needed. What was missing is snippet context: the Sentry SDK's `contextLines` integration reads source files from disk, and the runner image only shipped `dist/` + `node_modules`.

The runner stage now copies the pruned workspace sources (`out/full/packages` and the app's `src/`) from the pruner stage — copied from pruner rather than builder so no pnpm `node_modules` symlinks come along. Verified with a real `turbo prune --docker` run; the payload is ~1.2 MB for a typical service, well under 1% of image size, and the files are only ever read when an error event is captured.

## Testing

- New unit tests for `prettifyError` (span frames appear, internals stripped, cause chain prettified)
- `turbo prune --docker` run locally to verify the new COPY paths exist
- typecheck / format / lint pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reports with clearer, more actionable stack traces.
  - Added relevant source-code snippets to supported error events.
  - Included useful tracing context while removing internal framework noise.
  - Preserved existing error details when enhanced context is unavailable.

- **Documentation**
  - Added guidance on enhanced stack-trace processing, source maps, tracing context, and source snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->