### PR TITLE
chore(mobile): prepare 1.45.2 build 890

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,5 +1,5 @@
-const VERSION_CODE = 882
-const VERSION = '1.45.1'
+const VERSION_CODE = 890
+const VERSION = '1.45.2'
 const ENV_PRESET = process.env.ENV_PRESET
 const IS_LOCAL_ENV = ENV_PRESET === 'local'
 const COMMIT_HASH = process.env.EAS_BUILD_GIT_COMMIT_HASH ?? 'local'


### PR DESCRIPTION
Bumps the mobile app release metadata to version 1.45.2 with build code 890.

## Changes

- Set the app version to 1.45.2
- Set the iOS and Android build code to 890

## Checks

- pnpm turbo:typecheck --filter @vexl-next/mobile-app
- pnpm turbo:format --filter @vexl-next/mobile-app
- pnpm turbo:lint
- Resolved the production Expo config and confirmed version 1.45.2 and build 890

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the mobile app to version 1.45.2.
  * Incremented the internal release version code for the new build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->