### PR TITLE
Add server-side Sentry error reporting to web-app

### DIFF
--- a/.github/workflows/build-backend-stack.yaml
+++ b/.github/workflows/build-backend-stack.yaml
@@ -120,7 +120,7 @@ jobs:
             echo "::warning::SENTRY_AUTH_TOKEN secret is not set — skipping Sentry release creation; events will still carry the release sha, but without commit metadata."
             exit 0
           fi
-          PROJECTS="-p user-service -p contact-service -p offer-service -p chat-service -p notification-service -p content-service -p feedback-service -p location-service -p btc-exchange-rate-service -p metrics-service -p dashboard-app -p backoffice-app"
+          PROJECTS="-p user-service -p contact-service -p offer-service -p chat-service -p notification-service -p content-service -p feedback-service -p location-service -p btc-exchange-rate-service -p metrics-service -p dashboard-app -p backoffice-app -p web-app"
           VERSION="${{ github.sha }}"
           SENTRY_ENV="${{ inputs.env == 'prod' && 'production' || inputs.env }}"
           pnpm exec sentry-cli releases new $PROJECTS "$VERSION"

--- a/apps/web-app/instrumentation.ts
+++ b/apps/web-app/instrumentation.ts
@@ -1,0 +1,22 @@
+import * as Sentry from '@sentry/nextjs'
+import {scrubSensitiveDataInPlace} from '@vexl-next/generic-utils/src/scrubSensitiveData'
+
+export function register(): void {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return
+
+  if (process.env.SENTRY_DSN) {
+    Sentry.init({
+      dsn: process.env.SENTRY_DSN,
+      environment: process.env.SENTRY_ENVIRONMENT ?? process.env.NODE_ENV,
+      release: process.env.SERVICE_VERSION,
+      sendDefaultPii: false,
+      beforeBreadcrumb: () => null,
+      beforeSend: (event) => {
+        scrubSensitiveDataInPlace(event)
+        return event
+      },
+    })
+  }
+}
+
+export const onRequestError = Sentry.captureRequestError

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@effect/platform": "^0.93.6",
+    "@sentry/nextjs": "^10.69.0",
     "@vexl-next/cryptography": "0.0.0",
     "@vexl-next/domain": "0.0.0",
     "@vexl-next/generic-utils": "0.0.0",

--- a/docs/backend_sentry.md
+++ b/docs/backend_sentry.md
@@ -1,8 +1,8 @@
 # Backend Sentry error reporting
 
 All Effect backend services report errors to Sentry through shared code in
-`packages/server-utils`; the backoffice-app (Next.js) has its own setup in
-`apps/backoffice-app/instrumentation.ts`.
+`packages/server-utils`; the Next.js apps (backoffice-app, web-app) have their
+own server-side setup in their `instrumentation.ts`.
 
 ## How it works
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1503,6 +1503,9 @@ importers:
       '@effect/platform':
         specifier: ^0.93.6
         version: 0.93.8(effect@3.21.4)
+      '@sentry/nextjs':
+        specifier: ^10.69.0
+        version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.109.2)
       '@vexl-next/cryptography':
         specifier: 0.0.0
         version: link:../../packages/cryptography
@@ -14687,6 +14690,22 @@ snapshots:
       - encoding
       - supports-color
 
+  '@sentry/bundler-plugins@10.69.0(rollup@4.62.2)(webpack@5.109.2)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@sentry/cli': 2.58.6
+      '@sentry/core': 10.69.0
+      dotenv: 17.4.2
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.62.2
+      webpack: 5.109.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@sentry/cli-darwin@2.58.4':
     optional: true
 
@@ -14853,6 +14872,32 @@ snapshots:
       - supports-color
       - webpack
 
+  '@sentry/nextjs@10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.109.2)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
+      '@sentry/browser-utils': 10.69.0
+      '@sentry/bundler-plugin-core': 5.3.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.69.0
+      '@sentry/node': 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.69.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/react': 10.69.0(react@19.2.3)
+      '@sentry/server-utils': 10.69.0
+      '@sentry/vercel-edge': 10.69.0
+      '@sentry/webpack-plugin': 5.4.0(rollup@4.62.2)(webpack@5.109.2)
+      next: 16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      rollup: 4.62.2
+      stacktrace-parser: 0.1.11
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/sdk-trace-base'
+      - encoding
+      - react
+      - supports-color
+      - webpack
+
   '@sentry/node-core@10.69.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@sentry/conventions': 0.16.0
@@ -14952,6 +14997,15 @@ snapshots:
     dependencies:
       '@sentry/bundler-plugins': 10.69.0(rollup@4.62.2)(webpack@5.109.2(postcss@8.5.15))
       webpack: 5.109.2(postcss@8.5.15)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@sentry/webpack-plugin@5.4.0(rollup@4.62.2)(webpack@5.109.2)':
+    dependencies:
+      '@sentry/bundler-plugins': 10.69.0(rollup@4.62.2)(webpack@5.109.2)
+      webpack: 5.109.2
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -20419,6 +20473,14 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.15
 
+  minimizer-webpack-plugin@5.6.1(webpack@5.109.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.48.0
+      webpack: 5.109.2
+
   minipass@4.2.8: {}
 
   minipass@7.1.3: {}
@@ -22687,6 +22749,42 @@ snapshots:
   webidl-conversions@7.0.0: {}
 
   webpack-sources@3.5.1: {}
+
+  webpack@5.109.2:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.17.0
+      browserslist: 4.28.4
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.4
+      es-module-lexer: 2.3.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      graceful-fs: 4.2.11
+      mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(webpack@5.109.2)
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
 
   webpack@5.109.2(postcss@8.5.15):
     dependencies:


### PR DESCRIPTION
The web-app was the only deployed app in the backend stack with no Sentry integration at all — no SDK, no release, and the `sentry-release` job neither waited for its build nor created a release for it.

## Changes

- **`apps/web-app/instrumentation.ts`** — server-side `@sentry/nextjs` init mirroring the backoffice-app setup: nodejs runtime only, errors only (no tracing, no breadcrumbs), `sendDefaultPii` off, every event scrubbed via `scrubSensitiveDataInPlace`, plus `onRequestError = Sentry.captureRequestError` for SSR/route errors.
- ~~`build-web-app.yaml`~~ — no longer part of this PR: the consolidated `[Build] backend docker image` workflow (#2678) already passes `SERVICE_VERSION` and `ENVIRONMENT` to web-app.
- **`build-backend-stack.yaml`** — add `web-app` to the Sentry `PROJECTS` list so a release is created for it (after #2678 the `sentry-release` job already waits on the full image matrix).
- **`docs/backend_sentry.md`** — mention web-app alongside backoffice-app as the Next.js apps with instrumentation-based setup.

## Deployment prerequisites (not part of this PR)

- Create the `web-app` project in the Sentry org (the release step targets `-p web-app`).
- Inject `SENTRY_DSN` and `SENTRY_ENVIRONMENT` via the deployment manifests in the infrastructure repo. Without `SENTRY_DSN` the SDK stays disabled, so this is safe to ship first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side error monitoring for the web app.
  * Improved error reports with environment and release details while removing sensitive information.
  * Included the web app in release tracking.

* **Documentation**
  * Updated monitoring setup documentation to cover both Next.js applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
