### PR TITLE
Stop reporting offline recipients of stream-only messages as errors

### DIFF
--- a/apps/notification-service/src/routes/issueStreamOnlyMessageHandler.ts
+++ b/apps/notification-service/src/routes/issueStreamOnlyMessageHandler.ts
@@ -56,6 +56,11 @@ export const issueStreamOnlyMessageHandler = HttpApiBuilder.handler(
               minimalClientVersion: req.payload.minimalOtherSideVersion,
             })
           ),
+          Effect.catchTag('NoActiveSocketConnectionsError', () =>
+            Effect.logDebug(
+              'No active socket connections, skipping stream only chat message'
+            )
+          ),
           Effect.tapError((e) =>
             Effect.logError('Failed to send stream only chat message', e)
           ),

--- a/apps/notification-service/src/services/NotificationSocketMessaging/domain.ts
+++ b/apps/notification-service/src/services/NotificationSocketMessaging/domain.ts
@@ -41,6 +41,15 @@ import {Option, pipe, Schema, String, type Effect} from 'effect/index'
 
 const EXPO_PREFIX = 'expo-'
 
+/**
+ * The target token has no open socket connections (matching the minimal
+ * client version). Expected whenever the recipient is offline — handle it,
+ * don't report it.
+ */
+export class NoActiveSocketConnectionsError extends Schema.TaggedError<NoActiveSocketConnectionsError>(
+  'NoActiveSocketConnectionsError'
+)('NoActiveSocketConnectionsError', {}) {}
+
 export const ClientInfo = Schema.Struct({
   notificationToken: VexlNotificationTokenSecret,
   version: VersionCode,

--- a/apps/notification-service/src/services/NotificationSocketMessaging/index.ts
+++ b/apps/notification-service/src/services/NotificationSocketMessaging/index.ts
@@ -1,9 +1,10 @@
+import {type UnexpectedServerError} from '@vexl-next/domain/src/general/commonErrors'
 import {type VexlNotificationTokenSecret} from '@vexl-next/domain/src/general/notifications/VexlNotificationToken'
 import {type VersionCode} from '@vexl-next/domain/src/utility/VersionCode.brand'
 import {RedisPubSubService} from '@vexl-next/server-utils/src/RedisPubSubService'
-import {NoSuchElementException} from 'effect/Cause'
 import {Array, Context, Effect, flow, Layer, pipe} from 'effect/index'
 import {
+  NoActiveSocketConnectionsError,
   type ConnectionManagerChannelId,
   type NewChatMessageNoticeSendTask,
   type SendMessageTask,
@@ -20,19 +21,25 @@ export interface NotificationSocketMessagingOperations {
     task: NewChatMessageNoticeSendTask
   ) => Effect.Effect<
     void,
-    NoSuchElementException | SendMessageTasksManagerError
+    | NoActiveSocketConnectionsError
+    | UnexpectedServerError
+    | SendMessageTasksManagerError
   >
   sendStreamOnlyChatMessage: (
     task: StreamOnlyChatMessageSendTask
   ) => Effect.Effect<
     void,
-    NoSuchElementException | SendMessageTasksManagerError
+    | NoActiveSocketConnectionsError
+    | UnexpectedServerError
+    | SendMessageTasksManagerError
   >
   sendNotice: (
     task: SendMessageTask
   ) => Effect.Effect<
     void,
-    NoSuchElementException | SendMessageTasksManagerError
+    | NoActiveSocketConnectionsError
+    | UnexpectedServerError
+    | SendMessageTasksManagerError
   >
 }
 
@@ -50,7 +57,7 @@ export class NotificationSocketMessaging extends Context.Tag(
         minimalClientVersion?: VersionCode
       ): Effect.Effect<
         Array.NonEmptyArray<ConnectionManagerChannelId>,
-        NoSuchElementException
+        NoActiveSocketConnectionsError | UnexpectedServerError
       > =>
         pipe(
           registry.getConnectionsForToken(token),
@@ -65,8 +72,8 @@ export class NotificationSocketMessaging extends Context.Tag(
           ),
           Effect.filterOrFail(Array.isNonEmptyArray),
           Effect.catchTag(
-            'UnexpectedServerError',
-            () => new NoSuchElementException()
+            'NoSuchElementException',
+            () => new NoActiveSocketConnectionsError()
           )
         )
 


### PR DESCRIPTION
Fixes Sentry issue [NOTIFICATION-SERVICE-1](https://vexl.sentry.io/issues/7667840586/) (`NoSuchElementException`, ~1.6k events/day).

## What was happening

`issueStreamOnlyMessage` sends a chat message that should only be delivered over an open socket stream. When the recipient has no open connection — the completely normal offline case — `NotificationSocketMessaging.findManagerIdsForOpenConnections` failed with a generic `NoSuchElementException`, and the handler logged it at **error** level. Since error-level logging is the Sentry reporting API (docs/backend_sentry.md), every message to an offline recipient produced a Sentry error event.

On top of that, redis `UnexpectedServerError`s were squashed into the same `NoSuchElementException`, making a real redis outage indistinguishable from "recipient offline" on this path.

## Changes

- New tagged error `NoActiveSocketConnectionsError` in `NotificationSocketMessaging/domain.ts` — the no-open-connections case now has a name instead of a generic exception.
- `findManagerIdsForOpenConnections` no longer catches `UnexpectedServerError`; redis failures propagate in the error union of all three `send*` methods (they were already logged at error level inside `RedisConnectionRegistry`, so Sentry visibility is unchanged — this fixes the typing/masking).
- `issueStreamOnlyMessageHandler` catches `NoActiveSocketConnectionsError` and logs it at debug; only unexpected failures (`UnexpectedServerError`, `SendMessageTasksManagerError`) still hit the error-level log.
- The other two callers (`issueNotificationHandler`, `ProcessUserNotificationWorker`) already `catchAll` and fall back to push at info/warning level — unchanged.

After deploy, NOTIFICATION-SERVICE-1 can be marked resolved-in-next-release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when no active notification connections are available.
  * Stream-only notifications now continue gracefully without treating missing connections as an operational error.
  * Notification delivery errors are reported more accurately, improving reliability and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->