### PR TITLE
fix: correct club reach count and keep offer reach readable next to long club lists

### DIFF
--- a/apps/mobile/src/components/CRUDOfferFlow/index.tsx
+++ b/apps/mobile/src/components/CRUDOfferFlow/index.tsx
@@ -15,7 +15,6 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {getTokens, Stack, YStack} from 'tamagui'
 import {type RootStackScreenProps} from '../../navigationTypes'
 import {useTranslation} from '../../utils/localization/I18nProvider'
-import {formatInteger} from '../../utils/localization/formatting'
 import {formattingLocaleAtom} from '../../utils/localization/formattingLocaleAtom'
 import {getOfferExpirationLabel} from '../../utils/offerAmountDetails'
 import useSafeGoBack from '../../utils/useSafeGoBack'
@@ -35,6 +34,7 @@ import OfferTypeStep from './components/OfferTypeStep'
 import PriceUpToStep from './components/PriceUpToStep'
 import ProductCategoryStep from './components/ProductCategoryStep'
 import {type OfferSetupStep} from './offerSetupSteps'
+import {useFriendLevelLabels} from './useFriendLevelLabels'
 
 function CRUDOfferFlow(): React.ReactElement {
   const {t} = useTranslation()
@@ -54,7 +54,6 @@ function CRUDOfferFlow(): React.ReactElement {
   const offerType = useAtomValue(offerTypeAtom)
   const listingType = useAtomValue(listingTypeAtom)
   const expirationDate = useAtomValue(expirationDateAtom)
-  const intendedConnectionLevel = useAtomValue(intendedConnectionLevelAtom)
   const numberOfFriends = useAtomValue(numberOfFriendsAtom)
   const showDialog = useSetAtom(globalDialogAtom)
   const initializeValuesForOfferForm = useSetAtom(
@@ -117,32 +116,7 @@ function CRUDOfferFlow(): React.ReactElement {
       if (step === activeStep) scrollToActiveStep()
     }
 
-  const friendLevelReachLabel = (() => {
-    const friendLevelLabel =
-      intendedConnectionLevel === 'FIRST'
-        ? t('offerForm.friendLevel.firstDegree')
-        : t('offerForm.friendLevel.secondDegree')
-
-    if (numberOfFriends.state === 'loading') {
-      return `${friendLevelLabel} (${t('common.loading')})`
-    }
-
-    if (numberOfFriends.state === 'error') {
-      return `${friendLevelLabel} (${t('offerForm.friendLevel.noVexlers')})`
-    }
-
-    const reachCount =
-      intendedConnectionLevel === 'FIRST'
-        ? numberOfFriends.firstLevelFriendsCount
-        : numberOfFriends.firstAndSecondLevelFriendsCount
-
-    return `${friendLevelLabel} (${t(
-      'offerForm.friendLevel.reachPeopleInlineFormatted',
-      {
-        localizedString: formatInteger(reachCount, locale),
-      }
-    )})`
-  })()
+  const friendLevelLabels = useFriendLevelLabels()
   const areFriendLevelCountsLoading = numberOfFriends.state === 'loading'
   const expirationLabel = getOfferExpirationLabel({
     expirationDate,
@@ -368,8 +342,11 @@ function CRUDOfferFlow(): React.ReactElement {
                     <EditRow
                       state="completed"
                       overline={t('offerForm.whoCanSeeYourOffer')}
-                      headline={friendLevelReachLabel}
-                      subheadline={expirationLabel}
+                      headline={friendLevelLabels.headline}
+                      subheadline={[
+                        friendLevelLabels.reachLabel,
+                        expirationLabel,
+                      ]}
                       onPress={() => {
                         setActiveStep('friendLevel')
                       }}

--- a/apps/mobile/src/components/CRUDOfferFlow/useFriendLevelLabels.ts
+++ b/apps/mobile/src/components/CRUDOfferFlow/useFriendLevelLabels.ts
@@ -1,0 +1,40 @@
+import {useMolecule} from 'bunshi/dist/react'
+import {useAtomValue} from 'jotai'
+import {useTranslation} from '../../utils/localization/I18nProvider'
+import {formatInteger} from '../../utils/localization/formatting'
+import {formattingLocaleAtom} from '../../utils/localization/formattingLocaleAtom'
+import numberOfFriendsAtom from './atoms/numberOfFriendsAtom'
+import {offerFormMolecule} from './atoms/offerFormStateAtoms'
+
+export function useFriendLevelLabels(): {
+  headline: string
+  reachLabel: string
+} {
+  const {t} = useTranslation()
+  const locale = useAtomValue(formattingLocaleAtom)
+  const {intendedConnectionLevelAtom} = useMolecule(offerFormMolecule)
+  const intendedConnectionLevel = useAtomValue(intendedConnectionLevelAtom)
+  const numberOfFriends = useAtomValue(numberOfFriendsAtom)
+
+  const headline =
+    intendedConnectionLevel === 'FIRST'
+      ? t('offerForm.friendLevel.firstDegree')
+      : t('offerForm.friendLevel.secondDegree')
+
+  const reachLabel = (() => {
+    if (numberOfFriends.state === 'loading') return t('common.loading')
+    if (numberOfFriends.state === 'error')
+      return t('offerForm.friendLevel.noVexlers')
+
+    const reachCount =
+      intendedConnectionLevel === 'FIRST'
+        ? numberOfFriends.firstLevelFriendsCount
+        : numberOfFriends.firstAndSecondLevelFriendsCount
+
+    return t('offerForm.friendLevel.reachPeopleFormatted', {
+      localizedString: formatInteger(reachCount, locale),
+    })
+  })()
+
+  return {headline, reachLabel}
+}

--- a/apps/mobile/src/components/MyOfferDetailScreen/index.tsx
+++ b/apps/mobile/src/components/MyOfferDetailScreen/index.tsx
@@ -42,7 +42,6 @@ import {formatInteger} from '../../utils/localization/formatting'
 import {formattingLocaleAtom} from '../../utils/localization/formattingLocaleAtom'
 import {getOfferExpirationLabel} from '../../utils/offerAmountDetails'
 import useSafeGoBack from '../../utils/useSafeGoBack'
-import numberOfFriendsAtom from '../CRUDOfferFlow/atoms/numberOfFriendsAtom'
 import {offerFormMolecule} from '../CRUDOfferFlow/atoms/offerFormStateAtoms'
 import AmountStep from '../CRUDOfferFlow/components/AmountStep'
 import DescribeStep from '../CRUDOfferFlow/components/DescribeStep'
@@ -52,6 +51,7 @@ import NetworkStep from '../CRUDOfferFlow/components/NetworkStep'
 import PriceUpToStep from '../CRUDOfferFlow/components/PriceUpToStep'
 import ProductCategoryStep from '../CRUDOfferFlow/components/ProductCategoryStep'
 import {type EditableOfferField} from '../CRUDOfferFlow/offerSetupSteps'
+import {useFriendLevelLabels} from '../CRUDOfferFlow/useFriendLevelLabels'
 
 type Props = RootStackScreenProps<'MyOfferDetail'>
 
@@ -77,7 +77,6 @@ function MyOfferDetailScreen({
     showUnpublishedChangesDialogActionAtom,
     listingTypeAtom,
     offerTitleAtom,
-    intendedConnectionLevelAtom,
     expirationDateAtom,
     selectedClubsUuidsAtom,
   } = useMolecule(offerFormMolecule)
@@ -94,10 +93,8 @@ function MyOfferDetailScreen({
   )
   const listingType = useAtomValue(listingTypeAtom)
   const offerTitle = useAtomValue(offerTitleAtom)
-  const intendedConnectionLevel = useAtomValue(intendedConnectionLevelAtom)
   const expirationDate = useAtomValue(expirationDateAtom)
   const selectedClubsUuids = useAtomValue(selectedClubsUuidsAtom)
-  const numberOfFriends = useAtomValue(numberOfFriendsAtom)
   const selectedClubNames = useGetAllClubsNamesForIds(selectedClubsUuids)
   const allClubsWithMembers = useAtomValue(clubsWithMembersAtom)
   const isMissingProductCategory = useAtomValue(
@@ -142,42 +139,20 @@ function MyOfferDetailScreen({
     [navigation, offerId]
   )
 
-  const friendLevelHeadline = (() => {
-    const level = intendedConnectionLevel
-    const base =
-      level === 'FIRST'
-        ? t('offerForm.friendLevel.firstDegree')
-        : t('offerForm.friendLevel.secondDegree')
-    if (numberOfFriends.state !== 'success') return base
-    const reach =
-      level === 'FIRST'
-        ? numberOfFriends.firstLevelFriendsCount
-        : numberOfFriends.firstAndSecondLevelFriendsCount
-    return `${base} (${t('offerForm.friendLevel.reachPeopleInlineFormatted', {
-      localizedString: formatInteger(reach, locale),
-    })})`
-  })()
+  const friendLevelLabels = useFriendLevelLabels()
   const expirationLabel = getOfferExpirationLabel({
     expirationDate,
     locale,
     t,
   })
 
-  const clubsHeadline = (() => {
-    if (selectedClubNames.length === 0) return t('editOffer.noClubsSelected')
-    const reach = pipe(
-      allClubsWithMembers,
-      Array.filter((c) => selectedClubsUuids.includes(c.club.uuid)),
-      Array.map(getClubReach),
-      Number.sumAll
-    )
-    return `${selectedClubNames.join(', ')} (${t(
-      'offerForm.friendLevel.reachPeopleInlineFormatted',
-      {
-        localizedString: formatInteger(reach, locale),
-      }
-    )})`
-  })()
+  const hasSelectedClubs = Array.isNonEmptyArray(selectedClubNames)
+  const clubsReach = pipe(
+    allClubsWithMembers,
+    Array.filter((c) => selectedClubsUuids.includes(c.club.uuid)),
+    Array.map(getClubReach),
+    Number.sumAll
+  )
   if (Option.isNone(offerOption)) {
     return (
       <Screen
@@ -354,8 +329,8 @@ function MyOfferDetailScreen({
             state="completed"
             icon={PeopleUsers}
             overline={t('editOffer.detail.whoCanSeeYourOffer')}
-            headline={friendLevelHeadline}
-            subheadline={expirationLabel}
+            headline={friendLevelLabels.headline}
+            subheadline={[friendLevelLabels.reachLabel, expirationLabel]}
             onPress={() => {
               navigateToEdit('friendLevel')
             }}
@@ -365,7 +340,18 @@ function MyOfferDetailScreen({
               state="completed"
               icon={ConferenceClub}
               overline={t('editOffer.detail.publishToVexlClub')}
-              headline={clubsHeadline}
+              headline={
+                hasSelectedClubs
+                  ? selectedClubNames.join(', ')
+                  : t('editOffer.noClubsSelected')
+              }
+              subheadline={
+                hasSelectedClubs
+                  ? t('offerForm.friendLevel.reachPeopleFormatted', {
+                      localizedString: formatInteger(clubsReach, locale),
+                    })
+                  : undefined
+              }
               onPress={() => {
                 navigateToEdit('clubs')
               }}

--- a/apps/mobile/src/components/MyOfferDetailScreen/index.tsx
+++ b/apps/mobile/src/components/MyOfferDetailScreen/index.tsx
@@ -22,7 +22,7 @@ import {
   PinGeolocation,
 } from '@vexl-next/ui/src/icons'
 import {useMolecule} from 'bunshi/dist/react'
-import {Effect, Option} from 'effect'
+import {Array, Effect, Number, Option, pipe} from 'effect'
 import {useAtomValue, useSetAtom} from 'jotai'
 import React, {useCallback, useLayoutEffect, useMemo} from 'react'
 import {BackHandler} from 'react-native'
@@ -33,6 +33,7 @@ import {
   clubsWithMembersAtom,
   useGetAllClubsNamesForIds,
 } from '../../state/clubs/atom/clubsWithMembersAtom'
+import {getClubReach} from '../../state/clubs/utils'
 import {useSingleOffer} from '../../state/marketplace'
 import {isOfferMissingProductCategoryAtom} from '../../state/marketplace/atoms/offersState'
 import {isOfferExpired} from '../../utils/isOfferExpired'
@@ -164,9 +165,12 @@ function MyOfferDetailScreen({
 
   const clubsHeadline = (() => {
     if (selectedClubNames.length === 0) return t('editOffer.noClubsSelected')
-    const reach = allClubsWithMembers
-      .filter((c) => selectedClubsUuids.includes(c.club.uuid))
-      .reduce((sum, c) => sum + c.members.length, 0)
+    const reach = pipe(
+      allClubsWithMembers,
+      Array.filter((c) => selectedClubsUuids.includes(c.club.uuid)),
+      Array.map(getClubReach),
+      Number.sumAll
+    )
     return `${selectedClubNames.join(', ')} (${t(
       'offerForm.friendLevel.reachPeopleInlineFormatted',
       {

--- a/apps/mobile/src/state/clubs/utils.ts
+++ b/apps/mobile/src/state/clubs/utils.ts
@@ -99,3 +99,7 @@ export const fetchClubWithMembersReportApiErrors = ({
       return new FetchingClubError({cause: e})
     })
   )
+
+// Server lists the current user among club members, so they must be excluded from reach
+export const getClubReach = (club: ClubWithMembers): number =>
+  Math.max(0, club.members.length - 1)

--- a/apps/mobile/src/state/connections/atom/connectionStateAtom.ts
+++ b/apps/mobile/src/state/connections/atom/connectionStateAtom.ts
@@ -10,7 +10,7 @@ import {generateUuid} from '@vexl-next/domain/src/utility/Uuid.brand'
 import {FETCH_CONNECTIONS_PAGE_SIZE} from '@vexl-next/resources-utils/src/offers/utils/fetchContactsForOffer'
 import fetchAllPaginatedData from '@vexl-next/rest-api/src/fetchAllPaginatedData'
 import {type ContactApi} from '@vexl-next/rest-api/src/services/contact'
-import {Array, Effect, HashMap, Option} from 'effect'
+import {Array, Effect, HashMap, Number, Option} from 'effect'
 import {pipe} from 'fp-ts/function'
 import {atom, type Atom} from 'jotai'
 import {apiAtom} from '../../../api'
@@ -24,6 +24,7 @@ import {showDebugNotificationIfEnabled} from '../../../utils/notifications/showD
 import reportError, {reportErrorE} from '../../../utils/reportError'
 import {effectWithEnsuredBenchmark} from '../../ActionBenchmarks'
 import {clubsWithMembersAtom} from '../../clubs/atom/clubsWithMembersAtom'
+import {getClubReach} from '../../clubs/utils'
 import {ensureAndGetAllImportedContactsHaveServerToClientHashActionAtom} from '../../contacts/atom/ensureAndGetAllImportedContactsHaveServerToClientHashActionAtom'
 import {ConnectionsState} from '../domain'
 
@@ -253,11 +254,7 @@ export const fistAndSecondLevelConnectionsReachAtom = atom((get) => {
 })
 
 export const clubsConnectionsReachAtom = atom((get) => {
-  return pipe(
-    get(clubsWithMembersAtom),
-    Array.flatMap((club) => club.members),
-    Array.length
-  )
+  return pipe(get(clubsWithMembersAtom), Array.map(getClubReach), Number.sumAll)
 })
 
 export const reachNumberAtom = atom((get) => {

--- a/packages/localization/locales/ar/offers.json
+++ b/packages/localization/locales/ar/offers.json
@@ -204,8 +204,6 @@
   "offerForm.friendLevel.noVexlers": "No vexlers",
   "offerForm.friendLevel.noPeople": "لا يوجد أشخاص",
   "offerForm.friendLevel.reachVexlers": "Reach {{count}} vexlers",
-  "offerForm.friendLevel.reachPeopleInline": "تصل إلى {{count}} أشخاص",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "تصل إلى {{localizedString}} أشخاص",
   "offerForm.friendLevel.reachPeople": "تصل إلى {{count}} أشخاص",
   "offerForm.friendLevel.reachPeopleFormatted": "تصل إلى {{localizedString}} أشخاص",
   "offerForm.errorCreatingOffer": "Error while creating offer",

--- a/packages/localization/locales/bg/offers.json
+++ b/packages/localization/locales/bg/offers.json
@@ -206,8 +206,6 @@
   "offerForm.friendLevel.noVexlers": "Няма хора",
   "offerForm.friendLevel.noPeople": "Няма хора",
   "offerForm.friendLevel.reachVexlers": "Достигаш до {{count}} души",
-  "offerForm.friendLevel.reachPeopleInline": "достигаш до {{count}} души",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "достигаш до {{localizedString}} души",
   "offerForm.friendLevel.reachPeople": "Достигаш до {{count}} души",
   "offerForm.friendLevel.reachPeopleFormatted": "Достигаш до {{localizedString}} души",
   "offerForm.errorCreatingOffer": "Грешка при създаване на оферта",

--- a/packages/localization/locales/cs/offers.json
+++ b/packages/localization/locales/cs/offers.json
@@ -206,8 +206,6 @@
   "offerForm.friendLevel.noVexlers": "Žádní lidé",
   "offerForm.friendLevel.noPeople": "Žádní lidé",
   "offerForm.friendLevel.reachVexlers": "Oslovíš {{count}} lidí",
-  "offerForm.friendLevel.reachPeopleInline": "oslovíš {{count}} lidí",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "oslovíš {{localizedString}} lidí",
   "offerForm.friendLevel.reachPeople": "Oslovíš {{count}} lidí",
   "offerForm.friendLevel.reachPeopleFormatted": "Oslovíš {{localizedString}} lidí",
   "offerForm.errorCreatingOffer": "Chyba při vytváření nabídky",

--- a/packages/localization/locales/de/offers.json
+++ b/packages/localization/locales/de/offers.json
@@ -206,8 +206,6 @@
   "offerForm.friendLevel.noVexlers": "Keine Personen",
   "offerForm.friendLevel.noPeople": "Keine Personen",
   "offerForm.friendLevel.reachVexlers": "Du erreichst {{count}} Personen",
-  "offerForm.friendLevel.reachPeopleInline": "du erreichst {{count}} Personen",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "du erreichst {{localizedString}} Personen",
   "offerForm.friendLevel.reachPeople": "Du erreichst {{count}} Personen",
   "offerForm.friendLevel.reachPeopleFormatted": "Du erreichst {{localizedString}} Personen",
   "offerForm.errorCreatingOffer": "Fehler beim Erstellen des Angebots",

--- a/packages/localization/locales/en/offers.json
+++ b/packages/localization/locales/en/offers.json
@@ -206,8 +206,6 @@
   "offerForm.friendLevel.noVexlers": "No people",
   "offerForm.friendLevel.noPeople": "No people",
   "offerForm.friendLevel.reachVexlers": "Reach {{count}} people",
-  "offerForm.friendLevel.reachPeopleInline": "you reach {{count}} people",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "you reach {{localizedString}} people",
   "offerForm.friendLevel.reachPeople": "You reach {{count}} people",
   "offerForm.friendLevel.reachPeopleFormatted": "You reach {{localizedString}} people",
   "offerForm.errorCreatingOffer": "Error while creating offer",

--- a/packages/localization/locales/es/offers.json
+++ b/packages/localization/locales/es/offers.json
@@ -206,8 +206,6 @@
   "offerForm.friendLevel.noVexlers": "Nadie",
   "offerForm.friendLevel.noPeople": "Nadie",
   "offerForm.friendLevel.reachVexlers": "Llegas a {{count}} personas",
-  "offerForm.friendLevel.reachPeopleInline": "llegas a {{count}} personas",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "llegas a {{localizedString}} personas",
   "offerForm.friendLevel.reachPeople": "Llegas a {{count}} personas",
   "offerForm.friendLevel.reachPeopleFormatted": "Llegas a {{localizedString}} personas",
   "offerForm.errorCreatingOffer": "Error al crear oferta",

--- a/packages/localization/locales/fa/offers.json
+++ b/packages/localization/locales/fa/offers.json
@@ -204,8 +204,6 @@
   "offerForm.friendLevel.noVexlers": "No vexlers",
   "offerForm.friendLevel.noPeople": "هیچ‌کس",
   "offerForm.friendLevel.reachVexlers": "Reach {{count}} vexlers",
-  "offerForm.friendLevel.reachPeopleInline": "به {{count}} نفر می‌رسی",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "به {{localizedString}} نفر می‌رسی",
   "offerForm.friendLevel.reachPeople": "به {{count}} نفر می‌رسی",
   "offerForm.friendLevel.reachPeopleFormatted": "به {{localizedString}} نفر می‌رسی",
   "offerForm.errorCreatingOffer": "Error while creating offer",

--- a/packages/localization/locales/fi/offers.json
+++ b/packages/localization/locales/fi/offers.json
@@ -204,8 +204,6 @@
   "offerForm.friendLevel.noVexlers": "No vexlers",
   "offerForm.friendLevel.noPeople": "Ei ihmisiä",
   "offerForm.friendLevel.reachVexlers": "Reach {{count}} vexlers",
-  "offerForm.friendLevel.reachPeopleInline": "tavoitat {{count}} ihmistä",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "tavoitat {{localizedString}} ihmistä",
   "offerForm.friendLevel.reachPeople": "Tavoitat {{count}} ihmistä",
   "offerForm.friendLevel.reachPeopleFormatted": "Tavoitat {{localizedString}} ihmistä",
   "offerForm.errorCreatingOffer": "Error while creating offer",

--- a/packages/localization/locales/fr/offers.json
+++ b/packages/localization/locales/fr/offers.json
@@ -206,8 +206,6 @@
   "offerForm.friendLevel.noVexlers": "Personne",
   "offerForm.friendLevel.noPeople": "Personne",
   "offerForm.friendLevel.reachVexlers": "Toucher {{count}} personnes",
-  "offerForm.friendLevel.reachPeopleInline": "tu touches {{count}} personnes",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "tu touches {{localizedString}} personnes",
   "offerForm.friendLevel.reachPeople": "Tu touches {{count}} personnes",
   "offerForm.friendLevel.reachPeopleFormatted": "Tu touches {{localizedString}} personnes",
   "offerForm.errorCreatingOffer": "Erreur lors de la création de l'offre",

--- a/packages/localization/locales/id/offers.json
+++ b/packages/localization/locales/id/offers.json
@@ -204,8 +204,6 @@
   "offerForm.friendLevel.noVexlers": "No vexlers",
   "offerForm.friendLevel.noPeople": "Tidak ada orang",
   "offerForm.friendLevel.reachVexlers": "Reach {{count}} vexlers",
-  "offerForm.friendLevel.reachPeopleInline": "kamu menjangkau {{count}} orang",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "kamu menjangkau {{localizedString}} orang",
   "offerForm.friendLevel.reachPeople": "Kamu menjangkau {{count}} orang",
   "offerForm.friendLevel.reachPeopleFormatted": "Kamu menjangkau {{localizedString}} orang",
   "offerForm.errorCreatingOffer": "Error while creating offer",

--- a/packages/localization/locales/it/offers.json
+++ b/packages/localization/locales/it/offers.json
@@ -206,8 +206,6 @@
   "offerForm.friendLevel.noVexlers": "Nessuna persona",
   "offerForm.friendLevel.noPeople": "Nessuna persona",
   "offerForm.friendLevel.reachVexlers": "Raggiungi {{count}} persone",
-  "offerForm.friendLevel.reachPeopleInline": "raggiungi {{count}} persone",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "raggiungi {{localizedString}} persone",
   "offerForm.friendLevel.reachPeople": "Raggiungi {{count}} persone",
   "offerForm.friendLevel.reachPeopleFormatted": "Raggiungi {{localizedString}} persone",
   "offerForm.errorCreatingOffer": "Errore durante la creazione dell'offerta",

--- a/packages/localization/locales/ja/offers.json
+++ b/packages/localization/locales/ja/offers.json
@@ -206,8 +206,6 @@
   "offerForm.friendLevel.noVexlers": "Vexlユーザがいません",
   "offerForm.friendLevel.noPeople": "対象者なし",
   "offerForm.friendLevel.reachVexlers": "{{count}}人に届く",
-  "offerForm.friendLevel.reachPeopleInline": "{{count}}人に届く",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "{{localizedString}}人に届く",
   "offerForm.friendLevel.reachPeople": "{{count}}人に届く",
   "offerForm.friendLevel.reachPeopleFormatted": "{{localizedString}}人に届く",
   "offerForm.errorCreatingOffer": "オファーの作成中にエラーが発生しました",

--- a/packages/localization/locales/nl/offers.json
+++ b/packages/localization/locales/nl/offers.json
@@ -206,8 +206,6 @@
   "offerForm.friendLevel.noVexlers": "Geen mensen",
   "offerForm.friendLevel.noPeople": "Geen mensen",
   "offerForm.friendLevel.reachVexlers": "Bereik {{count}} mensen",
-  "offerForm.friendLevel.reachPeopleInline": "je bereikt {{count}} mensen",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "je bereikt {{localizedString}} mensen",
   "offerForm.friendLevel.reachPeople": "Je bereikt {{count}} mensen",
   "offerForm.friendLevel.reachPeopleFormatted": "Je bereikt {{localizedString}} mensen",
   "offerForm.errorCreatingOffer": "Fout bij het aanmaken aanbieding",

--- a/packages/localization/locales/no/offers.json
+++ b/packages/localization/locales/no/offers.json
@@ -204,8 +204,6 @@
   "offerForm.friendLevel.noVexlers": "No vexlers",
   "offerForm.friendLevel.noPeople": "Ingen personer",
   "offerForm.friendLevel.reachVexlers": "Reach {{count}} vexlers",
-  "offerForm.friendLevel.reachPeopleInline": "du når {{count}} personer",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "du når {{localizedString}} personer",
   "offerForm.friendLevel.reachPeople": "Du når {{count}} personer",
   "offerForm.friendLevel.reachPeopleFormatted": "Du når {{localizedString}} personer",
   "offerForm.errorCreatingOffer": "Error while creating offer",

--- a/packages/localization/locales/pcm/offers.json
+++ b/packages/localization/locales/pcm/offers.json
@@ -204,8 +204,6 @@
   "offerForm.friendLevel.noVexlers": "No vexlers",
   "offerForm.friendLevel.noPeople": "No people",
   "offerForm.friendLevel.reachVexlers": "Reach {{count}} vexlers",
-  "offerForm.friendLevel.reachPeopleInline": "you reach {{count}} people",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "you reach {{localizedString}} people",
   "offerForm.friendLevel.reachPeople": "You reach {{count}} people",
   "offerForm.friendLevel.reachPeopleFormatted": "You reach {{localizedString}} people",
   "offerForm.errorCreatingOffer": "Error while creating offer",

--- a/packages/localization/locales/pl/offers.json
+++ b/packages/localization/locales/pl/offers.json
@@ -206,8 +206,6 @@
   "offerForm.friendLevel.noVexlers": "Brak osób",
   "offerForm.friendLevel.noPeople": "Brak osób",
   "offerForm.friendLevel.reachVexlers": "Docierasz do {{count}} osób",
-  "offerForm.friendLevel.reachPeopleInline": "docierasz do {{count}} osób",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "docierasz do {{localizedString}} osób",
   "offerForm.friendLevel.reachPeople": "Docierasz do {{count}} osób",
   "offerForm.friendLevel.reachPeopleFormatted": "Docierasz do {{localizedString}} osób",
   "offerForm.errorCreatingOffer": "Błąd podczas tworzenia oferty",

--- a/packages/localization/locales/pt/offers.json
+++ b/packages/localization/locales/pt/offers.json
@@ -206,8 +206,6 @@
   "offerForm.friendLevel.noVexlers": "Sem pessoas",
   "offerForm.friendLevel.noPeople": "Sem pessoas",
   "offerForm.friendLevel.reachVexlers": "Alcançar {{count}} pessoas",
-  "offerForm.friendLevel.reachPeopleInline": "alcanças {{count}} pessoas",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "alcanças {{localizedString}} pessoas",
   "offerForm.friendLevel.reachPeople": "Alcanças {{count}} pessoas",
   "offerForm.friendLevel.reachPeopleFormatted": "Alcanças {{localizedString}} pessoas",
   "offerForm.errorCreatingOffer": "Erro ao criar a oferta",

--- a/packages/localization/locales/sk/offers.json
+++ b/packages/localization/locales/sk/offers.json
@@ -206,8 +206,6 @@
   "offerForm.friendLevel.noVexlers": "Žiadni ľudia",
   "offerForm.friendLevel.noPeople": "Žiadni ľudia",
   "offerForm.friendLevel.reachVexlers": "Dosah: {{count}} ľudí",
-  "offerForm.friendLevel.reachPeopleInline": "oslovíš {{count}} ľudí",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "oslovíš {{localizedString}} ľudí",
   "offerForm.friendLevel.reachPeople": "Oslovíš {{count}} ľudí",
   "offerForm.friendLevel.reachPeopleFormatted": "Oslovíš {{localizedString}} ľudí",
   "offerForm.errorCreatingOffer": "Chyba pri vytváraní ponuky",

--- a/packages/localization/locales/sv/offers.json
+++ b/packages/localization/locales/sv/offers.json
@@ -204,8 +204,6 @@
   "offerForm.friendLevel.noVexlers": "No vexlers",
   "offerForm.friendLevel.noPeople": "Inga personer",
   "offerForm.friendLevel.reachVexlers": "Reach {{count}} vexlers",
-  "offerForm.friendLevel.reachPeopleInline": "du når {{count}} personer",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "du når {{localizedString}} personer",
   "offerForm.friendLevel.reachPeople": "Du når {{count}} personer",
   "offerForm.friendLevel.reachPeopleFormatted": "Du når {{localizedString}} personer",
   "offerForm.errorCreatingOffer": "Error while creating offer",

--- a/packages/localization/locales/sw/offers.json
+++ b/packages/localization/locales/sw/offers.json
@@ -206,8 +206,6 @@
   "offerForm.friendLevel.noVexlers": "Hakuna watu",
   "offerForm.friendLevel.noPeople": "Hakuna watu",
   "offerForm.friendLevel.reachVexlers": "Fikia watu {{count}}",
-  "offerForm.friendLevel.reachPeopleInline": "unafikia watu {{count}}",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "unafikia watu {{localizedString}}",
   "offerForm.friendLevel.reachPeople": "Unafikia watu {{count}}",
   "offerForm.friendLevel.reachPeopleFormatted": "Unafikia watu {{localizedString}}",
   "offerForm.errorCreatingOffer": "Hitilafu wakati wa kuunda ofa",

--- a/packages/localization/locales/tr/offers.json
+++ b/packages/localization/locales/tr/offers.json
@@ -204,8 +204,6 @@
   "offerForm.friendLevel.noVexlers": "No vexlers",
   "offerForm.friendLevel.noPeople": "Kimse yok",
   "offerForm.friendLevel.reachVexlers": "Reach {{count}} vexlers",
-  "offerForm.friendLevel.reachPeopleInline": "{{count}} kişiye ulaşırsın",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "{{localizedString}} kişiye ulaşırsın",
   "offerForm.friendLevel.reachPeople": "{{count}} kişiye ulaşırsın",
   "offerForm.friendLevel.reachPeopleFormatted": "{{localizedString}} kişiye ulaşırsın",
   "offerForm.errorCreatingOffer": "Error while creating offer",

--- a/packages/localization/locales/uk/offers.json
+++ b/packages/localization/locales/uk/offers.json
@@ -204,8 +204,6 @@
   "offerForm.friendLevel.noVexlers": "No vexlers",
   "offerForm.friendLevel.noPeople": "Немає людей",
   "offerForm.friendLevel.reachVexlers": "Reach {{count}} vexlers",
-  "offerForm.friendLevel.reachPeopleInline": "ти охоплюєш {{count}} людей",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "ти охоплюєш {{localizedString}} людей",
   "offerForm.friendLevel.reachPeople": "Ти охоплюєш {{count}} людей",
   "offerForm.friendLevel.reachPeopleFormatted": "Ти охоплюєш {{localizedString}} людей",
   "offerForm.errorCreatingOffer": "Error while creating offer",

--- a/packages/localization/locales/zh/offers.json
+++ b/packages/localization/locales/zh/offers.json
@@ -206,8 +206,6 @@
   "offerForm.friendLevel.noVexlers": "没有人",
   "offerForm.friendLevel.noPeople": "没有人",
   "offerForm.friendLevel.reachVexlers": "触达 {{count}} 人",
-  "offerForm.friendLevel.reachPeopleInline": "你可以触达 {{count}} 人",
-  "offerForm.friendLevel.reachPeopleInlineFormatted": "你可以触达 {{localizedString}} 人",
   "offerForm.friendLevel.reachPeople": "你可以触达 {{count}} 人",
   "offerForm.friendLevel.reachPeopleFormatted": "你可以触达 {{localizedString}} 人",
   "offerForm.errorCreatingOffer": "创建报价时出错",

--- a/packages/ui/src/components/EditRow.tsx
+++ b/packages/ui/src/components/EditRow.tsx
@@ -1,3 +1,4 @@
+import {Array, pipe} from 'effect'
 import React from 'react'
 import {getTokens, styled, useTheme} from 'tamagui'
 
@@ -71,7 +72,7 @@ const OptionalTag = styled(XStack, {
 interface EditRowBaseProps {
   readonly headline: string
   readonly headlineSuffix?: string
-  readonly subheadline?: string
+  readonly subheadline?: string | readonly string[]
   readonly overline?: string
   readonly optionalLabel?: string
   readonly headlineColor?: TypographyProps['color']
@@ -197,6 +198,10 @@ export function EditRow({
     }
   })()
   const showLeadingIcon = isProfile || !isInitial || showInitialIcon
+  const subheadlines = pipe(
+    typeof subheadline === 'string' ? [subheadline] : (subheadline ?? []),
+    Array.filter((line) => line !== '')
+  )
 
   return (
     <EditRowFrame
@@ -211,7 +216,10 @@ export function EditRow({
           <IconBox tone={iconBoxTone}>{leadingIcon}</IconBox>
         )
       ) : null}
-      <YStack flex={1} gap={overline || subheadline ? '$2' : undefined}>
+      <YStack
+        flex={1}
+        gap={overline || subheadlines.length > 0 ? '$2' : undefined}
+      >
         {overline ? (
           <Typography
             variant="micro"
@@ -236,15 +244,16 @@ export function EditRow({
             {headline}
           </Typography>
         )}
-        {subheadline ? (
+        {subheadlines.map((line, i) => (
           <Typography
+            key={i}
             variant="micro"
             color="$foregroundPrimary"
             numberOfLines={1}
           >
-            {subheadline}
+            {line}
           </Typography>
-        ) : null}
+        ))}
       </YStack>
       {optionalLabel ? (
         <OptionalTag>

--- a/packages/ui/src/provider/useThemeMode.ts
+++ b/packages/ui/src/provider/useThemeMode.ts
@@ -1,5 +1,5 @@
 import {useCallback, useEffect, useMemo, useState} from 'react'
-import {useColorScheme} from 'react-native'
+import {Appearance, useColorScheme} from 'react-native'
 
 export type ThemeMode = 'light' | 'dark' | 'system'
 
@@ -19,6 +19,11 @@ export function useThemeMode(
   useEffect(() => {
     setMode(initialMode)
   }, [initialMode])
+
+  // Keeps native controls (e.g. iOS switch, alerts, keyboard) on the app theme
+  useEffect(() => {
+    Appearance.setColorScheme(mode === 'system' ? 'unspecified' : mode)
+  }, [mode])
 
   const resolvedTheme = useMemo(
     () =>


### PR DESCRIPTION
Three pieces of user feedback about the reach shown when publishing or editing an offer, plus a toggle visibility bug.

**Club reach counted the user themselves.** A club with 23 members showed a reach of 23, but one of those members is the user, so the offer can only reach 22 other people. The contact service returns the caller in the club member list, so the app now subtracts them. This applies to the clubs reach on the Clubs screen, the per-offer club reach, and the total reach number used for marketplace thresholds.

**Reach pushed long club lists off screen.** The reach was appended inline after the friend level label and after the list of selected clubs, so a long club list wrapped and the reach ended up truncated. The friend level and club names now stay in the headline and the reach is shown on its own line below in the smaller subheadline style, in both the offer creation flow and the offer detail screen.

**Toggle nearly invisible with device dark mode and app light mode.** Native controls like the iOS switch kept the device's dark style while the app rendered its light theme, so the switch track blended into the light background. The theme mode now sets the native color scheme to match the app theme and resets it when the app follows the system. This also makes device-scheme graphics, alerts and the keyboard follow the app theme.

Changes:
- `getClubReach` helper excludes the current user from a club's reach and is used by the clubs reach atom and the offer detail screen.
- `EditRow` accepts multiple subheadline lines.
- Friend level headline and reach label logic shared between the offer flow and the offer detail via `useFriendLevelLabels`.
- Removed the now unused inline reach translation keys from all locales.
- `useThemeMode` calls `Appearance.setColorScheme` whenever the mode changes.

| Before | After |
| --- | --- |
| `2. stupeň (oslovíš 330 ľudí)` / `Platí do 12.9.2026` | `2. stupeň` / `Oslovíš 330 ľudí` / `Platí do 12.9.2026` |
| `Club A, Club B, Club C, Club D (oslovíš …` | `Club A, Club B, Club C, Club D` / `Oslovíš 120 ľudí` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Offer forms and details now show friend-level headlines, reach counts, and expiration information as separate, clearly organized lines.
  - Club offer details display selected clubs alongside their calculated reachable-member count.
  - Friend reach messaging now reflects loading, unavailable, and formatted-count states.

- **UI Improvements**
  - Edit rows support multiple subheadline lines with consistent spacing and filtering of empty content.
  - The app’s appearance now stays synchronized with the selected light, dark, or system theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->