### PR TITLE
fix(server-utils): stop dropping sslmode from DB_URL so location service can reach its SSL-only RDS

### DIFF
--- a/packages/server-utils/src/commonConfigs.ts
+++ b/packages/server-utils/src/commonConfigs.ts
@@ -79,6 +79,12 @@ export const makeDatabaseConfig = (vars: {
         database: parsedUrl.pathname.slice(1), // Remove leading '/'
         username: config.username,
         password: config.password,
+        // sslmode=require means "encrypt, don't verify the cert" (libpq
+        // semantics) — RDS certs are not in Node's default trust store, so
+        // plain `ssl: true` would be rejected as self-signed.
+        ...(parsedUrl.searchParams.get('sslmode') === 'require'
+          ? {ssl: {rejectUnauthorized: false}}
+          : {}),
       }
     })
   )


### PR DESCRIPTION
The prod location service fails on boot with `no pg_hba.conf entry for host ..., no encryption` when connecting to the new geocoding Postgres. The instance (infra `prod/db-location.tf`) enforces `rds.force_ssl=1` because it is publicly reachable for the OSM loader, and the `DB_URL` secret correctly carries `?sslmode=require` — but `makeDatabaseConfig` in server-utils parsed only host/port/database out of the URL and silently dropped the query string, so the client always connected in plaintext and RDS rejected it before authentication.

This maps `sslmode=require` in the connection URL to `ssl: {rejectUnauthorized: false}` on the `PgClientConfig`, matching libpq's `require` semantics (encrypt, don't verify the cert). Plain `ssl: true` would not work here: RDS certs chain to Amazon's RDS CA, which is not in Node's default trust store, so verification would fail as self-signed. URLs without `sslmode` behave exactly as before, so the main vexl DB connections are unaffected.

Verified with `pnpm turbo:typecheck`, `turbo:format`, and `turbo:lint` (all clean; only pre-existing mobile-app lint warnings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added support for encrypted database connections when the connection URL specifies `sslmode=require`.
  - Improved connectivity to hosted database services using certificates not included in Node’s default trust store.
  - Preserved existing behavior for connections without the `sslmode=require` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->