### PR TITLE
fix #2579: Remove iOS buildFromSource workaround for reanimated/worklets

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -156,15 +156,5 @@
     "typescript": "~6.0.3"
   },
   "prettier": "@vexl-next/prettier-config",
-  "expo": {
-    "autolinking": {
-      "ios": {
-        "buildFromSource": [
-          "react-native-reanimated",
-          "react-native-worklets"
-        ]
-      }
-    }
-  },
   "private": true
 }

--- a/packages/expo-background-notification-socket/.gitignore
+++ b/packages/expo-background-notification-socket/.gitignore
@@ -1,1 +1,2 @@
 /android/build/
+/android/.gradle/


### PR DESCRIPTION
Removes the `expo.autolinking.ios.buildFromSource` block from `apps/mobile/package.json` added in #2578 to work around the staging launch crash (`dyld: Library not loaded: @rpath/RNWorklets.framework/RNWorklets`).

Closes #2579 — both resolution conditions from the issue are now met:

1. **Upstream gate fixed**: expo/expo#47799 is closed as completed. The installed `expo-modules-autolinking` 57.0.10 no longer drops bare entries like `"RNWorklets"` in `prebuilt_dependency_pods`, and `resolve_prebuilt_status` propagates dependency unavailability — a prebuilt RNReanimated can no longer ship without a prebuilt RNWorklets (it falls back to source instead).
2. **Prebuilt artifacts exist** (HTTP 200 on Expo's CDN) for the exact installed triple: `react-native-worklets` 0.10.1 and `react-native-reanimated` 4.5.1 on RN 0.86.2 / Hermes 250829098.0.16.

Per the issue, the next staging IPA should be checked before release: `unzip -l app.ipa | grep Frameworks/` must show `RNWorklets.framework` whenever `RNReanimated.framework` is present, and the app must launch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated mobile app build configuration to use standard handling for selected native modules.
  * Improved project housekeeping by excluding generated Android build artifacts from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->