### PR TITLE
fix #2620: Chunk vCard import work and dedupe against stored contacts

### DIFF
--- a/apps/mobile/src/components/ContactPreferencesFlow/components/ContactListSelect/atom.ts
+++ b/apps/mobile/src/components/ContactPreferencesFlow/components/ContactListSelect/atom.ts
@@ -12,7 +12,10 @@ import {atomFamily, splitAtom} from 'jotai/utils'
 import {matchSorter, rankings} from 'match-sorter'
 import {Linking} from 'react-native'
 import {addContactToPhoneActionAtom} from '../../../../state/contacts/atom/addContactToPhoneWithUIFeedbackAtom'
-import {CONTACT_IMPORT_PROGRESS_DIALOG_MIN_CONTACTS} from '../../../../state/contacts/atom/contactImportUtils'
+import {
+  CONTACT_IMPORT_PROGRESS_DIALOG_MIN_CONTACTS,
+  CONTACT_NORMALIZATION_CHUNK_SIZE,
+} from '../../../../state/contacts/atom/contactImportUtils'
 import {
   normalizedContactsAtom,
   storedContactsAtom,
@@ -22,6 +25,7 @@ import {submitContactsActionAtom} from '../../../../state/contacts/atom/submitCo
 import {
   StoredContactWithComputedValues,
   type ContactsFilter,
+  type StoredContact,
 } from '../../../../state/contacts/domain'
 import {
   areContactsPermissionsAlreadyGranted,
@@ -30,7 +34,10 @@ import {
 } from '../../../../state/contacts/utils'
 import getValueFromSetStateActionOfAtom from '../../../../utils/atomUtils/getValueFromSetStateActionOfAtom'
 import {translationAtom} from '../../../../utils/localization/I18nProvider'
-import {runAfterTwoAnimationFrames} from '../../../../utils/runAfterAnimationFrames'
+import {
+  runAfterTwoAnimationFrames,
+  waitForNextAnimationFrameEffect,
+} from '../../../../utils/runAfterAnimationFrames'
 import toE164PhoneNumberWithDefaultCountryCode from '../../../../utils/toE164PhoneNumberWithDefaultCountryCode'
 import {parseVcardString} from '../../../../utils/vCard'
 import {showErrorAlert} from '../../../ErrorAlert'
@@ -53,6 +60,23 @@ class ContactsImportError extends Schema.TaggedError<ContactsImportError>(
 // Hard caps for untrusted .vcf input
 const MAX_VCF_FILE_SIZE_BYTES = 2 * 1024 * 1024
 const MAX_CONTACTS_PER_VCF_IMPORT = 5000
+
+// Raw numbers included so contacts whose normalization is still pending
+// are matched too (their computedValues are None)
+function collectStoredContactNumbers(
+  contacts: readonly StoredContact[]
+): Set<string> {
+  const numbers = new Set<string>()
+  pipe(
+    contacts,
+    Array.forEach((contact) => {
+      numbers.add(contact.info.rawNumber)
+      if (Option.isSome(contact.computedValues))
+        numbers.add(contact.computedValues.value.normalizedNumber)
+    })
+  )
+  return numbers
+}
 
 const matchSorterKeys = ['info.name', 'info.numberToDisplay']
 const matchSorterThreshold = rankings.CONTAINS
@@ -686,21 +710,47 @@ export const contactSelectMolecule = molecule((_, getScope) => {
           return false
         }
 
-        const existingNormalizedNumbers = new Set(
-          pipe(
-            get(normalizedContactsAtom),
-            Array.map((one) => one.computedValues.normalizedNumber)
+        const entries = pipe(
+          parsedContacts,
+          Array.flatMap(({name, phoneNumbers}) =>
+            pipe(
+              phoneNumbers,
+              Array.map((phoneNumber) => ({name, phoneNumber}))
+            )
           )
+        )
+        const existingContactNumbers = collectStoredContactNumbers(
+          get(storedContactsAtom)
         )
         const seenNumbers = new Set<E164PhoneNumber>()
         let skippedCount = 0
+        let processedEntriesCount = 0
+        let reachedContactLimit = false
         const contactsToImport: Array<{
           name: string
           normalizedNumber: E164PhoneNumber
         }> = []
 
-        for (const parsedContact of parsedContacts) {
-          for (const phoneNumber of parsedContact.phoneNumbers) {
+        for (const entriesChunk of pipe(
+          entries,
+          Array.chunksOf(CONTACT_NORMALIZATION_CHUNK_SIZE)
+        )) {
+          yield* _(waitForNextAnimationFrameEffect())
+          for (const {name, phoneNumber} of entriesChunk) {
+            if (contactsToImport.length >= MAX_CONTACTS_PER_VCF_IMPORT) {
+              skippedCount += entries.length - processedEntriesCount
+              reachedContactLimit = true
+              break
+            }
+            processedEntriesCount++
+
+            // Match on the raw string too - a stored contact pending
+            // normalization is only known by its raw number
+            if (existingContactNumbers.has(phoneNumber)) {
+              skippedCount++
+              continue
+            }
+
             const normalizedNumber =
               toE164PhoneNumberWithDefaultCountryCode(phoneNumber)
             if (Option.isNone(normalizedNumber)) {
@@ -709,19 +759,16 @@ export const contactSelectMolecule = molecule((_, getScope) => {
             }
             if (seenNumbers.has(normalizedNumber.value)) continue
             seenNumbers.add(normalizedNumber.value)
-            if (existingNormalizedNumbers.has(normalizedNumber.value)) {
-              skippedCount++
-              continue
-            }
-            if (contactsToImport.length >= MAX_CONTACTS_PER_VCF_IMPORT) {
+            if (existingContactNumbers.has(normalizedNumber.value)) {
               skippedCount++
               continue
             }
             contactsToImport.push({
-              name: parsedContact.name,
+              name,
               normalizedNumber: normalizedNumber.value,
             })
           }
+          if (reachedContactLimit) break
         }
 
         if (!Array.isNonEmptyArray(contactsToImport)) {
@@ -753,37 +800,62 @@ export const contactSelectMolecule = molecule((_, getScope) => {
         if (!importConfirmed) return false
 
         const newStoredContacts = yield* _(
-          Effect.forEach(contactsToImport, ({name, normalizedNumber}) =>
-            hashPhoneNumberE(normalizedNumber).pipe(
-              Effect.map((hash) =>
-                Schema.decodeSync(StoredContactWithComputedValues)({
-                  info: {
-                    name,
-                    numberToDisplay: normalizedNumber,
-                    rawNumber: normalizedNumber,
-                  },
-                  computedValues: {
-                    hash,
-                    normalizedNumber,
-                  },
-                  // seen: false so restored contacts surface on the "New" tab
-                  // (they get resolved as seen when the list screen unmounts)
-                  flags: {
-                    seen: false,
-                    imported: false,
-                    importedManually: true,
-                    invalidNumber: 'valid',
-                  },
-                })
+          Effect.forEach(
+            Array.chunksOf(contactsToImport, CONTACT_NORMALIZATION_CHUNK_SIZE),
+            (contactsToImportChunk) =>
+              waitForNextAnimationFrameEffect().pipe(
+                Effect.zipRight(
+                  Effect.forEach(
+                    contactsToImportChunk,
+                    ({name, normalizedNumber}) =>
+                      hashPhoneNumberE(normalizedNumber).pipe(
+                        Effect.map((hash) =>
+                          Schema.decodeSync(StoredContactWithComputedValues)({
+                            info: {
+                              name,
+                              numberToDisplay: normalizedNumber,
+                              rawNumber: normalizedNumber,
+                            },
+                            computedValues: {
+                              hash,
+                              normalizedNumber,
+                            },
+                            // seen: false so restored contacts surface on the
+                            // "New" tab (they get resolved as seen when the
+                            // list screen unmounts)
+                            flags: {
+                              seen: false,
+                              imported: false,
+                              importedManually: true,
+                              invalidNumber: 'valid',
+                            },
+                          })
+                        )
+                      )
+                  )
+                )
               )
-            )
+          ),
+          Effect.map(Array.flatten)
+        )
+
+        // The confirmation dialog can stay open indefinitely - drop entries
+        // that another flow (e.g. background contact sync) stored meanwhile
+        const currentContactNumbers = collectStoredContactNumbers(
+          get(storedContactsAtom)
+        )
+        const contactsToStore = pipe(
+          newStoredContacts,
+          Array.filter(
+            (one) =>
+              !currentContactNumbers.has(one.computedValues.normalizedNumber)
           )
         )
 
         set(storedContactsAtom, (prev) => [
           ...prev,
           ...pipe(
-            newStoredContacts,
+            contactsToStore,
             Array.map((one) => ({
               ...one,
               computedValues: Option.some(one.computedValues),
@@ -793,9 +865,9 @@ export const contactSelectMolecule = molecule((_, getScope) => {
         set(selectedNumbersAtom, (selectedNumbers) => {
           const nextSelectedNumbers = new Set(selectedNumbers)
           pipe(
-            contactsToImport,
-            Array.forEach(({normalizedNumber}) => {
-              nextSelectedNumbers.add(normalizedNumber)
+            contactsToStore,
+            Array.forEach((one) => {
+              nextSelectedNumbers.add(one.computedValues.normalizedNumber)
             })
           )
           return nextSelectedNumbers
@@ -805,7 +877,7 @@ export const contactSelectMolecule = molecule((_, getScope) => {
         set(
           toastNotificationAtom,
           t('contactPreferences.importVcf.success', {
-            count: contactsToImport.length,
+            count: contactsToStore.length,
           })
         )
 

--- a/apps/mobile/src/state/contacts/atom/contactImportUtils.ts
+++ b/apps/mobile/src/state/contacts/atom/contactImportUtils.ts
@@ -9,6 +9,7 @@ import {
 
 export const CONTACT_IMPORT_BATCH_SIZE = 1000
 export const CONTACT_IMPORT_LOCAL_PROCESSING_CHUNK_SIZE = 500
+export const CONTACT_NORMALIZATION_CHUNK_SIZE = 50
 // UX threshold, intentionally independent of the processing chunk size above —
 // tuning chunk sizes for performance must not change when the dialog appears.
 export const CONTACT_IMPORT_PROGRESS_DIALOG_MIN_CONTACTS = 500

--- a/apps/mobile/src/state/contacts/atom/exportVexlOnlyContactsActionAtom.ts
+++ b/apps/mobile/src/state/contacts/atom/exportVexlOnlyContactsActionAtom.ts
@@ -2,6 +2,7 @@ import {Array, Effect, Schema, pipe} from 'effect'
 import {shareAsync} from 'expo-sharing'
 import {atom} from 'jotai'
 import {showErrorAlert} from '../../../components/ErrorAlert'
+import {askAreYouSureActionAtom} from '../../../components/GlobalDialog'
 import {getContactsBackupFile} from '../../../utils/fsDirectories'
 import {translationAtom} from '../../../utils/localization/I18nProvider'
 import {contactsToVcardString} from '../../../utils/vCard'
@@ -15,7 +16,7 @@ class ContactsExportError extends Schema.TaggedError<ContactsExportError>(
 
 export const exportVexlOnlyContactsActionAtom = atom(
   null,
-  (get): Effect.Effect<boolean> => {
+  (get, set): Effect.Effect<boolean> => {
     const {t} = get(translationAtom)
     const vexlOnlyContacts = get(vexlOnlyContactsAtom)
 
@@ -49,6 +50,19 @@ export const exportVexlOnlyContactsActionAtom = atom(
       },
       catch: (e) => new ContactsExportError({cause: e}),
     }).pipe(
+      Effect.zipRight(
+        set(askAreYouSureActionAtom, {
+          variant: 'info',
+          steps: [
+            {
+              type: 'StepWithText',
+              title: t('vexlOnlyContacts.exportSuccessTitle'),
+              description: t('vexlOnlyContacts.exportSuccessDescription'),
+              positiveButtonText: t('common.gotIt'),
+            },
+          ],
+        }).pipe(Effect.ignore)
+      ),
       Effect.as(true),
       Effect.catchAll((e) =>
         Effect.sync(() => {

--- a/apps/mobile/src/state/contacts/atom/normalizeStoredContactsActionAtom.ts
+++ b/apps/mobile/src/state/contacts/atom/normalizeStoredContactsActionAtom.ts
@@ -10,6 +10,7 @@ import sequenceTasksWithAnimationFrames from '../../../utils/sequenceTasksWithAn
 import toE164PhoneNumberWithDefaultCountryCode from '../../../utils/toE164PhoneNumberWithDefaultCountryCode'
 import {type ContactComputedValues, type StoredContact} from '../domain'
 import {hashPhoneNumber} from '../utils'
+import {CONTACT_NORMALIZATION_CHUNK_SIZE} from './contactImportUtils'
 import {storedContactsAtom} from './contactsStore'
 
 function markContactInvalid(contact: StoredContact): StoredContact {
@@ -108,12 +109,15 @@ const normalizeStoredContactsActionAtom = atom(
         pipe(
           toNormalize,
           Array.map(flow(normalizeContact, effectToTask)),
-          sequenceTasksWithAnimationFrames(50, (percentage) => {
-            onProgress({
-              total: toNormalize.length,
-              percentDone: percentage,
-            })
-          }),
+          sequenceTasksWithAnimationFrames(
+            CONTACT_NORMALIZATION_CHUNK_SIZE,
+            (percentage) => {
+              onProgress({
+                total: toNormalize.length,
+                percentDone: percentage,
+              })
+            }
+          ),
           taskToEffect
         )
       )

--- a/apps/mobile/src/utils/vCard.test.ts
+++ b/apps/mobile/src/utils/vCard.test.ts
@@ -94,6 +94,140 @@ describe('parseVcardString', () => {
     ])
   })
 
+  it('decodes a quoted-printable UTF-8 formatted name', () => {
+    const result = parseVcardString(
+      'BEGIN:VCARD\r\n' +
+        'VERSION:2.1\r\n' +
+        'FN;CHARSET=UTF-8;ENCODING=QUOTED-PRINTABLE:=C5=A0t=C4=9Bp=C3=A1n\r\n' +
+        'TEL:+420777888999\r\n' +
+        'END:VCARD\r\n'
+    )
+
+    expect(result).toEqual([{name: 'Štěpán', phoneNumbers: ['+420777888999']}])
+  })
+
+  it('recognizes the bare quoted-printable parameter', () => {
+    const result = parseVcardString(
+      'BEGIN:VCARD\n' +
+        'FN;CHARSET=UTF-8;QUOTED-PRINTABLE:=C5=A0t=C4=9Bp=C3=A1n\n' +
+        'TEL:+420777888999\n' +
+        'END:VCARD\n'
+    )
+
+    expect(result).toEqual([{name: 'Štěpán', phoneNumbers: ['+420777888999']}])
+  })
+
+  it('joins and decodes quoted-printable soft line breaks', () => {
+    const result = parseVcardString(
+      'BEGIN:VCARD\r\n' +
+        'FN;ENCODING=QUOTED-PRINTABLE:=C5=A0t=C4=\r\n' +
+        '=9Bp=C3=A1n\r\n' +
+        'TEL:+420777888999\r\n' +
+        'END:VCARD\r\n'
+    )
+
+    expect(result).toEqual([{name: 'Štěpán', phoneNumbers: ['+420777888999']}])
+  })
+
+  it('parses a vCard 2.1 structured quoted-printable name', () => {
+    const result = parseVcardString(
+      'BEGIN:VCARD\r\n' +
+        'VERSION:2.1\r\n' +
+        'N;CHARSET=UTF-8;ENCODING=QUOTED-PRINTABLE:=C4=8Cern=C3=BD;Jan;;;\r\n' +
+        'TEL;CELL:+420777888999\r\n' +
+        'END:VCARD\r\n'
+    )
+
+    expect(result).toEqual([
+      {name: 'Jan Černý', phoneNumbers: ['+420777888999']},
+    ])
+  })
+
+  it('keeps malformed quoted-printable values without throwing', () => {
+    const malformedEscape = parseVcardString(
+      'BEGIN:VCARD\n' +
+        'FN;ENCODING=QUOTED-PRINTABLE:=ZZ\n' +
+        'TEL:+420777888999\n' +
+        'END:VCARD\n'
+    )
+    const invalidUtf8 = parseVcardString(
+      'BEGIN:VCARD\n' +
+        'FN;ENCODING=QUOTED-PRINTABLE:=FF\n' +
+        'TEL:+420111222333\n' +
+        'END:VCARD\n'
+    )
+
+    expect(malformedEscape).toEqual([
+      {name: '=ZZ', phoneNumbers: ['+420777888999']},
+    ])
+    expect(invalidUtf8).toEqual([
+      {name: '=FF', phoneNumbers: ['+420111222333']},
+    ])
+  })
+
+  it('joins a soft-break continuation whose content contains a colon', () => {
+    const result = parseVcardString(
+      'BEGIN:VCARD\n' +
+        'FN;ENCODING=QUOTED-PRINTABLE:John =\n' +
+        'Smith:Jr\n' +
+        'TEL:+420777888999\n' +
+        'END:VCARD\n' +
+        'BEGIN:VCARD\n' +
+        'FN;ENCODING=QUOTED-PRINTABLE:Jane =\n' +
+        'SMITH:JR\n' +
+        'TEL:+420111222333\n' +
+        'END:VCARD\n'
+    )
+
+    expect(result).toEqual([
+      {name: 'John Smith:Jr', phoneNumbers: ['+420777888999']},
+      {name: 'Jane SMITH:JR', phoneNumbers: ['+420111222333']},
+    ])
+  })
+
+  it('stops joining at lowercase property and boundary lines', () => {
+    const result = parseVcardString(
+      'BEGIN:VCARD\n' +
+        'FN;ENCODING=QUOTED-PRINTABLE:Alice=\n' +
+        'tel:+420777888999\n' +
+        'end:vcard\n'
+    )
+
+    expect(result).toEqual([{name: 'Alice=', phoneNumbers: ['+420777888999']}])
+  })
+
+  it('does not consume the TEL property or card boundary after a malformed trailing equals sign', () => {
+    const result = parseVcardString(
+      'BEGIN:VCARD\n' +
+        'FN;ENCODING=QUOTED-PRINTABLE:Test=\n' +
+        'TEL:+420777888999\n' +
+        'END:VCARD\n' +
+        'BEGIN:VCARD\n' +
+        'FN:Second\n' +
+        'TEL:+420111222333\n' +
+        'END:VCARD\n'
+    )
+
+    expect(result).toEqual([
+      {name: 'Test=', phoneNumbers: ['+420777888999']},
+      {name: 'Second', phoneNumbers: ['+420111222333']},
+    ])
+  })
+
+  it('does not decode literal equals signs without a quoted-printable param', () => {
+    const result = parseVcardString(
+      'BEGIN:VCARD\n' +
+        'VERSION:3.0\n' +
+        'FN:Name=C5=A0\n' +
+        'TEL:+420777888999\n' +
+        'END:VCARD\n'
+    )
+
+    expect(result).toEqual([
+      {name: 'Name=C5=A0', phoneNumbers: ['+420777888999']},
+    ])
+  })
+
   it('ignores other vCard properties and cards without name or number', () => {
     const result = parseVcardString(
       'BEGIN:VCARD\n' +

--- a/apps/mobile/src/utils/vCard.ts
+++ b/apps/mobile/src/utils/vCard.ts
@@ -68,6 +68,30 @@ function sanitizeParsedName(name: string): string {
     .slice(0, MAX_PARSED_NAME_LENGTH)
 }
 
+// Lines that must terminate a QP soft-break join: card boundaries and
+// well-known vCard properties (optionally with an "item1." group and
+// ;params), matched case-insensitively like the rest of the parser.
+// A whitelist is used because QP continuation content may legitimately
+// contain a colon (e.g. "Smith:Jr") and must not be mistaken for a
+// property line.
+const propertyLinePattern =
+  /^([\w-]+\.)?(BEGIN|END|VERSION|FN|N|TEL|EMAIL|ADR|ORG|TITLE|NOTE|URL|PHOTO|BDAY|X-[\w-]+)(;[^:]*)?:/i
+
+function looksLikePropertyLine(line: string): boolean {
+  return propertyLinePattern.test(line.trim())
+}
+
+function decodeQuotedPrintableValue(value: string): string {
+  try {
+    return decodeURIComponent(
+      value.replace(/%/g, '%25').replace(/=([0-9A-Fa-f]{2})/g, '%$1')
+    )
+  } catch {
+    // malformed QP or invalid UTF-8 - keep the raw value rather than dropping the contact
+    return value
+  }
+}
+
 function splitOnUnescapedSemicolons(value: string): string[] {
   const parts: string[] = []
   let currentPart = ''
@@ -119,7 +143,9 @@ export function parseVcardString(vcardString: string): ParsedVcardContact[] {
     | {formattedName?: string; structuredName?: string; phoneNumbers: string[]}
     | undefined
 
-  for (const line of lines) {
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex]
+    if (line === undefined) continue
     const upperCasedLine = line.trim().toUpperCase()
     if (upperCasedLine === 'BEGIN:VCARD') {
       currentContact = {phoneNumbers: []}
@@ -144,16 +170,40 @@ export function parseVcardString(vcardString: string): ParsedVcardContact[] {
 
     const colonIndex = line.indexOf(':')
     if (colonIndex <= 0) continue
-    const value = line.slice(colonIndex + 1).trim()
-    if (value === '') continue
+    const propertyAndParams = line.slice(0, colonIndex).split(';')
     // strip params (TEL;TYPE=CELL) and Apple item groups (item1.TEL)
-    const property = line
-      .slice(0, colonIndex)
-      .split(';')[0]
+    const property = propertyAndParams[0]
       ?.split('.')
       .pop()
       ?.trim()
       .toUpperCase()
+    const isQuotedPrintable = pipe(
+      propertyAndParams,
+      Array.drop(1),
+      Array.some((param) => {
+        const normalizedParam = param.trim().toUpperCase()
+        return (
+          normalizedParam === 'ENCODING=QUOTED-PRINTABLE' ||
+          normalizedParam === 'QUOTED-PRINTABLE'
+        )
+      })
+    )
+    let value = line.slice(colonIndex + 1).trim()
+    if (isQuotedPrintable) {
+      while (value.endsWith('=') && lineIndex + 1 < lines.length) {
+        const nextLine = lines[lineIndex + 1]
+        if (nextLine === undefined) break
+        // A malformed trailing "=" (not a real QP soft break) must not eat
+        // the next property or card boundary - stop instead of consuming it.
+        if (looksLikePropertyLine(nextLine)) break
+        lineIndex++
+        value = `${value.slice(0, -1)}${nextLine}`
+      }
+      if (property === 'FN' || property === 'N' || property === 'TEL') {
+        value = decodeQuotedPrintableValue(value)
+      }
+    }
+    if (value === '') continue
 
     if (property === 'FN' && currentContact.formattedName === undefined) {
       currentContact.formattedName = unescapeVcardValue(value)

--- a/packages/localization/locales/bg/contacts.json
+++ b/packages/localization/locales/bg/contacts.json
@@ -84,6 +84,8 @@
   "vexlOnlyContacts.description": "Тези контакти са запазени само във Vexl, не в телефона ти — добавени са ръчно или са възстановени от резервно копие. Експортирай ги като файл с контакти (.vcf), за да имаш сигурно копие извън приложението.",
   "vexlOnlyContacts.exportButton": "Експортирай контактите",
   "vexlOnlyContacts.exportSheetTitle": "Запази резервно копие на тези контакти",
+  "vexlOnlyContacts.exportSuccessTitle": "Резервното копие е готово!",
+  "vexlOnlyContacts.exportSuccessDescription": "Контактите ти са запазени във файл с резервно копие (.vcf). Пази го на сигурно място — можеш да ги върнеш по всяко време от екрана Добавяне на нов контакт.",
   "vexlOnlyContacts.emptyTitle": "Няма нищо за запазване",
   "vexlOnlyContacts.emptyDescription": "Контактите, които съществуват само във Vexl — добавени ръчно или възстановени от резервно копие — ще се показват тук. Имаш файл с резервно копие (.vcf)? Импортирай го от екрана Добавяне на нов контакт.",
   "contactPreferences.importVcf.invalidFileTitle": "Файлът не можа да бъде прочетен",

--- a/packages/localization/locales/cs/contacts.json
+++ b/packages/localization/locales/cs/contacts.json
@@ -84,6 +84,8 @@
   "vexlOnlyContacts.description": "Tyto kontakty jsou uložené jen ve Vexlu, ne v telefonu — byly přidány ručně nebo obnoveny ze zálohy. Exportuj je jako soubor kontaktů (.vcf), ať máš bezpečnou kopii i mimo aplikaci.",
   "vexlOnlyContacts.exportButton": "Exportovat kontakty",
   "vexlOnlyContacts.exportSheetTitle": "Zálohovat tyto kontakty",
+  "vexlOnlyContacts.exportSuccessTitle": "Záloha hotová!",
+  "vexlOnlyContacts.exportSuccessDescription": "Kontakty jsou uložené v záložním souboru (.vcf). Ulož si ho někam do bezpečí — kdykoli je můžeš vrátit zpátky na obrazovce Přidat nový kontakt.",
   "vexlOnlyContacts.emptyTitle": "Není co zálohovat",
   "vexlOnlyContacts.emptyDescription": "Kontakty, které existují jen ve Vexlu — přidané ručně nebo obnovené ze zálohy — se zobrazí tady. Máš záložní soubor (.vcf)? Naimportuj ho na obrazovce Přidat nový kontakt.",
   "contactPreferences.importVcf.invalidFileTitle": "Soubor se nepodařilo přečíst",

--- a/packages/localization/locales/de/contacts.json
+++ b/packages/localization/locales/de/contacts.json
@@ -84,6 +84,8 @@
   "vexlOnlyContacts.description": "Diese Kontakte sind nur in Vexl gespeichert, nicht auf deinem Telefon — du hast sie manuell hinzugefügt oder aus einem Backup wiederhergestellt. Exportiere sie als Kontaktdatei (.vcf), um eine sichere Kopie außerhalb der App zu haben.",
   "vexlOnlyContacts.exportButton": "Kontakte exportieren",
   "vexlOnlyContacts.exportSheetTitle": "Diese Kontakte sichern",
+  "vexlOnlyContacts.exportSuccessTitle": "Backup fertig!",
+  "vexlOnlyContacts.exportSuccessDescription": "Deine Kontakte sind in einer Backup-Datei (.vcf) gespeichert. Bewahre sie sicher auf — du kannst sie jederzeit über den Bildschirm „Neuen Kontakt hinzufügen“ zurückholen.",
   "vexlOnlyContacts.emptyTitle": "Nichts zu sichern",
   "vexlOnlyContacts.emptyDescription": "Kontakte, die nur in Vexl existieren — manuell hinzugefügt oder aus einem Backup wiederhergestellt — erscheinen hier. Du hast eine Backup-Datei (.vcf)? Importiere sie über den Bildschirm „Neuen Kontakt hinzufügen“.",
   "contactPreferences.importVcf.invalidFileTitle": "Datei konnte nicht gelesen werden",

--- a/packages/localization/locales/en/contacts.json
+++ b/packages/localization/locales/en/contacts.json
@@ -84,6 +84,8 @@
   "vexlOnlyContacts.description": "These contacts are saved only in Vexl, not in your phone — you added them manually or restored them from a backup. Export them as a contact file (.vcf) to keep a safe copy outside the app.",
   "vexlOnlyContacts.exportButton": "Export contacts",
   "vexlOnlyContacts.exportSheetTitle": "Back up these contacts",
+  "vexlOnlyContacts.exportSuccessTitle": "Backup done!",
+  "vexlOnlyContacts.exportSuccessDescription": "Your contacts are saved in a backup file (.vcf). Keep it somewhere safe — you can bring them back anytime from the Add new contact screen.",
   "vexlOnlyContacts.emptyTitle": "Nothing to back up",
   "vexlOnlyContacts.emptyDescription": "Contacts that live only in Vexl — added manually or restored from a backup — will show up here. Have a backup file (.vcf)? Import it from the Add new contact screen.",
   "contactPreferences.importVcf.invalidFileTitle": "Couldn't read the file",

--- a/packages/localization/locales/es/contacts.json
+++ b/packages/localization/locales/es/contacts.json
@@ -84,6 +84,8 @@
   "vexlOnlyContacts.description": "Estos contactos están guardados solo en Vexl, no en tu teléfono — los añadiste manualmente o los restauraste desde una copia de seguridad. Expórtalos como archivo de contactos (.vcf) para tener una copia segura fuera de la app.",
   "vexlOnlyContacts.exportButton": "Exportar contactos",
   "vexlOnlyContacts.exportSheetTitle": "Guardar copia de estos contactos",
+  "vexlOnlyContacts.exportSuccessTitle": "¡Copia lista!",
+  "vexlOnlyContacts.exportSuccessDescription": "Tus contactos están guardados en un archivo de copia de seguridad (.vcf). Guárdalo en un sitio seguro — puedes recuperarlos cuando quieras desde la pantalla Añadir nuevo contacto.",
   "vexlOnlyContacts.emptyTitle": "Nada que guardar",
   "vexlOnlyContacts.emptyDescription": "Los contactos que solo existen en Vexl — añadidos manualmente o restaurados desde una copia de seguridad — aparecerán aquí. ¿Tienes un archivo de copia de seguridad (.vcf)? Impórtalo desde la pantalla Añadir nuevo contacto.",
   "contactPreferences.importVcf.invalidFileTitle": "No se pudo leer el archivo",

--- a/packages/localization/locales/fr/contacts.json
+++ b/packages/localization/locales/fr/contacts.json
@@ -84,6 +84,8 @@
   "vexlOnlyContacts.description": "Ces contacts sont enregistrés uniquement dans Vexl, pas sur ton téléphone — tu les as ajoutés manuellement ou restaurés depuis une sauvegarde. Exporte-les dans un fichier de contacts (.vcf) pour en garder une copie sûre en dehors de l'app.",
   "vexlOnlyContacts.exportButton": "Exporter les contacts",
   "vexlOnlyContacts.exportSheetTitle": "Sauvegarder ces contacts",
+  "vexlOnlyContacts.exportSuccessTitle": "Sauvegarde terminée !",
+  "vexlOnlyContacts.exportSuccessDescription": "Tes contacts sont enregistrés dans un fichier de sauvegarde (.vcf). Garde-le en lieu sûr — tu peux les récupérer à tout moment depuis l'écran Ajouter un nouveau contact.",
   "vexlOnlyContacts.emptyTitle": "Rien à sauvegarder",
   "vexlOnlyContacts.emptyDescription": "Les contacts qui n'existent que dans Vexl — ajoutés manuellement ou restaurés depuis une sauvegarde — apparaîtront ici. Tu as un fichier de sauvegarde (.vcf) ? Importe-le depuis l'écran Ajouter un nouveau contact.",
   "contactPreferences.importVcf.invalidFileTitle": "Impossible de lire le fichier",

--- a/packages/localization/locales/it/contacts.json
+++ b/packages/localization/locales/it/contacts.json
@@ -84,6 +84,8 @@
   "vexlOnlyContacts.description": "Questi contatti sono salvati solo in Vexl, non sul tuo telefono — li hai aggiunti manualmente o ripristinati da un backup. Esportali come file di contatti (.vcf) per conservarne una copia sicura fuori dall'app.",
   "vexlOnlyContacts.exportButton": "Esporta contatti",
   "vexlOnlyContacts.exportSheetTitle": "Fai il backup di questi contatti",
+  "vexlOnlyContacts.exportSuccessTitle": "Backup fatto!",
+  "vexlOnlyContacts.exportSuccessDescription": "I tuoi contatti sono salvati in un file di backup (.vcf). Tienilo al sicuro — puoi recuperarli quando vuoi dalla schermata Aggiungi nuovo contatto.",
   "vexlOnlyContacts.emptyTitle": "Niente da salvare",
   "vexlOnlyContacts.emptyDescription": "I contatti che esistono solo in Vexl — aggiunti manualmente o ripristinati da un backup — appariranno qui. Hai un file di backup (.vcf)? Importalo dalla schermata Aggiungi nuovo contatto.",
   "contactPreferences.importVcf.invalidFileTitle": "Impossibile leggere il file",

--- a/packages/localization/locales/ja/contacts.json
+++ b/packages/localization/locales/ja/contacts.json
@@ -84,6 +84,8 @@
   "vexlOnlyContacts.description": "これらの連絡先はVexlにのみ保存されており、スマホには保存されていません。手動で追加したか、バックアップから復元したものです。連絡先ファイル（.vcf）としてエクスポートして、アプリの外に安全なコピーを保管しましょう。",
   "vexlOnlyContacts.exportButton": "連絡先をエクスポート",
   "vexlOnlyContacts.exportSheetTitle": "これらの連絡先をバックアップ",
+  "vexlOnlyContacts.exportSuccessTitle": "バックアップ完了！",
+  "vexlOnlyContacts.exportSuccessDescription": "連絡先をバックアップファイル（.vcf）に保存しました。安全な場所に保管してください。「新しい連絡先を追加」画面からいつでも戻せます。",
   "vexlOnlyContacts.emptyTitle": "バックアップするものがありません",
   "vexlOnlyContacts.emptyDescription": "Vexlにのみ存在する連絡先（手動で追加、またはバックアップから復元したもの）がここに表示されます。バックアップファイル（.vcf）がある場合は、「新しい連絡先を追加」画面からインポートできます。",
   "contactPreferences.importVcf.invalidFileTitle": "ファイルを読み込めませんでした",

--- a/packages/localization/locales/nl/contacts.json
+++ b/packages/localization/locales/nl/contacts.json
@@ -84,6 +84,8 @@
   "vexlOnlyContacts.description": "Deze contacten zijn alleen in Vexl opgeslagen, niet op je telefoon — je hebt ze handmatig toegevoegd of hersteld uit een back-up. Exporteer ze als contactbestand (.vcf) om een veilige kopie buiten de app te bewaren.",
   "vexlOnlyContacts.exportButton": "Contacten exporteren",
   "vexlOnlyContacts.exportSheetTitle": "Maak een back-up van deze contacten",
+  "vexlOnlyContacts.exportSuccessTitle": "Back-up klaar!",
+  "vexlOnlyContacts.exportSuccessDescription": "Je contacten zijn opgeslagen in een back-upbestand (.vcf). Bewaar het op een veilige plek — je kunt ze altijd terughalen via het scherm Nieuw contact toevoegen.",
   "vexlOnlyContacts.emptyTitle": "Niets om te back-uppen",
   "vexlOnlyContacts.emptyDescription": "Contacten die alleen in Vexl bestaan — handmatig toegevoegd of hersteld uit een back-up — verschijnen hier. Heb je een back-upbestand (.vcf)? Importeer het via het scherm Nieuw contact toevoegen.",
   "contactPreferences.importVcf.invalidFileTitle": "Kan het bestand niet lezen",

--- a/packages/localization/locales/pl/contacts.json
+++ b/packages/localization/locales/pl/contacts.json
@@ -84,6 +84,8 @@
   "vexlOnlyContacts.description": "Te kontakty są zapisane tylko w Vexlu, nie w telefonie — zostały dodane ręcznie albo przywrócone z kopii zapasowej. Wyeksportuj je jako plik kontaktów (.vcf), aby mieć bezpieczną kopię poza aplikacją.",
   "vexlOnlyContacts.exportButton": "Eksportuj kontakty",
   "vexlOnlyContacts.exportSheetTitle": "Utwórz kopię zapasową tych kontaktów",
+  "vexlOnlyContacts.exportSuccessTitle": "Kopia gotowa!",
+  "vexlOnlyContacts.exportSuccessDescription": "Twoje kontakty są zapisane w pliku kopii zapasowej (.vcf). Trzymaj go w bezpiecznym miejscu — możesz je przywrócić w każdej chwili na ekranie Dodaj nowy kontakt.",
   "vexlOnlyContacts.emptyTitle": "Brak kontaktów do zapisania",
   "vexlOnlyContacts.emptyDescription": "Kontakty, które istnieją tylko w Vexlu — dodane ręcznie albo przywrócone z kopii zapasowej — pojawią się tutaj. Masz plik kopii zapasowej (.vcf)? Zaimportuj go na ekranie Dodaj nowy kontakt.",
   "contactPreferences.importVcf.invalidFileTitle": "Nie udało się odczytać pliku",

--- a/packages/localization/locales/pt/contacts.json
+++ b/packages/localization/locales/pt/contacts.json
@@ -84,6 +84,8 @@
   "vexlOnlyContacts.description": "Estes contactos estão guardados apenas no Vexl, não no teu telemóvel — adicionaste-os manualmente ou restauraste-os de um backup. Exporta-os como ficheiro de contactos (.vcf) para teres uma cópia segura fora da app.",
   "vexlOnlyContacts.exportButton": "Exportar contactos",
   "vexlOnlyContacts.exportSheetTitle": "Fazer backup destes contactos",
+  "vexlOnlyContacts.exportSuccessTitle": "Backup feito!",
+  "vexlOnlyContacts.exportSuccessDescription": "Os teus contactos estão guardados num ficheiro de backup (.vcf). Guarda-o num sítio seguro — podes trazê-los de volta a qualquer momento no ecrã Adicionar novo contacto.",
   "vexlOnlyContacts.emptyTitle": "Nada para guardar",
   "vexlOnlyContacts.emptyDescription": "Os contactos que só existem no Vexl — adicionados manualmente ou restaurados de um backup — vão aparecer aqui. Tens um ficheiro de backup (.vcf)? Importa-o no ecrã Adicionar novo contacto.",
   "contactPreferences.importVcf.invalidFileTitle": "Não foi possível ler o ficheiro",

--- a/packages/localization/locales/sk/contacts.json
+++ b/packages/localization/locales/sk/contacts.json
@@ -84,6 +84,8 @@
   "vexlOnlyContacts.description": "Tieto kontakty sú uložené len vo Vexli, nie v telefóne — boli pridané ručne alebo obnovené zo zálohy. Exportuj ich ako súbor kontaktov (.vcf), nech máš bezpečnú kópiu aj mimo aplikácie.",
   "vexlOnlyContacts.exportButton": "Exportovať kontakty",
   "vexlOnlyContacts.exportSheetTitle": "Zálohovať tieto kontakty",
+  "vexlOnlyContacts.exportSuccessTitle": "Záloha hotová!",
+  "vexlOnlyContacts.exportSuccessDescription": "Kontakty sú uložené v záložnom súbore (.vcf). Ulož si ho niekam do bezpečia — kedykoľvek ich môžeš vrátiť späť na obrazovke Pridať nový kontakt.",
   "vexlOnlyContacts.emptyTitle": "Nie je čo zálohovať",
   "vexlOnlyContacts.emptyDescription": "Kontakty, ktoré existujú len vo Vexli — pridané ručne alebo obnovené zo zálohy — sa zobrazia tu. Máš záložný súbor (.vcf)? Importuj ho na obrazovke Pridať nový kontakt.",
   "contactPreferences.importVcf.invalidFileTitle": "Súbor sa nepodarilo prečítať",

--- a/packages/localization/locales/sw/contacts.json
+++ b/packages/localization/locales/sw/contacts.json
@@ -84,6 +84,8 @@
   "vexlOnlyContacts.description": "Mawasiliano haya yamehifadhiwa kwenye Vexl pekee, si kwenye simu yako — uliyaongeza mwenyewe au kuyarejesha kutoka kwenye nakala rudufu. Yahamishe kama faili la mawasiliano (.vcf) ili uwe na nakala salama nje ya programu.",
   "vexlOnlyContacts.exportButton": "Hamisha mawasiliano",
   "vexlOnlyContacts.exportSheetTitle": "Hifadhi nakala ya mawasiliano haya",
+  "vexlOnlyContacts.exportSuccessTitle": "Nakala rudufu imekamilika!",
+  "vexlOnlyContacts.exportSuccessDescription": "Mawasiliano yako yamehifadhiwa kwenye faili la nakala rudufu (.vcf). Lihifadhi mahali salama — unaweza kuyarejesha wakati wowote kupitia skrini ya Ongeza mwasiliani mpya.",
   "vexlOnlyContacts.emptyTitle": "Hakuna cha kuhifadhi",
   "vexlOnlyContacts.emptyDescription": "Mawasiliano yaliyopo kwenye Vexl pekee — yaliyoongezwa mwenyewe au kurejeshwa kutoka kwenye nakala rudufu — yataonekana hapa. Una faili la nakala rudufu (.vcf)? Liingize kupitia skrini ya Ongeza mwasiliani mpya.",
   "contactPreferences.importVcf.invalidFileTitle": "Imeshindikana kusoma faili",

--- a/packages/localization/locales/zh/contacts.json
+++ b/packages/localization/locales/zh/contacts.json
@@ -84,6 +84,8 @@
   "vexlOnlyContacts.description": "这些联系人只保存在 Vexl 中，不在你的手机里——它们是你手动添加或从备份恢复的。将它们导出为联系人文件（.vcf），在应用之外保留一份安全副本。",
   "vexlOnlyContacts.exportButton": "导出联系人",
   "vexlOnlyContacts.exportSheetTitle": "备份这些联系人",
+  "vexlOnlyContacts.exportSuccessTitle": "备份完成！",
+  "vexlOnlyContacts.exportSuccessDescription": "你的联系人已存放在备份文件（.vcf）中。请把它保存在安全的地方——随时可以在「添加新联系人」页面恢复它们。",
   "vexlOnlyContacts.emptyTitle": "没有可备份的内容",
   "vexlOnlyContacts.emptyDescription": "只存在于 Vexl 中的联系人——手动添加或从备份恢复的——会显示在这里。有备份文件（.vcf）？可以在「添加新联系人」页面导入。",
   "contactPreferences.importVcf.invalidFileTitle": "无法读取文件",


### PR DESCRIPTION
Closes #2620.

- **No more JS-thread freeze on large `.vcf` files:** `importVexlOnlyContactsActionAtom` flattens parsed contacts into per-TEL entries and normalizes them in chunks of 50 with an animation-frame yield per chunk (the same pattern `normalizeStoredContactsActionAtom` uses — the chunk size is now a shared constant in `contactImportUtils.ts`). The `MAX_CONTACTS_PER_VCF_IMPORT` cap is checked before normalizing, and the loop stops entirely once it's reached, counting the remainder as skipped. The post-confirm hash+decode step is chunked the same way.
- **Dedupe against `storedContactsAtom`:** the existing-numbers set is built from every stored contact's `rawNumber` plus `normalizedNumber` when present, so importing while first normalization is still in flight can no longer persist duplicate rows.
- **Quoted-printable support (the nice-to-have):** `parseVcardString` recognizes `ENCODING=QUOTED-PRINTABLE` (incl. the bare vCard 2.1 form), joins QP soft line breaks, and decodes values as UTF-8 with a raw-value fallback on malformed input, so legacy Android vCard 2.1 exports with non-ASCII names import correctly. Covered by new unit tests, including a regression guard for literal `=` in non-QP cards.

## Test plan

Import the same `.vcf` twice: the first run should import, the second should report "nothing new". A vCard 2.1 file with QP-encoded diacritics in names should import them un-garbled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved contact imports by excluding duplicates, including contacts stored concurrently during the import flow.
  - Added support for quoted-printable encoded values in vCard files, including multiline and structured fields.
  - Added a success confirmation after exporting contacts, with guidance on restoring the `.vcf` backup.

- **Bug Fixes**
  - Improved resilience when reading malformed encoded vCard data.
  - Prevented malformed vCard lines from interfering with subsequent contact fields.

- **Chores**
  - Updated project ignore rules for generated Android build files.
  - Added translations for the contact export confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->