### PR TITLE
feat #2604: encrypt user MMKV data at rest with a session-derived key

### DIFF
--- a/apps/mobile/__mocks__/react-native-mmkv.ts
+++ b/apps/mobile/__mocks__/react-native-mmkv.ts
@@ -1,47 +1,54 @@
-type StoredValue = ArrayBuffer | boolean | number | string
+import {InMemoryMmkvStore} from '../src/utils/mmkv/mmkvStore'
 
-class MMKV {
-  private readonly data = new Map<string, StoredValue>()
-  private readonly listeners = new Set<(key: string) => void>()
+interface Configuration {
+  id?: string
+  encryptionKey?: string
+  encryptionType?: 'AES-128' | 'AES-256'
+  recoveryStrategy?: 'discard-on-error' | 'recover-on-error'
+  compareBeforeSet?: boolean
+}
 
-  set(key: string, value: StoredValue): void {
-    this.data.set(key, value)
-    this.emitChange(key)
-  }
+const DEFAULT_ID = 'mmkv.default'
 
-  getString(key: string): string | undefined {
-    const value = this.data.get(key)
-    return typeof value === 'string' ? value : undefined
-  }
+// Simulates the on-disk files: one entry per instance id, remembering which
+// key it was written with, and surviving across `createMMKV` calls the way
+// files survive across app launches.
+const files = new Map<
+  string,
+  {encryptionKey: string | undefined; store: MMKV}
+>()
 
-  getBoolean(key: string): boolean | undefined {
-    const value = this.data.get(key)
-    return typeof value === 'boolean' ? value : undefined
-  }
-
-  remove(key: string): void {
-    this.data.delete(key)
-    this.emitChange(key)
-  }
-
-  clearAll(): void {
-    this.data.clear()
-  }
-
-  getAllKeys(): string[] {
-    return Array.from(this.data.keys())
-  }
-
-  addOnValueChangedListener(listener: (key: string) => void): {
-    remove: () => void
-  } {
-    this.listeners.add(listener)
-    return {remove: () => this.listeners.delete(listener)}
-  }
-
-  private emitChange(key: string): void {
-    for (const listener of this.listeners) listener(key)
+class MMKV extends InMemoryMmkvStore {
+  constructor(
+    readonly id: string,
+    encryptionKey: string | undefined
+  ) {
+    super(encryptionKey !== undefined)
   }
 }
 
-export const createMMKV = (): MMKV => new MMKV()
+/** The unwrapped implementation, for tests that override `createMMKV` once. */
+export const createMockMMKV = (configuration?: Configuration): MMKV => {
+  const id = configuration?.id ?? DEFAULT_ID
+  const encryptionKey = configuration?.encryptionKey
+  const existing = files.get(id)
+  if (existing !== undefined && existing.encryptionKey === encryptionKey)
+    return existing.store
+
+  // A new file, or an existing file opened with the wrong key: real MMKV
+  // cannot decode the latter and, with recover-on-error, starts over empty.
+  const store = new MMKV(id, encryptionKey)
+  files.set(id, {encryptionKey, store})
+  return store
+}
+
+export const createMMKV = jest.fn(createMockMMKV)
+
+export const existsMMKV = jest.fn((id: string): boolean => files.has(id))
+
+export const deleteMMKV = jest.fn((id: string): boolean => files.delete(id))
+
+/** Test helper: forget every simulated file. */
+export const resetMockMmkvFiles = (): void => {
+  files.clear()
+}

--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -30,7 +30,6 @@ import {BACKGROUND_NOTIFICATION_HEADLESS_TASK} from '@vexl-next/expo-background-
 import {registerRootComponent} from 'expo'
 import {AppRegistry} from 'react-native'
 import App from './src/App'
-import {detectMmkvDataLoss} from './src/utils/mmkv/detectMmkvDataLoss'
 
 // polyfill Array.at() function
 if (![].at) {
@@ -45,9 +44,6 @@ if (![].toSorted) {
     return [...this].sort(...arg)
   }
 }
-
-// TODO: Temporary diagnostic for silent MMKV data wipes. Remove with the sentinel.
-detectMmkvDataLoss()
 
 AppRegistry.registerHeadlessTask(
   BACKGROUND_NOTIFICATION_HEADLESS_TASK,

--- a/apps/mobile/src/components/AppLogsScreen/utils/storage.ts
+++ b/apps/mobile/src/components/AppLogsScreen/utils/storage.ts
@@ -3,7 +3,7 @@
  * kept as a ring buffer capped at MAX_LOG_LINES lines (cached in memory so we
  * don't re-read and re-split the whole blob on every stored line).
  */
-import {storage} from '../../../utils/mmkv/effectMmkv'
+import {plaintextStorage} from '../../../utils/mmkv/effectMmkv'
 
 export const LOGS_KEY = 'logs'
 export const IS_CUSTOM_LOGGKING_ENABLED_KEY = 'logs_enabled'
@@ -14,18 +14,21 @@ let cachedLogLines: string[] | undefined
 
 function getLogLines(): string[] {
   if (cachedLogLines === undefined) {
-    const raw = storage._storage.getString(LOGS_KEY)
+    const raw = plaintextStorage._storage.getString(LOGS_KEY)
     cachedLogLines = raw ? raw.split('\n') : []
   }
   return cachedLogLines
 }
 
 export function setCustomLoggingEnabled(enabled: boolean): void {
-  storage._storage.set(IS_CUSTOM_LOGGKING_ENABLED_KEY, enabled)
+  plaintextStorage._storage.set(IS_CUSTOM_LOGGKING_ENABLED_KEY, enabled)
 }
 
 export function getCustomLoggingEnabled(): boolean {
-  return storage._storage.getBoolean(IS_CUSTOM_LOGGKING_ENABLED_KEY) ?? false
+  return (
+    plaintextStorage._storage.getBoolean(IS_CUSTOM_LOGGKING_ENABLED_KEY) ??
+    false
+  )
 }
 
 export function readLogs(): string[] {
@@ -33,24 +36,24 @@ export function readLogs(): string[] {
 }
 
 export function readLogsRaw(): string {
-  const logs = storage._storage.getString(LOGS_KEY)
+  const logs = plaintextStorage._storage.getString(LOGS_KEY)
   return logs !== undefined && logs !== '' ? logs : '[[NO LOGS YET]]'
 }
 
 export function storeLog(logMessage: string): void {
   cachedLogLines = [...getLogLines(), logMessage].slice(-MAX_LOG_LINES)
-  storage._storage.set(LOGS_KEY, cachedLogLines.join('\n'))
+  plaintextStorage._storage.set(LOGS_KEY, cachedLogLines.join('\n'))
 }
 
 export function clearLogs(): void {
   cachedLogLines = []
-  storage._storage.remove(LOGS_KEY)
+  plaintextStorage._storage.remove(LOGS_KEY)
 }
 
 export function listenOnAppLogs(
   listener: (logs: string[]) => void
 ): () => void {
-  return storage._storage.addOnValueChangedListener((key) => {
+  return plaintextStorage._storage.addOnValueChangedListener((key) => {
     if (key !== LOGS_KEY) return
     const logs = readLogs()
     listener(logs)

--- a/apps/mobile/src/components/FullscreenWarningScreen/state.tsx
+++ b/apps/mobile/src/components/FullscreenWarningScreen/state.tsx
@@ -7,7 +7,7 @@ import {Array, Effect, Option, Schema} from 'effect'
 import {pipe} from 'fp-ts/lib/function'
 import {atom} from 'jotai'
 import {apiAtom} from '../../api'
-import {atomWithParsedMmkvStorage} from '../../utils/atomUtils/atomWithParsedMmkvStorage'
+import {atomWithParsedPlaintextMmkvStorage} from '../../utils/atomUtils/atomWithParsedMmkvStorage'
 import {ignoreReportErrors} from '../../utils/reportError'
 
 const newsAndAnnouncementsAtom = atom<NewsAndAnnouncementsResponse | null>()
@@ -26,7 +26,7 @@ export const fullScreenWarningDataAtom = atom(
   }
 )
 
-const cancelledIdsMmkv = atomWithParsedMmkvStorage(
+const cancelledIdsMmkv = atomWithParsedPlaintextMmkvStorage(
   'cancelledIds',
   {ids: []},
   Schema.Struct({

--- a/apps/mobile/src/state/ActionBenchmarks.ts
+++ b/apps/mobile/src/state/ActionBenchmarks.ts
@@ -6,7 +6,7 @@ import {Array, Effect, Option, Record, Schema} from 'effect/index'
 import {pipe} from 'fp-ts/lib/function'
 import {atom, getDefaultStore} from 'jotai'
 import {focusAtom} from 'jotai-optics'
-import {atomWithParsedMmkvStorage} from '../utils/atomUtils/atomWithParsedMmkvStorage'
+import {atomWithParsedPlaintextMmkvStorage} from '../utils/atomUtils/atomWithParsedMmkvStorage'
 
 const BenchmarkRecord = Schema.Struct({
   startedAt: UnixMilliseconds,
@@ -21,7 +21,7 @@ const BenchmarkStorage = Schema.Struct({
   }),
 })
 
-const storageAtom = atomWithParsedMmkvStorage(
+const storageAtom = atomWithParsedPlaintextMmkvStorage(
   'actionsBenchmarks',
   {benchmarks: {}, enabled: false},
   BenchmarkStorage

--- a/apps/mobile/src/state/numberOfLoginAttemptsMmkvAtom.ts
+++ b/apps/mobile/src/state/numberOfLoginAttemptsMmkvAtom.ts
@@ -7,7 +7,7 @@ import {Array, Schema} from 'effect/index'
 import {atom} from 'jotai'
 import {focusAtom} from 'jotai-optics'
 import {DateTime} from 'luxon'
-import {atomWithParsedMmkvStorage} from '../utils/atomUtils/atomWithParsedMmkvStorage'
+import {atomWithParsedPlaintextMmkvStorage} from '../utils/atomUtils/atomWithParsedMmkvStorage'
 
 const CAN_LOGIN_AGAIN_AFTER_MILLIS = 1000 * 60 // 1 day
 
@@ -19,7 +19,7 @@ const LoginAttemptsDataStored = Schema.Struct({
 })
 type LoginAttemptsDataStored = typeof LoginAttemptsDataStored.Type
 
-const loginAttemptsPhoneNumbersMmkvAtom = atomWithParsedMmkvStorage(
+const loginAttemptsPhoneNumbersMmkvAtom = atomWithParsedPlaintextMmkvStorage(
   'numberOfLoginAttempts',
   {data: {phoneNumbers: [], timestamp: UnixMilliseconds0}},
   LoginAttemptsDataStored

--- a/apps/mobile/src/state/session/index.ts
+++ b/apps/mobile/src/state/session/index.ts
@@ -17,6 +17,10 @@ import {
   makeErrorJsonWithRemovedSensitiveData,
   makeErrorWithRemovedSensitiveData,
 } from '../../utils/errorSanitization'
+import {
+  bindUserMmkvStorage,
+  deleteUserMmkvStorage,
+} from '../../utils/mmkv/userMmkvStorage'
 import {replaceAll} from '../../utils/replaceAll'
 import {dummySession} from './dummySesssion'
 import {clearV2SecretWasWrittenFlag} from './utils/v2SecretStorageFlag'
@@ -117,6 +121,7 @@ export const sessionAtom: WritableAtom<
       void SecretStorage.deleteItemAsync(SECRET_TOKEN_KEY)
       void SecretStorage.deleteItemAsync(SECRET_TOKEN_KEY_V2)
       clearV2SecretWasWrittenFlag()
+      deleteUserMmkvStorage()
 
       set(sessionHolderAtom, {state: 'loggedOut'})
       return
@@ -125,6 +130,7 @@ export const sessionAtom: WritableAtom<
     console.info('🔑 Logging in user')
     // TODO we should show UI indication that we are saving the session and also show error if it fails
 
+    bindUserMmkvStorage(nextValue.value)
     set(sessionHolderAtom, {state: 'loggedIn', session: nextValue.value})
     Effect.runFork(
       writeSessionToStorage(nextValue.value).pipe(

--- a/apps/mobile/src/state/session/loadSession.test.ts
+++ b/apps/mobile/src/state/session/loadSession.test.ts
@@ -80,6 +80,12 @@ jest.mock('../../utils/reportError', () => {
 
 jest.mock('react-native-mmkv')
 
+// Runs after the user store is bound and reads AsyncStorage on its own; the
+// tests below count storage calls of the session load itself.
+jest.mock('../../utils/mmkv/detectMmkvDataLoss', () => ({
+  detectMmkvDataLoss: jest.fn(),
+}))
+
 jest.mock('../../utils/localization/I18nProvider', () => {
   const {atom: createAtom} = jest.requireActual('jotai')
 

--- a/apps/mobile/src/state/session/loadSession.ts
+++ b/apps/mobile/src/state/session/loadSession.ts
@@ -19,6 +19,8 @@ import {
   versionCode,
 } from '../../utils/environment'
 import {translationAtom} from '../../utils/localization/I18nProvider'
+import {detectMmkvDataLoss} from '../../utils/mmkv/detectMmkvDataLoss'
+import {bindUserMmkvStorage} from '../../utils/mmkv/userMmkvStorage'
 import {showDebugNotificationIfEnabled} from '../../utils/notifications/showDebugNotificationIfEnabled'
 import {isDeveloperAtom} from '../../utils/preferences'
 import {reportErrorE} from '../../utils/reportError'
@@ -262,6 +264,11 @@ function performSessionLoad(): Effect.Effect<LoadSessionResult> {
 
       return sessionNotLoadedResult(loadingError)
     }
+
+    // Atoms read user data only once the encrypted store is bound, so this
+    // must precede the V1 -> V2 upgrade and the logged-in state.
+    bindUserMmkvStorage(readSessionResult.right)
+    detectMmkvDataLoss()
 
     const session = yield* ensureV2SessionIfNotCreateAndWrite(
       readSessionResult.right

--- a/apps/mobile/src/state/session/utils/v2SecretStorageFlag.ts
+++ b/apps/mobile/src/state/session/utils/v2SecretStorageFlag.ts
@@ -1,10 +1,10 @@
-import {storage} from '../../../utils/mmkv/effectMmkv'
+import {plaintextStorage} from '../../../utils/mmkv/effectMmkv'
 
 export const V2_SECRET_WAS_WRITTEN_STORAGE_KEY = 'session:v2SecretWasWritten'
 
 export function markV2SecretAsWritten(): void {
   try {
-    storage._storage.set(V2_SECRET_WAS_WRITTEN_STORAGE_KEY, true)
+    plaintextStorage._storage.set(V2_SECRET_WAS_WRITTEN_STORAGE_KEY, true)
   } catch {
     // This marker is diagnostic only and must not block session persistence.
   }
@@ -12,7 +12,7 @@ export function markV2SecretAsWritten(): void {
 
 export function clearV2SecretWasWrittenFlag(): void {
   try {
-    storage._storage.remove(V2_SECRET_WAS_WRITTEN_STORAGE_KEY)
+    plaintextStorage._storage.remove(V2_SECRET_WAS_WRITTEN_STORAGE_KEY)
   } catch {
     // This marker is diagnostic only and must not block logout cleanup.
   }
@@ -21,7 +21,8 @@ export function clearV2SecretWasWrittenFlag(): void {
 export function wasV2SecretWritten(): boolean {
   try {
     return (
-      storage._storage.getBoolean(V2_SECRET_WAS_WRITTEN_STORAGE_KEY) ?? false
+      plaintextStorage._storage.getBoolean(V2_SECRET_WAS_WRITTEN_STORAGE_KEY) ??
+      false
     )
   } catch {
     return false

--- a/apps/mobile/src/utils/atomUtils/atomWithParsedMmkvStorage.ts
+++ b/apps/mobile/src/utils/atomUtils/atomWithParsedMmkvStorage.ts
@@ -6,8 +6,9 @@ import {
   type WritableAtom,
 } from 'jotai'
 import {isCriticalMmkvKey} from '../mmkv/criticalMmkvKeys'
-import {storage} from '../mmkv/effectMmkv'
+import {plaintextStorage, storage, type EffectMmkv} from '../mmkv/effectMmkv'
 import {recordCriticalMmkvKeyPersisted} from '../mmkv/mmkvDataLossDiagnosticStorage'
+import {type PlaintextMmkvKey} from '../mmkv/userMmkvStorage'
 import reportError from '../reportError'
 import runWhenIdleWithTimeout from '../runWhenIdleWithTimeout'
 import getValueFromSetStateActionOfAtom from './getValueFromSetStateActionOfAtom'
@@ -177,19 +178,24 @@ function reportStoredValueParseError(
   )
 }
 
-function readRawString(key: string): string | undefined {
+function readRawString(
+  effectMmkv: EffectMmkv,
+  key: string
+): string | undefined {
   try {
-    return storage._storage.getString(key) ?? undefined
+    return effectMmkv._storage.getString(key) ?? undefined
   } catch {
     return undefined
   }
 }
 
 function getInitialValue<A>({
+  effectMmkv,
   key,
   decodeRawValue,
   defaultValue,
 }: {
+  effectMmkv: EffectMmkv
   key: string
   decodeRawValue: (raw: string) => Either.Either<A, ParseResult.ParseError>
   defaultValue: A
@@ -197,7 +203,7 @@ function getInitialValue<A>({
   scheduleStartupReport()
 
   return pipe(
-    storage.get(key),
+    effectMmkv.get(key),
     Either.match({
       onLeft: (l): StoredRead<A> => {
         if (l._tag === 'ValueNotSet') {
@@ -274,17 +280,15 @@ export interface AtomWithParsedMmkvStorageWithImmediateSaveOption<A> {
  * below), so the field is no longer written. Blobs that still contain it
  * decode fine — effect Schema structs ignore excess properties by default.
  */
-export function atomWithParsedMmkvStorageWithImmediateSaveOption<
-  A,
-  I extends object,
->(
+function createPersistedAtom<A, I extends object>(
+  effectMmkv: EffectMmkv,
   key: string,
   defaultValue: A,
   schema: Schema.Schema<A, I, never>,
   debugLabel?: string
 ): AtomWithParsedMmkvStorageWithImmediateSaveOption<A> {
   const decodeRawValue = Schema.decodeEither(Schema.parseJson(schema))
-  const persistValue = storage.saveVerified(key, schema)
+  const persistValue = effectMmkv.saveVerified(key, schema)
   const recordSuccessfulPersist = (): void => {
     if (isCriticalMmkvKey(key)) {
       void recordCriticalMmkvKeyPersisted(key)
@@ -354,6 +358,7 @@ export function atomWithParsedMmkvStorageWithImmediateSaveOption<
   // raw string can be GCed) on first mount to avoid decoding the same blob
   // twice on startup.
   let initialRead: StoredRead<A> | undefined = getInitialValue({
+    effectMmkv,
     key,
     decodeRawValue,
     defaultValue,
@@ -398,13 +403,15 @@ export function atomWithParsedMmkvStorageWithImmediateSaveOption<
 
     if (
       cachedInitialRead === undefined ||
-      readRawString(key) !== cachedInitialRead.raw
+      readRawString(effectMmkv, key) !== cachedInitialRead.raw
     ) {
-      setAtom(getInitialValue({key, decodeRawValue, defaultValue}).value)
+      setAtom(
+        getInitialValue({effectMmkv, key, decodeRawValue, defaultValue}).value
+      )
     }
 
     changeListenerAttached = true
-    const listener = storage._storage.addOnValueChangedListener(
+    const listener = effectMmkv._storage.addOnValueChangedListener(
       (changedKey) => {
         if (changedKey === CLEAR_STORAGE_KEY) {
           console.info(`Setting MMKV atom with key '${key}' to default value`)
@@ -423,7 +430,7 @@ export function atomWithParsedMmkvStorageWithImmediateSaveOption<
         runWhenIdleWithTimeout(
           () => {
             pipe(
-              storage.getVerified(key, schema),
+              effectMmkv.getVerified(key, schema),
               Either.match({
                 onLeft: (e) => {
                   if (e._tag === 'ValueNotSet') {
@@ -433,7 +440,7 @@ export function atomWithParsedMmkvStorageWithImmediateSaveOption<
                     setAtom(defaultValue)
                     return
                   }
-                  const raw = readRawString(key)
+                  const raw = readRawString(effectMmkv, key)
                   reportStoredValueParseError(
                     key,
                     `Error while parsing stored mmkv value in onChange function. Key: '${key}'`,
@@ -502,18 +509,41 @@ export function atomWithParsedMmkvStorageWithImmediateSaveOption<
   return {atom: flushableAtom, setAndSaveImmediatelyAtom}
 }
 
+export function atomWithParsedMmkvStorageWithImmediateSaveOption<
+  A,
+  I extends object,
+>(
+  key: string,
+  defaultValue: A,
+  schema: Schema.Schema<A, I, never>,
+  debugLabel?: string
+): AtomWithParsedMmkvStorageWithImmediateSaveOption<A> {
+  return createPersistedAtom(storage, key, defaultValue, schema, debugLabel)
+}
+
+/** Persisted in the logged-in user's encrypted store. */
 export function atomWithParsedMmkvStorage<A, I extends object>(
   key: string,
   defaultValue: A,
   schema: Schema.Schema<A, I, never>,
   debugLabel?: string
 ): FlushablePrimitiveAtom<A> {
-  const storageAtom = atomWithParsedMmkvStorageWithImmediateSaveOption(
+  return createPersistedAtom(storage, key, defaultValue, schema, debugLabel)
+    .atom
+}
+
+/** Persisted in the plaintext store that is readable before login. */
+export function atomWithParsedPlaintextMmkvStorage<A, I extends object>(
+  key: PlaintextMmkvKey,
+  defaultValue: A,
+  schema: Schema.Schema<A, I, never>,
+  debugLabel?: string
+): FlushablePrimitiveAtom<A> {
+  return createPersistedAtom(
+    plaintextStorage,
     key,
     defaultValue,
     schema,
     debugLabel
-  )
-
-  return storageAtom.atom
+  ).atom
 }

--- a/apps/mobile/src/utils/clearMmkvStorageAndEmptyAtoms.ts
+++ b/apps/mobile/src/utils/clearMmkvStorageAndEmptyAtoms.ts
@@ -2,18 +2,22 @@ import {
   beginMmkvStorageClear,
   CLEAR_STORAGE_KEY,
 } from './atomUtils/atomWithParsedMmkvStorage'
-import {storage} from './mmkv/effectMmkv'
+import {plaintextStorage, storage} from './mmkv/effectMmkv'
 import {clearMmkvDataLossDiagnostics} from './mmkv/mmkvDataLossDiagnosticStorage'
+import {deleteUserMmkvStorage} from './mmkv/userMmkvStorage'
 
 export default async function clearMmkvStorageAndEmptyAtoms(): Promise<void> {
   // set all atoms to defaultValue
-  storage._storage.set(CLEAR_STORAGE_KEY, Date.now().toString())
+  const clearedAt = Date.now().toString()
+  storage._storage.set(CLEAR_STORAGE_KEY, clearedAt)
+  plaintextStorage._storage.set(CLEAR_STORAGE_KEY, clearedAt)
 
   const finishStorageClear = beginMmkvStorageClear()
 
   try {
     await clearMmkvDataLossDiagnostics(() => {
-      storage._storage.clearAll()
+      plaintextStorage._storage.clearAll()
+      deleteUserMmkvStorage()
     })
   } finally {
     finishStorageClear()

--- a/apps/mobile/src/utils/deepLinks/index.ts
+++ b/apps/mobile/src/utils/deepLinks/index.ts
@@ -7,7 +7,7 @@ import {Alert} from 'react-native'
 import {showErrorAlert} from '../../components/ErrorAlert'
 import {admitUserToClubActionAtom} from '../../state/clubs/atom/admitUserToClubActionAtom'
 import {submitCodeToJoinClubActionAtom} from '../../state/clubs/atom/submitCodeToJoinClubActionAtom'
-import {atomWithParsedMmkvStorage} from '../atomUtils/atomWithParsedMmkvStorage'
+import {atomWithParsedPlaintextMmkvStorage} from '../atomUtils/atomWithParsedMmkvStorage'
 import {translationAtom} from '../localization/I18nProvider'
 import {
   isOnSpecificChat,
@@ -27,17 +27,20 @@ import {
   parseDeepLink,
 } from './parseDeepLink'
 
-export const lastInitialLinkStorageAtom = atomWithParsedMmkvStorage(
+export const lastInitialLinkStorageAtom = atomWithParsedPlaintextMmkvStorage(
   'lastInitialLink',
   {lastLinkImported: null},
   Schema.Struct({lastLinkImported: Schema.NullOr(Schema.String)})
 )
 
-export const lastUniversalOrAppLinkStorageAtom = atomWithParsedMmkvStorage(
-  'lastUniversalOrAppLink',
-  {lastUniversalOrAppLinkImported: null},
-  Schema.Struct({lastUniversalOrAppLinkImported: Schema.NullOr(Schema.String)})
-)
+export const lastUniversalOrAppLinkStorageAtom =
+  atomWithParsedPlaintextMmkvStorage(
+    'lastUniversalOrAppLink',
+    {lastUniversalOrAppLinkImported: null},
+    Schema.Struct({
+      lastUniversalOrAppLinkImported: Schema.NullOr(Schema.String),
+    })
+  )
 
 export class InvalidDeepLinkTypeError extends Schema.TaggedError<InvalidDeepLinkTypeError>(
   'InvalidDeepLinkTypeError'

--- a/apps/mobile/src/utils/mmkv/criticalMmkvKeys.ts
+++ b/apps/mobile/src/utils/mmkv/criticalMmkvKeys.ts
@@ -1,5 +1,5 @@
 import {Array, Schema, pipe} from 'effect'
-import {type MMKV} from 'react-native-mmkv'
+import {type MmkvStore} from './mmkvStore'
 
 export const STORED_CLUBS_V2_MMKV_KEY = 'storedClubsV2'
 export const FCM_CYPHER_TO_KEY_HOLDER_MMKV_KEY = 'fcmCypherToKeyHolder'
@@ -44,7 +44,9 @@ export function isCriticalMmkvKey(key: string): key is CriticalMmkvKey {
   return pipe(CRITICAL_MMKV_KEYS, Array.contains(key))
 }
 
-export function getPresentCriticalMmkvKeys(mmkv: MMKV): CriticalMmkvKey[] {
+export function getPresentCriticalMmkvKeys(
+  mmkv: Pick<MmkvStore, 'getAllKeys'>
+): CriticalMmkvKey[] {
   const allKeys = mmkv.getAllKeys()
   return pipe(
     CRITICAL_MMKV_KEYS,

--- a/apps/mobile/src/utils/mmkv/detectMmkvDataLoss.ts
+++ b/apps/mobile/src/utils/mmkv/detectMmkvDataLoss.ts
@@ -1,5 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import {Array, Either, Schema, pipe} from 'effect'
+import {Array, Either, pipe, Schema} from 'effect'
 import {File, Paths} from 'expo-file-system'
 import {AppState} from 'react-native'
 import reportError from '../reportError'
@@ -9,7 +9,7 @@ import {
   getPresentCriticalMmkvKeys,
   type CriticalMmkvKey,
 } from './criticalMmkvKeys'
-import {storage} from './effectMmkv'
+import {storage, USER_MMKV_ID} from './effectMmkv'
 import {
   ASYNC_SENTINEL_KEY,
   runMmkvDataLossDiagnosticOperation,
@@ -31,8 +31,8 @@ function getMmkvFilesDiagnostics(): Record<string, unknown> {
   const docDir = Paths.document
   if (!docDir) return {error: 'no document directory'}
 
-  const dataFile = new File(docDir, 'mmkv/mmkv.default')
-  const crcFile = new File(docDir, 'mmkv/mmkv.default.crc')
+  const dataFile = new File(docDir, `mmkv/${USER_MMKV_ID}`)
+  const crcFile = new File(docDir, `mmkv/${USER_MMKV_ID}.crc`)
 
   return {
     dataFileExists: dataFile.exists,

--- a/apps/mobile/src/utils/mmkv/effectMmkv.ts
+++ b/apps/mobile/src/utils/mmkv/effectMmkv.ts
@@ -1,10 +1,12 @@
 import {Either, flow, Schema, type ParseResult} from 'effect'
-import {createMMKV, type MMKV} from 'react-native-mmkv'
+import {createMMKV} from 'react-native-mmkv'
 import {JsonParseError, JsonStringifyError} from '../fpUtils'
 import {ReadingFromStoreError, ValueNotSet, WritingToStoreError} from './domain'
+import {type MmkvStore} from './mmkvStore'
+import {SessionBoundMmkvStore} from './sessionBoundMmkvStore'
 
 export interface EffectMmkv {
-  _storage: MMKV
+  _storage: MmkvStore
   set: (
     key: string
   ) => (value: string) => Either.Either<void, WritingToStoreError>
@@ -43,7 +45,7 @@ export interface EffectMmkv {
   ) => Either.Either<void, WritingToStoreError | ParseResult.ParseError>
 }
 
-function createEffectMmkv(storage: MMKV): EffectMmkv {
+function createEffectMmkv(storage: MmkvStore): EffectMmkv {
   function set(key: string): ReturnType<EffectMmkv['set']> {
     return (value) =>
       Either.try({
@@ -112,13 +114,28 @@ function createEffectMmkv(storage: MMKV): EffectMmkv {
   }
 }
 
-const mmkv = createMMKV({
-  id: 'mmkv.default',
-  recoveryStrategy: 'recover-on-error',
-  compareBeforeSet: true,
-})
+export const USER_MMKV_ID = 'mmkv.user'
+
+/**
+ * Readable before anyone is logged in. Only keys listed in `PlaintextMmkvKey`
+ * (see `userMmkvStorage.ts`) may live here.
+ */
+export const plaintextStorage = createEffectMmkv(
+  createMMKV({
+    id: 'mmkv.default',
+    recoveryStrategy: 'recover-on-error',
+    compareBeforeSet: true,
+  })
+)
+
+/**
+ * Bound to the logged-in user's AES-256 encrypted MMKV instance by
+ * `bindUserMmkvStorage` (see `userMmkvStorage.ts`). Before that it is a
+ * volatile placeholder.
+ */
+export const userMmkvStore = new SessionBoundMmkvStore()
 if (__DEV__) {
   // @ts-expect-error for debugging purposes
-  window.__mmkv = mmkv
+  window.__mmkv = userMmkvStore
 }
-export const storage = createEffectMmkv(mmkv)
+export const storage = createEffectMmkv(userMmkvStore)

--- a/apps/mobile/src/utils/mmkv/mmkvStore.ts
+++ b/apps/mobile/src/utils/mmkv/mmkvStore.ts
@@ -1,0 +1,94 @@
+import {Array} from 'effect'
+import {type MMKV} from 'react-native-mmkv'
+
+/**
+ * The subset of the native MMKV API the app relies on. Narrower than `MMKV`
+ * so a non-native store can stand in before the user's encrypted store is
+ * bound (see `sessionBoundMmkvStore.ts`).
+ */
+export type MmkvStore = Pick<
+  MMKV,
+  | 'set'
+  | 'getString'
+  | 'getBoolean'
+  | 'contains'
+  | 'remove'
+  | 'getAllKeys'
+  | 'clearAll'
+  | 'addOnValueChangedListener'
+  | 'length'
+  | 'isEncrypted'
+>
+
+type MmkvStoredValue = boolean | string
+
+/** Strings and booleans are the only value types the app stores. */
+export function copyMmkvEntries(
+  from: MmkvStore,
+  to: MmkvStore,
+  keys: readonly string[]
+): void {
+  for (const key of keys) {
+    const value = from.getString(key) ?? from.getBoolean(key)
+    if (value !== undefined) to.set(key, value)
+  }
+}
+
+export class InMemoryMmkvStore implements MmkvStore {
+  private readonly values = new Map<string, MmkvStoredValue>()
+  private readonly listeners = new Set<(key: string) => void>()
+
+  constructor(readonly isEncrypted: boolean = false) {}
+
+  get length(): number {
+    return this.values.size
+  }
+
+  set(key: string, value: MmkvStoredValue): void {
+    this.values.set(key, value)
+    this.notify(key)
+  }
+
+  getString(key: string): string | undefined {
+    const value = this.values.get(key)
+    return typeof value === 'string' ? value : undefined
+  }
+
+  getBoolean(key: string): boolean | undefined {
+    const value = this.values.get(key)
+    return typeof value === 'boolean' ? value : undefined
+  }
+
+  contains(key: string): boolean {
+    return this.values.has(key)
+  }
+
+  remove(key: string): boolean {
+    const removed = this.values.delete(key)
+    if (removed) this.notify(key)
+    return removed
+  }
+
+  getAllKeys(): string[] {
+    return Array.fromIterable(this.values.keys())
+  }
+
+  clearAll(): void {
+    this.values.clear()
+  }
+
+  addOnValueChangedListener(listener: (key: string) => void): {
+    remove: () => void
+  } {
+    this.listeners.add(listener)
+    return {
+      remove: () => {
+        this.listeners.delete(listener)
+      },
+    }
+  }
+
+  private notify(key: string): void {
+    for (const listener of this.listeners) listener(key)
+  }
+}

--- a/apps/mobile/src/utils/mmkv/sessionBoundMmkvStore.ts
+++ b/apps/mobile/src/utils/mmkv/sessionBoundMmkvStore.ts
@@ -1,0 +1,89 @@
+import {copyMmkvEntries, InMemoryMmkvStore, type MmkvStore} from './mmkvStore'
+
+/**
+ * The store all user-data atoms read through. Until a session is known it
+ * delegates to a volatile in-memory store, so atoms created at import time
+ * simply see defaults. `bind` switches it to the user's encrypted store and
+ * notifies every listener for each stored key, which makes mounted atoms
+ * re-read their values.
+ */
+export class SessionBoundMmkvStore implements MmkvStore {
+  private target: MmkvStore = new InMemoryMmkvStore()
+  private targetSubscription: {remove: () => void} | undefined
+  private readonly listeners = new Set<(key: string) => void>()
+
+  constructor() {
+    this.attach(this.target)
+  }
+
+  get isEncrypted(): boolean {
+    return this.target.isEncrypted
+  }
+
+  get length(): number {
+    return this.target.length
+  }
+
+  bind(store: MmkvStore): void {
+    // Writes made before the session was known (e.g. by the login flow)
+    // belong to the user that is being bound.
+    copyMmkvEntries(this.target, store, this.target.getAllKeys())
+    this.attach(store)
+    for (const key of store.getAllKeys()) this.notify(key)
+  }
+
+  unbind(): void {
+    this.attach(new InMemoryMmkvStore())
+  }
+
+  set(key: string, value: Parameters<MmkvStore['set']>[1]): void {
+    this.target.set(key, value)
+  }
+
+  getString(key: string): string | undefined {
+    return this.target.getString(key)
+  }
+
+  getBoolean(key: string): boolean | undefined {
+    return this.target.getBoolean(key)
+  }
+
+  contains(key: string): boolean {
+    return this.target.contains(key)
+  }
+
+  remove(key: string): boolean {
+    return this.target.remove(key)
+  }
+
+  getAllKeys(): string[] {
+    return this.target.getAllKeys()
+  }
+
+  clearAll(): void {
+    this.target.clearAll()
+  }
+
+  addOnValueChangedListener(listener: (key: string) => void): {
+    remove: () => void
+  } {
+    this.listeners.add(listener)
+    return {
+      remove: () => {
+        this.listeners.delete(listener)
+      },
+    }
+  }
+
+  private attach(store: MmkvStore): void {
+    this.targetSubscription?.remove()
+    this.target = store
+    this.targetSubscription = store.addOnValueChangedListener((key) => {
+      this.notify(key)
+    })
+  }
+
+  private notify(key: string): void {
+    for (const listener of this.listeners) listener(key)
+  }
+}

--- a/apps/mobile/src/utils/mmkv/userMmkvStorage.test.ts
+++ b/apps/mobile/src/utils/mmkv/userMmkvStorage.test.ts
@@ -1,0 +1,149 @@
+import {KeyHolder} from '@vexl-next/cryptography'
+import {Schema} from 'effect'
+import {createMMKV} from 'react-native-mmkv'
+import {plaintextStorage, storage, USER_MMKV_ID} from './effectMmkv'
+import {InMemoryMmkvStore} from './mmkvStore'
+import {SessionBoundMmkvStore} from './sessionBoundMmkvStore'
+import {bindUserMmkvStorage, deleteUserMmkvStorage} from './userMmkvStorage'
+
+jest.mock('react-native-mmkv')
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => undefined),
+    removeItem: jest.fn(async () => undefined),
+  },
+}))
+
+const decodeKeyHolder = Schema.decodeUnknownSync(KeyHolder.PrivateKeyHolder)
+const sessionA = {
+  privateKey: decodeKeyHolder({
+    privateKeyPemBase64: 'private-key-a',
+    publicKeyPemBase64: 'public-key-a',
+  }),
+}
+const sessionB = {
+  privateKey: decodeKeyHolder({
+    privateKeyPemBase64: 'private-key-b',
+    publicKeyPemBase64: 'public-key-b',
+  }),
+}
+
+const mockedCreateMMKV = jest.mocked(createMMKV)
+
+beforeEach(() => {
+  deleteUserMmkvStorage()
+  plaintextStorage._storage.clearAll()
+  jest.clearAllMocks()
+})
+
+describe('bindUserMmkvStorage', () => {
+  it('opens an AES-256 store whose key is derived from the session', () => {
+    bindUserMmkvStorage(sessionA)
+
+    expect(mockedCreateMMKV).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: USER_MMKV_ID,
+        encryptionType: 'AES-256',
+        encryptionKey: expect.stringMatching(/^[A-Za-z0-9+/]{32}$/),
+      })
+    )
+    expect(storage._storage.isEncrypted).toBe(true)
+  })
+
+  it('is a no-op when the same session is already bound', () => {
+    bindUserMmkvStorage(sessionA)
+    bindUserMmkvStorage(sessionA)
+    expect(mockedCreateMMKV).toHaveBeenCalledTimes(1)
+  })
+
+  it('derives the same key for the same session across launches', () => {
+    bindUserMmkvStorage(sessionA)
+    storage._storage.set('chats', 'value')
+    const firstKey = mockedCreateMMKV.mock.calls[0]?.[0]?.encryptionKey
+
+    // Fresh JS state, files still on disk.
+    storage._storage.set('chats', 'value')
+    bindUserMmkvStorage(sessionB)
+    bindUserMmkvStorage(sessionA)
+
+    expect(mockedCreateMMKV.mock.calls.at(-1)?.[0]?.encryptionKey).toBe(
+      firstKey
+    )
+  })
+
+  it('does not expose one user data to another session', () => {
+    bindUserMmkvStorage(sessionA)
+    storage._storage.set('chats', 'a-chats')
+
+    bindUserMmkvStorage(sessionB)
+    expect(storage._storage.getString('chats')).toBeUndefined()
+  })
+
+  it('keeps writes made before the session was known', () => {
+    storage._storage.set('marketplaceReadyNotification', 'pending')
+
+    bindUserMmkvStorage(sessionA)
+    expect(storage._storage.getString('marketplaceReadyNotification')).toBe(
+      'pending'
+    )
+  })
+
+  it('notifies listeners for every stored key so mounted atoms re-read', () => {
+    const onDisk = new InMemoryMmkvStore(true)
+    onDisk.set('offers', 'value')
+    const proxy = new SessionBoundMmkvStore()
+    const listener = jest.fn()
+    proxy.addOnValueChangedListener(listener)
+
+    proxy.bind(onDisk)
+
+    expect(listener).toHaveBeenCalledWith('offers')
+    expect(proxy.getString('offers')).toBe('value')
+  })
+
+  describe('migration from the plaintext store', () => {
+    it('moves user entries and leaves pre-login entries in place', () => {
+      plaintextStorage._storage.set('preferences', '{"isDeveloper":true}')
+      plaintextStorage._storage.set('storedContacts', '[1,2]')
+      plaintextStorage._storage.set('session:v2SecretWasWritten', true)
+      plaintextStorage._storage.set('hideForMessage-1', true)
+
+      bindUserMmkvStorage(sessionA)
+
+      expect(storage._storage.getString('storedContacts')).toBe('[1,2]')
+      expect(storage._storage.getBoolean('hideForMessage-1')).toBe(true)
+      expect(storage._storage.contains('preferences')).toBe(false)
+      expect(plaintextStorage._storage.getAllKeys().sort()).toEqual([
+        'preferences',
+        'session:v2SecretWasWritten',
+      ])
+    })
+
+    it('runs only once', () => {
+      plaintextStorage._storage.set('storedContacts', '[1]')
+      bindUserMmkvStorage(sessionA)
+      storage._storage.set('storedContacts', '[1,2]')
+
+      deleteUserMmkvStorage()
+      bindUserMmkvStorage(sessionA)
+      expect(storage._storage.getString('storedContacts')).toBeUndefined()
+      expect(plaintextStorage._storage.contains('storedContacts')).toBe(false)
+    })
+  })
+})
+
+describe('deleteUserMmkvStorage', () => {
+  it('removes the store files and detaches storage', () => {
+    bindUserMmkvStorage(sessionA)
+    storage._storage.set('chats', 'value')
+
+    deleteUserMmkvStorage()
+    expect(storage._storage.isEncrypted).toBe(false)
+    expect(storage._storage.getString('chats')).toBeUndefined()
+
+    bindUserMmkvStorage(sessionA)
+    expect(storage._storage.getString('chats')).toBeUndefined()
+  })
+})

--- a/apps/mobile/src/utils/mmkv/userMmkvStorage.ts
+++ b/apps/mobile/src/utils/mmkv/userMmkvStorage.ts
@@ -1,0 +1,89 @@
+import {createHash} from 'crypto'
+import {Array, pipe, Schema} from 'effect'
+import {createMMKV, deleteMMKV} from 'react-native-mmkv'
+import {type Session} from '../../brands/Session.brand'
+import {plaintextStorage, USER_MMKV_ID, userMmkvStore} from './effectMmkv'
+import {copyMmkvEntries, type MmkvStore} from './mmkvStore'
+
+// MMKV wants the AES-256 key as 32 single-byte characters. Hashing the session
+// private key with a purpose tag binds the store to the user's identity while
+// keeping the identity key itself out of MMKV.
+function deriveUserMmkvKey(session: Pick<Session, 'privateKey'>): string {
+  return createHash('sha256')
+    .update(`vexl-user-mmkv-v1:${session.privateKey.privateKeyPemBase64}`)
+    .digest('base64')
+    .slice(0, 32)
+}
+
+/**
+ * Keys that must be readable before anyone is logged in (preferences read by
+ * the login screens, login-flow counters, deep links, diagnostics). Everything
+ * else is user data and lives in the encrypted store.
+ *
+ * The migration below decides by this list alone which entries to move out of
+ * the plaintext instance, so a plaintext atom for a key missing here would
+ * lose its value on the first launch after the update. That is why
+ * `atomWithParsedPlaintextMmkvStorage` only accepts keys from this list.
+ */
+export const PlaintextMmkvKey = Schema.Literal(
+  'preferences',
+  'previewChannel',
+  'numberOfLoginAttempts',
+  'lastInitialLink',
+  'lastUniversalOrAppLink',
+  'cancelledIds',
+  'actionsBenchmarks',
+  'session:v2SecretWasWritten',
+  'logs',
+  'logs_enabled',
+  'notificationToken'
+)
+export type PlaintextMmkvKey = typeof PlaintextMmkvKey.Type
+const isPlaintextMmkvKey = Schema.is(PlaintextMmkvKey)
+
+// Before storage was encrypted every key lived in the plaintext instance.
+// Moves the user's entries over on the first bind after the update.
+function migrateLegacyPlaintextEntries(target: MmkvStore): void {
+  const legacy = plaintextStorage._storage
+  const legacyKeys = pipe(
+    legacy.getAllKeys(),
+    Array.filter((key) => !isPlaintextMmkvKey(key))
+  )
+  if (!Array.isNonEmptyArray(legacyKeys)) return
+
+  copyMmkvEntries(legacy, target, legacyKeys)
+  for (const key of legacyKeys) legacy.remove(key)
+}
+
+let boundPublicKey: string | undefined
+
+/**
+ * Opens the encrypted store for the given session and routes `storage` to it.
+ * Idempotent for the same session. Must run wherever a session becomes
+ * available: session load (foreground, background task, notification task)
+ * and login.
+ */
+export function bindUserMmkvStorage(
+  session: Pick<Session, 'privateKey'>
+): void {
+  const publicKey = session.privateKey.publicKeyPemBase64
+  if (boundPublicKey === publicKey) return
+  if (boundPublicKey !== undefined) deleteUserMmkvStorage()
+
+  const store = createMMKV({
+    id: USER_MMKV_ID,
+    encryptionKey: deriveUserMmkvKey(session),
+    encryptionType: 'AES-256',
+    recoveryStrategy: 'recover-on-error',
+  })
+  migrateLegacyPlaintextEntries(store)
+  userMmkvStore.bind(store)
+  boundPublicKey = publicKey
+}
+
+/** Detaches `storage` from the user's store and removes its files. */
+export function deleteUserMmkvStorage(): void {
+  userMmkvStore.unbind()
+  boundPublicKey = undefined
+  deleteMMKV(USER_MMKV_ID)
+}

--- a/apps/mobile/src/utils/notifications/notificationReceivedHandler/index.ts
+++ b/apps/mobile/src/utils/notifications/notificationReceivedHandler/index.ts
@@ -86,11 +86,14 @@ const processNotification = (
     const notificationData = notificationDataOption.value
     yield* Effect.log('Got notification', input.source, notificationData._tag)
 
-    if (notificationRequiresLoadedSession(notificationData)) {
-      const session = yield* loadSession()
-      if (!session.sessionLoaded)
-        return yield* Effect.fail(new ErrorLoadingSession())
-    }
+    // Loading the session also binds the user's encrypted storage, which the
+    // handlers below write to.
+    const session = yield* loadSession()
+    if (
+      !session.sessionLoaded &&
+      notificationRequiresLoadedSession(notificationData)
+    )
+      return yield* Effect.fail(new ErrorLoadingSession())
 
     if (notificationData._tag === 'NewChatMessageNoticeNotificationData') {
       yield* handleNewChatMessageNoticeNotification(notificationData)

--- a/apps/mobile/src/utils/notifications/refreshNotificationTokenOnResumeTask.ts
+++ b/apps/mobile/src/utils/notifications/refreshNotificationTokenOnResumeTask.ts
@@ -1,5 +1,5 @@
 import {apiAtom} from '../../api'
-import {storage} from '../mmkv/effectMmkv'
+import {plaintextStorage} from '../mmkv/effectMmkv'
 import {reportErrorE} from '../reportError'
 
 import {Effect} from 'effect/index'
@@ -18,15 +18,18 @@ export const refreshNotificationTaskId = registerInAppLoadingTask({
   },
   task: (store) =>
     Effect.gen(function* (_) {
-      const oldToken = storage._storage.getString(NOTIFICATION_TOKEN_CACHE_KEY)
+      const oldToken = plaintextStorage._storage.getString(
+        NOTIFICATION_TOKEN_CACHE_KEY
+      )
       const newToken = yield* _(getNotificationTokenE())
       if (oldToken === newToken) {
         console.log('Notification token has not changed since the last refresh')
         return
       }
 
-      if (newToken) storage._storage.set(NOTIFICATION_TOKEN_CACHE_KEY, newToken)
-      else storage._storage.remove(NOTIFICATION_TOKEN_CACHE_KEY)
+      if (newToken)
+        plaintextStorage._storage.set(NOTIFICATION_TOKEN_CACHE_KEY, newToken)
+      else plaintextStorage._storage.remove(NOTIFICATION_TOKEN_CACHE_KEY)
 
       yield* _(
         store

--- a/apps/mobile/src/utils/prPreview/index.ts
+++ b/apps/mobile/src/utils/prPreview/index.ts
@@ -5,7 +5,7 @@ import {Alert} from 'react-native'
 import {showErrorAlert} from '../../components/ErrorAlert'
 import {globalDialogAtom} from '../../components/GlobalDialog'
 import {loadingOverlayDisplayedAtom} from '../../components/LoadingOverlayProvider'
-import {atomWithParsedMmkvStorage} from '../atomUtils/atomWithParsedMmkvStorage'
+import {atomWithParsedPlaintextMmkvStorage} from '../atomUtils/atomWithParsedMmkvStorage'
 import {enableHiddenFeatures} from '../environment'
 import {reportErrorE} from '../reportError'
 import {PreviewChannel, PreviewError} from './domain'
@@ -22,7 +22,7 @@ import {PreviewChannel, PreviewError} from './domain'
 // expo-updates has no getter for the active header override (Updates.channel
 // reflects it only after a reload), so the app tracks the active preview
 // channel itself for display and clearing.
-export const previewChannelStorageAtom = atomWithParsedMmkvStorage(
+export const previewChannelStorageAtom = atomWithParsedPlaintextMmkvStorage(
   'previewChannel',
   {activeChannel: null},
   Schema.Struct({activeChannel: Schema.NullOr(PreviewChannel)})

--- a/apps/mobile/src/utils/preferences/index.ts
+++ b/apps/mobile/src/utils/preferences/index.ts
@@ -5,13 +5,13 @@ import {
 import {Option, pipe} from 'effect'
 import {atom} from 'jotai'
 import {focusAtom} from 'jotai-optics'
-import {atomWithParsedMmkvStorage} from '../atomUtils/atomWithParsedMmkvStorage'
+import {atomWithParsedPlaintextMmkvStorage} from '../atomUtils/atomWithParsedMmkvStorage'
 import {devAppLanguage, getDeviceLanguage} from '../localization/appLanguage'
 import {currencies} from '../localization/currency'
 import getDefaultSpokenLanguage from '../localization/getDefaultSpokenLanguage'
 import {Preferences} from './domain'
 
-export const preferencesAtom = atomWithParsedMmkvStorage(
+export const preferencesAtom = atomWithParsedPlaintextMmkvStorage(
   'preferences',
   {
     disableOfferRerequestLimit: false,

--- a/docs/mmkv_data_loss_sentry_guide.md
+++ b/docs/mmkv_data_loss_sentry_guide.md
@@ -43,7 +43,8 @@ are discarded instead of being flushed.
 
 | File                                                                       | Responsibility                                                                                             |
 | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `apps/mobile/src/utils/mmkv/effectMmkv.ts`                                 | Creates the v4 MMKV instance with `recover-on-error`                                                       |
+| `apps/mobile/src/utils/mmkv/effectMmkv.ts`                                 | Creates the plaintext instance and the session-bound user store                                            |
+| `apps/mobile/src/utils/mmkv/userMmkvStorage.ts`                            | Opens the encrypted user instance with `recover-on-error` on session load; see `mmkv_encryption.md`       |
 | `apps/mobile/src/utils/mmkv/detectMmkvDataLoss.ts`                         | Detects total and partial loss and gathers MMKV file metadata                                              |
 | `apps/mobile/src/utils/mmkv/criticalMmkvKeys.ts`                           | Defines the critical keys and the key-name-only presence record schema                                     |
 | `apps/mobile/src/utils/mmkv/mmkvDataLossDiagnosticStorage.ts`              | Serializes presence-record updates, startup detection, and intentional clears                              |

--- a/docs/mmkv_encryption.md
+++ b/docs/mmkv_encryption.md
@@ -1,0 +1,61 @@
+# MMKV encryption at rest
+
+The mobile app keeps local state in two MMKV instances:
+
+| Instance       | Content                                                                                     | Encryption                                  |
+| -------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `mmkv.default` | The few keys needed before login: preferences, login-flow counters, deep links, diagnostics | none                                        |
+| `mmkv.user`    | Everything else: chats, offers, contacts, clubs, notification key material, ...             | AES-256 with a key derived from the session |
+
+Which keys stay in `mmkv.default` is the closed list `PlaintextMmkvKey` next
+to the migration in `apps/mobile/src/utils/mmkv/userMmkvStorage.ts`. Atoms opt into it with
+`atomWithParsedPlaintextMmkvStorage`; the default `atomWithParsedMmkvStorage`
+writes to the user store.
+
+## Key
+
+The user store key is `sha256("vexl-user-mmkv-v1:" + privateKeyPemBase64)`,
+base64, truncated to the 32 single-byte characters MMKV accepts. The session
+private key already lives in SecureStore with
+`AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY`, so the store is readable exactly when
+the session is: in the foreground, in background tasks and in notification
+tasks after the first unlock, and never on a device that lacks the keychain
+item (for example a backup restored elsewhere). No second secret is stored.
+
+## Lifecycle
+
+`storage` (the `EffectMmkv` every user-data atom uses) routes through
+`SessionBoundMmkvStore`. Until a session is known it delegates to an in-memory
+placeholder, so atoms created at import time read defaults.
+`bindUserMmkvStorage(session)` opens the encrypted instance, migrates legacy
+plaintext entries, copies over anything written to the placeholder (the login
+flow writes before the session is set) and notifies listeners for every stored
+key so mounted atoms re-read. It runs in:
+
+- `loadSession`, right after the session is read from storage and before the
+  V1 to V2 upgrade. All entry points (splash screen, background task,
+  notification handler) go through it.
+- the `sessionAtom` login path.
+
+`deleteUserMmkvStorage()` detaches `storage` and removes the instance files.
+It runs from the `sessionAtom` logout path and from
+`clearMmkvStorageAndEmptyAtoms`, which the login flow and account deletion
+call.
+
+## Migration from the plaintext store
+
+Existing installs have every key in `mmkv.default`. On the first bind after
+the update, every key that is not in `PlaintextMmkvKey` is copied into the
+user store and removed from `mmkv.default`. Values pass through JavaScript
+(strings and booleans are the only types the app stores). The copy runs before
+any atom can write, and a kill in the middle simply reruns it on the next
+launch: source entries are removed only after they were written to the target.
+
+`remove()` does not scrub the old bytes from the plaintext file. Encryption
+protects copies of the app container taken after migration; it is not a
+forensic wipe of what was written before.
+
+## Diagnostics
+
+`detectMmkvDataLoss` runs after the bind in `loadSession`; see
+`mmkv_data_loss_sentry_guide.md`.


### PR DESCRIPTION
Closes #2604

User data in the mobile app (chats, offers, contacts, clubs, notification key material, ...) now lives in a separate AES-256 MMKV instance, `mmkv.user`. Its key is derived from the session private key (`sha256("vexl-user-mmkv-v1:" + privateKeyPemBase64)`), so no second secret is stored: the store is readable exactly when the session is, including background and notification tasks after first unlock, and unreadable on a device that lacks the keychain item.

The few keys that must be readable before login (preferences, login-flow counters, deep links, diagnostics) stay in the plaintext `mmkv.default` instance. They are the closed list `PlaintextMmkvKey`; atoms opt into it with `atomWithParsedPlaintextMmkvStorage`.

## How it works

- `storage` routes through `SessionBoundMmkvStore`. Until a session is known it is an in-memory placeholder, so atoms created at import time read defaults.
- `bindUserMmkvStorage(session)` opens the encrypted instance, migrates legacy plaintext entries, carries over anything the login flow wrote before the session was set, and notifies listeners so mounted atoms re-read. It runs in `loadSession` (all entry points go through it) and in the `sessionAtom` login path.
- `deleteUserMmkvStorage()` detaches `storage` and removes the instance files. It runs on logout and in `clearMmkvStorageAndEmptyAtoms`.
- The notification handler now always loads the session (it only fails when the notification needs one), so the user store is bound whenever a session exists.
- `detectMmkvDataLoss` runs after the bind in `loadSession` instead of at app start.

## Migration

On the first bind after the update, every key that is not in `PlaintextMmkvKey` is copied from `mmkv.default` into `mmkv.user` and removed from the source. Values pass through JS (strings and booleans only). A kill mid-way reruns the copy on the next launch. No native patch and no new binaries are needed.

Design notes: [docs/mmkv_encryption.md](docs/mmkv_encryption.md).

## Verification

- Mobile typecheck, repository format and lint pass.
- All 339 mobile tests pass, including new tests for key derivation, session isolation, migration, pre-session writes, and deletion on logout.
- Native runs (upgrade of a populated plaintext install, background/notification tasks, logout, second account) are still to be done on both platforms before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Data Protection**
  * Added encrypted, session-specific storage for user data.
  * User data is isolated between accounts and removed when signing out.
  * Existing data is migrated to encrypted storage when a session is established.
  * Pre-login preferences and other required settings remain available before sign-in.

* **Reliability**
  * Improved storage recovery and session handling across login, logout, and app launches.
  * Notifications now refresh session state consistently before processing.

* **Documentation**
  * Added documentation describing storage encryption, migration, and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->