### PR TITLE
feat(server-utils): include lock resource names in RedisLockError and spans

### DIFF
--- a/packages/server-utils/src/RedisService.ts
+++ b/packages/server-utils/src/RedisService.ts
@@ -30,6 +30,7 @@ export class RedisLockError extends Schema.TaggedError<RedisLockError>(
   'RedisLockError'
 )('RedisLockError', {
   cause: Schema.Unknown,
+  resources: Schema.Array(Schema.String),
 }) {}
 
 export interface RedisOperations {
@@ -155,29 +156,40 @@ export class RedisService extends Context.Tag('RedisService')<
       const acquireLockEffect = (
         resources: string[] | string,
         duration: Duration.DurationInput
-      ): Effect.Effect<Lock, RedisLockError> =>
-        Effect.promise(
+      ): Effect.Effect<Lock, RedisLockError> => {
+        const resourcesArray = Array.isArray(resources)
+          ? resources
+          : [resources]
+
+        return Effect.promise(
           async () =>
-            await redlock.acquire(
-              Array.isArray(resources) ? resources : [resources],
-              Duration.toMillis(duration)
-            )
+            await redlock.acquire(resourcesArray, Duration.toMillis(duration))
         ).pipe(
-          Effect.zipLeft(Effect.logInfo('Acquired Redis lock', {duration})),
+          Effect.zipLeft(
+            Effect.logInfo('Acquired Redis lock', {
+              duration,
+              resources: resourcesArray,
+            })
+          ),
           catchAllDefect(
             (e) =>
               new RedisLockError({
                 cause: e,
+                resources: resourcesArray,
               })
           )
         )
+      }
 
       const releaseLockEffect = (lock: Lock): Effect.Effect<void> => {
         const now = Date.now()
         if (lock.expiration < now) {
           return Effect.logWarning(
             'Attempted to release an expired lock. Lock time should be increased',
-            {overExpirationMillis: now - lock.expiration}
+            {
+              overExpirationMillis: now - lock.expiration,
+              resources: lock.resources,
+            }
           )
         }
 
@@ -198,7 +210,10 @@ export class RedisService extends Context.Tag('RedisService')<
             releaseLockEffect
           ).pipe(
             Effect.withSpan('Redis lock', {
-              attributes: {duration},
+              attributes: {
+                duration,
+                resources: Array.isArray(resources) ? resources : [resources],
+              },
             })
           )
 


### PR DESCRIPTION
## What changed

When a Redis distributed lock fails to acquire (e.g. Redlock quorum error), the resulting "RedisLockError" now carries the exact lock resource name(s). The "Redis lock" OpenTelemetry span and the lock acquisition/release logs also include the resources.

## Why

Debugging lock contention currently requires cross-referencing the route and guessing which key was contended. With this change, Sentry events and traces will directly show keys like `offerAdminAction:<hashedId>`.

## Privacy note

Lock resources are already hashed identifiers before being passed to Redis, so no new plaintext user data is exposed.

## Verification

- `pnpm turbo:typecheck --filter=@vexl-next/server-utils` ✅
- `pnpm turbo:format --filter=@vexl-next/server-utils` ✅
- `pnpm turbo:lint --filter=@vexl-next/server-utils` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock error details by identifying the resources involved.
  * Expanded expired-lock warnings with resource information.
* **Monitoring**
  * Lock activity now records the resources involved and the time spent acquiring or holding locks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->