### PR TITLE
fix #2617: Optimize per-offer chat and club state subscriptions on marketplace

### DIFF
--- a/apps/mobile/src/components/ChatSearchScreen/components/ChatSearchChatResultItem.tsx
+++ b/apps/mobile/src/components/ChatSearchScreen/components/ChatSearchChatResultItem.tsx
@@ -3,6 +3,7 @@ import {Stack, Typography, XStack, YStack} from '@vexl-next/ui'
 import React from 'react'
 import {TouchableOpacity} from 'react-native'
 import {type RootStackScreenProps} from '../../../navigationTypes'
+import {chatDetailRouteParams} from '../../../utils/chat/goToChatDetail'
 import unixMillisecondsToLocaleDateTime from '../../../utils/unixMillisecondsToLocaleDateTime'
 import FromNowComponent from '../../FromNowComponent'
 import UserAvatar from '../../UserAvatar'
@@ -23,10 +24,7 @@ function ChatSearchChatResultItem({
   return (
     <TouchableOpacity
       onPress={() => {
-        navigation.navigate('ChatDetail', {
-          otherSideKey: result.chat.otherSide.publicKey,
-          inboxKey: result.chat.inbox.privateKey.publicKeyPemBase64,
-        })
+        navigation.navigate('ChatDetail', chatDetailRouteParams(result.chat))
       }}
     >
       <XStack py="$4" gap="$4" ai="center">

--- a/apps/mobile/src/components/ChatSearchScreen/components/ChatSearchMessageResultItem.tsx
+++ b/apps/mobile/src/components/ChatSearchScreen/components/ChatSearchMessageResultItem.tsx
@@ -3,6 +3,7 @@ import {Typography, XStack, YStack} from '@vexl-next/ui'
 import React from 'react'
 import {TouchableOpacity} from 'react-native'
 import {type RootStackScreenProps} from '../../../navigationTypes'
+import {chatDetailRouteParams} from '../../../utils/chat/goToChatDetail'
 import unixMillisecondsToLocaleDateTime from '../../../utils/unixMillisecondsToLocaleDateTime'
 import FromNowComponent from '../../FromNowComponent'
 import {type SearchMessageResult} from '../state'
@@ -23,8 +24,7 @@ function ChatSearchMessageResultItem({
     <TouchableOpacity
       onPress={() => {
         navigation.navigate('ChatDetail', {
-          otherSideKey: result.chat.chat.otherSide.publicKey,
-          inboxKey: result.chat.chat.inbox.privateKey.publicKeyPemBase64,
+          ...chatDetailRouteParams(result.chat.chat),
           targetMessageId: result.messageId,
         })
       }}

--- a/apps/mobile/src/components/InsideRouter/components/MessagesScreen/components/ChatListItem.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/MessagesScreen/components/ChatListItem.tsx
@@ -20,6 +20,7 @@ import isNoteChatOrigin from '../../../../../state/chat/utils/isNoteChatOrigin'
 import {useOfferForChatOrigin} from '../../../../../state/marketplace'
 import {noteForChatOriginAtom} from '../../../../../state/notes/atoms/notesState'
 import {getOtherSideRealNameOrFriendLevel} from '../../../../../utils/chat/getOtherSideFriendLevel'
+import {chatDetailRouteParams} from '../../../../../utils/chat/goToChatDetail'
 import {useTranslation} from '../../../../../utils/localization/I18nProvider'
 import {formattingLocaleAtom} from '../../../../../utils/localization/formattingLocaleAtom'
 import unixMillisecondsToLocaleDateTime from '../../../../../utils/unixMillisecondsToLocaleDateTime'
@@ -165,10 +166,7 @@ function ChatListItem({
             isTyping={isTyping}
             tags={tagLabels}
             onPress={() => {
-              navigation.navigate('ChatDetail', {
-                otherSideKey: chatInfo.otherSide.publicKey,
-                inboxKey: chatInfo.inbox.privateKey.publicKeyPemBase64,
-              })
+              navigation.navigate('ChatDetail', chatDetailRouteParams(chatInfo))
             }}
           />
         </Stack>

--- a/apps/mobile/src/components/Notes/useNoteChatNavigation.ts
+++ b/apps/mobile/src/components/Notes/useNoteChatNavigation.ts
@@ -1,9 +1,9 @@
-import {useNavigation} from '@react-navigation/native'
 import {type NoteId} from '@vexl-next/domain/src/general/notes'
 import {useAtomValue} from 'jotai'
-import {useCallback, useMemo} from 'react'
+import {useMemo} from 'react'
 import chatWithMessagesForNoteAtom from '../../state/chat/atoms/chatWithMessagesForNoteAtom'
 import {getChatState} from '../../state/chat/utils/offerStates'
+import {useNavigateToChatDetail} from '../../utils/chat/goToChatDetail'
 
 /**
  * Looks up the chat opened from the given note (if any) and exposes whether
@@ -13,20 +13,12 @@ export function useNoteChatNavigation(noteId: NoteId): {
   readonly isChatOpen: boolean
   readonly navigateToChat: () => void
 } {
-  const navigation = useNavigation()
   const chat = useAtomValue(
     useMemo(() => chatWithMessagesForNoteAtom(noteId), [noteId])
   )
   const isChatOpen = getChatState(chat) === 'chatOpen'
 
-  const navigateToChat = useCallback(() => {
-    if (!chat) return
-
-    navigation.navigate('ChatDetail', {
-      otherSideKey: chat.chat.otherSide.publicKey,
-      inboxKey: chat.chat.inbox.privateKey.publicKeyPemBase64,
-    })
-  }, [chat, navigation])
+  const navigateToChat = useNavigateToChatDetail(chat?.chat)
 
   return {isChatOpen, navigateToChat}
 }

--- a/apps/mobile/src/components/OfferDetailScreen/index.tsx
+++ b/apps/mobile/src/components/OfferDetailScreen/index.tsx
@@ -23,7 +23,7 @@ import {useAtomValue, useSetAtom} from 'jotai'
 import React, {useCallback, useMemo} from 'react'
 import {ScrollView} from 'react-native'
 import {type RootStackScreenProps} from '../../navigationTypes'
-import {chatWithMessagesForOfferAtom} from '../../state/chat/hooks/useChatForOffer'
+import {useChatWithMessagesForOfferAtom} from '../../state/chat/hooks/useChatForOffer'
 import {
   canChatBeRequested,
   getRequestState,
@@ -32,9 +32,10 @@ import {useGetAllClubsForIds} from '../../state/clubs/atom/clubsWithMembersAtom'
 import {useSingleOffer} from '../../state/marketplace'
 import {toggleOfferMarkActionAtom} from '../../state/marketplace/atoms/offerMarkActionAtoms'
 import {useVisibleCommonFriendsForOffer} from '../../state/marketplace/hooks/useVisibleCommonFriendsForOffer'
-import {useTranslation} from '../../utils/localization/I18nProvider'
+import {useNavigateToChatDetail} from '../../utils/chat/goToChatDetail'
 import {formatInteger} from '../../utils/localization/formatting'
 import {formattingLocaleAtom} from '../../utils/localization/formattingLocaleAtom'
+import {useTranslation} from '../../utils/localization/I18nProvider'
 import useSafeGoBack from '../../utils/useSafeGoBack'
 import {offerRerequestLimitDaysAtom} from '../../utils/versionService/atoms'
 import CommonFriends from '../CommonFriends'
@@ -264,19 +265,8 @@ function OfferDetailScreen({
     onNone: () => false,
     onSome: (o) => !!o.ownershipInfo,
   })
-  const otherSidePublicKey = Option.match(offer, {
-    onNone: () => undefined,
-    onSome: (o) => o.offerInfo.publicPart.offerPublicKey,
-  })
-
-  const chatForOfferAtom = useMemo(
-    () =>
-      chatWithMessagesForOfferAtom({
-        offerId,
-        isMyOffer,
-        otherSidePublicKey: Option.fromNullable(otherSidePublicKey),
-      }),
-    [isMyOffer, offerId, otherSidePublicKey]
+  const chatForOfferAtom = useChatWithMessagesForOfferAtom(
+    Option.getOrUndefined(offer)
   )
   const chatForOffer = useAtomValue(chatForOfferAtom)
 
@@ -296,13 +286,7 @@ function OfferDetailScreen({
     navigation.navigate('SendMessage', {offerId})
   }, [navigation, offerId])
 
-  const handleOpenChat = useCallback(() => {
-    if (!chatForOffer) return
-    navigation.navigate('ChatDetail', {
-      otherSideKey: chatForOffer.chat.otherSide.publicKey,
-      inboxKey: chatForOffer.chat.inbox.privateKey.publicKeyPemBase64,
-    })
-  }, [chatForOffer, navigation])
+  const handleOpenChat = useNavigateToChatDetail(chatForOffer?.chat)
 
   const footerState: FooterState = useMemo(() => {
     if (canSendRequest) {

--- a/apps/mobile/src/components/OfferOnMarketplace.tsx
+++ b/apps/mobile/src/components/OfferOnMarketplace.tsx
@@ -4,21 +4,23 @@ import {
   IconTag,
   OfferCard,
   TextTag,
-  type OfferCardActionButton,
   type OfferCardDetail,
 } from '@vexl-next/ui'
 import {Option} from 'effect'
-import {useAtomValue, useSetAtom} from 'jotai'
+import {atom, useAtomValue, useSetAtom, type Atom} from 'jotai'
 import React, {useMemo} from 'react'
-import {chatWithMessagesForOfferAtom} from '../state/chat/hooks/useChatForOffer'
+import {type ChatWithMessages} from '../state/chat/domain'
+import {useChatWithMessagesForOfferAtom} from '../state/chat/hooks/useChatForOffer'
 import {shouldUseGrayscaleColours} from '../state/chat/utils/offerStates'
 import {
+  clubNamesForIdsAtom,
   smallestClubForIdsAtom,
-  useGetAllClubsNamesForIds,
 } from '../state/clubs/atom/clubsWithMembersAtom'
+import {type ClubWithMembers} from '../state/clubs/domain'
 import {useVisibleCommonFriendsForOffer} from '../state/marketplace/hooks/useVisibleCommonFriendsForOffer'
 import {isProductOfferMissingCategory} from '../state/marketplace/utils/isProductOfferMissingCategory'
 import {getOtherSideFriendLevel} from '../utils/chat/getOtherSideFriendLevel'
+import {useNavigateToChatDetail} from '../utils/chat/goToChatDetail'
 import {isOfferExpired} from '../utils/isOfferExpired'
 import formatSpokenLanguages from '../utils/localization/formatSpokenLanguages'
 import {formatInteger} from '../utils/localization/formatting'
@@ -36,21 +38,23 @@ import {randomSeedFromOfferInfo} from '../utils/RandomSeed'
 import {offerRerequestLimitDaysAtom} from '../utils/versionService/atoms'
 import {AnonymousAvatarOrClubImage} from './AnonymousAvatar'
 
+const noClubNamesAtom = atom<string[]>([])
+const noSmallestClubAtom = atom(Option.none<ClubWithMembers>())
+
 export default function OfferOnMarketplace({
   offer,
   onPress,
-  actionButton,
+  chatForOfferAtom,
 }: {
   offer: OneOfferInState
   onPress?: () => void
-  actionButton?: OfferCardActionButton
+  chatForOfferAtom?: Atom<ChatWithMessages | undefined>
 }): React.ReactElement {
   const {t} = useTranslation()
   const locale = useAtomValue(formattingLocaleAtom)
   const {publicPart, privatePart} = offer.offerInfo
   const {ownershipInfo} = offer
   const isMine = !!ownershipInfo?.adminId
-  const isMyOffer = !!ownershipInfo
   const isExpiredMyOffer = isMine && isOfferExpired(publicPart.expirationDate)
   const rerequestLimitDays = useAtomValue(offerRerequestLimitDaysAtom)
   const getAmountLabel = useSetAtom(getAmountLabelActionAtom)
@@ -58,34 +62,43 @@ export default function OfferOnMarketplace({
 
   const smallestClub = useAtomValue(
     useMemo(
-      () => smallestClubForIdsAtom(privatePart.clubIds ?? []),
-      [privatePart.clubIds]
+      () =>
+        isMine
+          ? noSmallestClubAtom
+          : smallestClubForIdsAtom(privatePart.clubIds ?? []),
+      [isMine, privatePart.clubIds]
     )
   )
 
-  const myClubNames = useGetAllClubsNamesForIds(
-    ownershipInfo?.intendedClubs ?? []
+  const myClubNames = useAtomValue(
+    useMemo(
+      () =>
+        isMine
+          ? clubNamesForIdsAtom(ownershipInfo?.intendedClubs ?? [])
+          : noClubNamesAtom,
+      [isMine, ownershipInfo?.intendedClubs]
+    )
   )
 
   const isOffering = getIsOffering(publicPart.listingType, publicPart.offerType)
   const iconTagVariant = getIconTagVariant(publicPart.listingType)
 
-  const chatForOfferAtom = useMemo(
-    () =>
-      chatWithMessagesForOfferAtom({
-        offerId: offer.offerInfo.offerId,
-        isMyOffer,
-        otherSidePublicKey: Option.some(publicPart.offerPublicKey),
-      }),
-    [isMyOffer, offer.offerInfo.offerId, publicPart.offerPublicKey]
-  )
-  const chatForOffer = useAtomValue(chatForOfferAtom)
+  const fallbackChatForOfferAtom = useChatWithMessagesForOfferAtom(offer)
+  const chatForOfferAtomToUse = chatForOfferAtom ?? fallbackChatForOfferAtom
+  const chatForOffer = useAtomValue(chatForOfferAtomToUse)
   const shouldBeGrayscaled = shouldUseGrayscaleColours({
     chat: chatForOffer,
     isMine,
     offerInfo: offer.offerInfo,
     rerequestLimitDays,
   })
+
+  const navigateToChat = useNavigateToChatDetail(chatForOffer?.chat)
+
+  const goToChatButton =
+    !isMine && !!chatForOffer?.chat && shouldBeGrayscaled
+      ? {label: t('offer.goToChat'), onPress: navigateToChat}
+      : undefined
 
   const name = isMine
     ? t('common.me')
@@ -208,7 +221,7 @@ export default function OfferOnMarketplace({
       details={details}
       statusLabel={statusLabel}
       onPress={onPress}
-      actionButton={actionButton}
+      actionButton={goToChatButton}
     />
   )
 }

--- a/apps/mobile/src/components/OffersList/OffersListItem.tsx
+++ b/apps/mobile/src/components/OffersList/OffersListItem.tsx
@@ -5,19 +5,15 @@ import {
   SwipeableOfferCard,
   type SwipeableOfferCardMark,
 } from '@vexl-next/ui'
-import {Effect, Option} from 'effect'
+import {Effect} from 'effect'
 import {useAtomValue, useSetAtom, type Atom} from 'jotai'
 import React, {useCallback, useMemo} from 'react'
-import {chatWithMessagesForOfferAtom} from '../../state/chat/hooks/useChatForOffer'
-import {
-  canChatBeRequested,
-  getRequestState,
-  shouldUseGrayscaleColours,
-} from '../../state/chat/utils/offerStates'
+import {useChatWithMessagesForOfferAtom} from '../../state/chat/hooks/useChatForOffer'
+import {getRequestState} from '../../state/chat/utils/offerStates'
 import {toggleOfferMarkActionAtom} from '../../state/marketplace/atoms/offerMarkActionAtoms'
+import {useNavigateToChatDetail} from '../../utils/chat/goToChatDetail'
 import {useTranslation} from '../../utils/localization/I18nProvider'
 import {getOfferMarkBadge} from '../../utils/offerHelpers'
-import {offerRerequestLimitDaysAtom} from '../../utils/versionService/atoms'
 import OfferOnMarketplace from '../OfferOnMarketplace'
 import {useOffersListAnimation} from './offersListAnimation'
 
@@ -30,7 +26,6 @@ function OffersListItem({offerAtom, swipeEnabled}: Props): React.ReactElement {
   const {t} = useTranslation()
   const navigation = useNavigation()
   const offer = useAtomValue(offerAtom)
-  const rerequestLimitDays = useAtomValue(offerRerequestLimitDaysAtom)
   const toggleOfferMark = useSetAtom(toggleOfferMarkActionAtom)
   const {
     animateNextListChange,
@@ -42,39 +37,8 @@ function OffersListItem({offerAtom, swipeEnabled}: Props): React.ReactElement {
     () => !!offer.ownershipInfo?.adminId,
     [offer.ownershipInfo?.adminId]
   )
-  const isMyOffer = !!offer.ownershipInfo
-
-  const chatForOfferAtom = useMemo(
-    () =>
-      chatWithMessagesForOfferAtom({
-        offerId: offer.offerInfo.offerId,
-        isMyOffer,
-        otherSidePublicKey: Option.some(
-          offer.offerInfo.publicPart.offerPublicKey
-        ),
-      }),
-    [
-      isMyOffer,
-      offer.offerInfo.offerId,
-      offer.offerInfo.publicPart.offerPublicKey,
-    ]
-  )
+  const chatForOfferAtom = useChatWithMessagesForOfferAtom(offer)
   const chatForOffer = useAtomValue(chatForOfferAtom)
-
-  const canBeRequested = useMemo(() => {
-    if (!chatForOffer) return true
-    return canChatBeRequested(chatForOffer, rerequestLimitDays).canBeRerequested
-  }, [chatForOffer, rerequestLimitDays])
-
-  const shouldShowGoToChatButton =
-    !isMine &&
-    !!chatForOffer?.chat &&
-    shouldUseGrayscaleColours({
-      chat: chatForOffer,
-      isMine,
-      offerInfo: offer.offerInfo,
-      rerequestLimitDays,
-    })
 
   const navigateToOffer = useCallback(() => {
     if (isMine) {
@@ -86,14 +50,7 @@ function OffersListItem({offerAtom, swipeEnabled}: Props): React.ReactElement {
     }
   }, [isMine, navigation, offer.offerInfo.offerId])
 
-  const navigateToChat = useCallback(() => {
-    if (!chatForOffer?.chat) return
-
-    navigation.navigate('ChatDetail', {
-      otherSideKey: chatForOffer.chat.otherSide.publicKey,
-      inboxKey: chatForOffer.chat.inbox.privateKey.publicKeyPemBase64,
-    })
-  }, [chatForOffer, navigation])
+  const navigateToChat = useNavigateToChatDetail(chatForOffer?.chat)
 
   const handleExitAnimationStart = useCallback(() => {
     onOfferExitAnimationStart(offer.offerInfo.offerId)
@@ -117,124 +74,23 @@ function OffersListItem({offerAtom, swipeEnabled}: Props): React.ReactElement {
     [animateNextListChange, offer, onOfferExitAnimationEnd, toggleOfferMark]
   )
 
-  const content = useMemo((): {
-    buttonText: string
-    actionableUI: boolean
-    onPress: () => void
-  } => {
-    if (isMine) {
-      return {
-        buttonText: t('myOffers.editOffer'),
-        actionableUI: true,
-        onPress: navigateToOffer,
-      }
-    }
+  const onPressCard = useMemo(() => {
+    if (isMine) return navigateToOffer
 
     const state = getRequestState(chatForOffer)
-    if (state === 'initial') {
-      return {
-        buttonText: t('common.request'),
-        actionableUI: true,
-        onPress: navigateToOffer,
-      }
-    }
-
-    if (state === 'requested') {
-      if (canBeRequested) {
-        return {
-          buttonText: t('common.requestAgain'),
-          actionableUI: true,
-          onPress: navigateToChat,
-        }
-      } else {
-        return {
-          buttonText: t('common.seeDetail'),
-          actionableUI: false,
-          onPress: navigateToChat,
-        }
-      }
-    }
-
-    if (state === 'cancelled') {
-      if (canBeRequested) {
-        return {
-          actionableUI: true,
-          buttonText: t('common.requestAgain'),
-          onPress: navigateToOffer,
-        }
-      } else {
-        return {
-          actionableUI: false,
-          buttonText: t('common.seeDetail'),
-          onPress: navigateToOffer,
-        }
-      }
-    }
-
-    if (state === 'accepted') {
-      return {
-        buttonText: t('offer.goToChat'),
-        actionableUI: false,
-        onPress: navigateToChat,
-      }
-    }
-
-    if (state === 'denied') {
-      if (canBeRequested) {
-        return {
-          actionableUI: true,
-          buttonText: t('common.requestAgain'),
-          onPress: navigateToChat,
-        }
-      } else {
-        return {
-          actionableUI: false,
-          buttonText: t('common.seeDetail'),
-          onPress: navigateToChat,
-        }
-      }
-    }
-
-    if (state === 'deleted') {
-      if (canBeRequested) {
-        return {
-          actionableUI: true,
-          buttonText: t('common.requestAgain'),
-          onPress: navigateToOffer,
-        }
-      } else {
-        return {
-          actionableUI: false,
-          buttonText: t('common.seeDetail'),
-          onPress: navigateToOffer,
-        }
-      }
-    }
-
-    if (state === 'otherSideLeft') {
-      return {
-        actionableUI: false,
-        buttonText: t('offer.goToChat'),
-        onPress: navigateToChat,
-      }
-    }
-
-    return {
-      buttonText: t('common.request'),
-      actionableUI: true,
-      onPress: navigateToOffer,
-    }
-  }, [canBeRequested, chatForOffer, isMine, navigateToChat, navigateToOffer, t])
+    return state === 'requested' ||
+      state === 'accepted' ||
+      state === 'denied' ||
+      state === 'otherSideLeft'
+      ? navigateToChat
+      : navigateToOffer
+  }, [chatForOffer, isMine, navigateToChat, navigateToOffer])
 
   const card = (
     <OfferOnMarketplace
       offer={offer}
-      onPress={content.onPress}
-      actionButton={
-        shouldShowGoToChatButton
-          ? {label: t('offer.goToChat'), onPress: navigateToChat}
-          : undefined
-      }
+      onPress={onPressCard}
+      chatForOfferAtom={chatForOfferAtom}
     />
   )
 

--- a/apps/mobile/src/state/chat/hooks/useChatForOffer.ts
+++ b/apps/mobile/src/state/chat/hooks/useChatForOffer.ts
@@ -3,7 +3,10 @@ import {
   type PublicKeyPemBase64,
 } from '@vexl-next/cryptography/src/KeyHolder'
 import {type Chat} from '@vexl-next/domain/src/general/messaging'
-import {type OfferId} from '@vexl-next/domain/src/general/offers'
+import {
+  type OfferId,
+  type OneOfferInState,
+} from '@vexl-next/domain/src/general/offers'
 import {Array, Option, pipe} from 'effect/index'
 import {atom, useAtomValue, type Atom} from 'jotai'
 import {focusAtom} from 'jotai-optics'
@@ -169,6 +172,28 @@ export function chatWithMessagesForOfferAtom({
       ) ?? chatIndex.oldStateChatsByPublicKey.get(publicKeyOrUndefined)
     )
   })
+}
+
+const noChatForOfferAtom = atom<ChatWithMessages | undefined>(undefined)
+
+export function useChatWithMessagesForOfferAtom(
+  offer: OneOfferInState | undefined
+): Atom<ChatWithMessages | undefined> {
+  const offerId = offer?.offerInfo.offerId
+  const offerPublicKey = offer?.offerInfo.publicPart.offerPublicKey
+  const isMyOffer = !!offer?.ownershipInfo
+
+  return useMemo(
+    () =>
+      offerId && offerPublicKey
+        ? chatWithMessagesForOfferAtom({
+            offerId,
+            isMyOffer,
+            otherSidePublicKey: Option.some(offerPublicKey),
+          })
+        : noChatForOfferAtom,
+    [offerId, isMyOffer, offerPublicKey]
+  )
 }
 
 export function useChatForOfferExists({

--- a/apps/mobile/src/state/clubs/atom/clubsWithMembersAtom.ts
+++ b/apps/mobile/src/state/clubs/atom/clubsWithMembersAtom.ts
@@ -40,6 +40,21 @@ export const clubsWithMembersAtom = atom(
   (get) => get(clubsWithMembersStorageAtom).data
 )
 
+const getClubNamesForIds = (
+  clubsWithMembers: readonly ClubWithMembers[],
+  clubsIds: readonly ClubUuid[]
+): string[] =>
+  pipe(
+    clubsWithMembers,
+    Array.filter((club) => Array.contains(club.club.uuid)(clubsIds)),
+    Array.map((club) => club.club.name)
+  )
+
+export const clubNamesForIdsAtom = (
+  clubsIds: readonly ClubUuid[]
+): Atom<string[]> =>
+  atom((get) => getClubNamesForIds(get(clubsWithMembersAtom), clubsIds))
+
 const clubsWithMembersByNameOrder = pipe(
   Order.string,
   Order.mapInput((clubWithMembers: ClubWithMembers) =>
@@ -198,11 +213,7 @@ export function useGetAllClubsNamesForIds(
   clubsIds: readonly ClubUuid[]
 ): string[] {
   const clubsWithMembers = useAtomValue(clubsWithMembersAtom)
-  return pipe(
-    clubsWithMembers,
-    Array.filter((club) => Array.contains(club.club.uuid)(clubsIds)),
-    Array.map((club) => club.club.name)
-  )
+  return getClubNamesForIds(clubsWithMembers, clubsIds)
 }
 
 export function useGetAllClubsForIds(

--- a/apps/mobile/src/utils/chat/goToChatDetail.ts
+++ b/apps/mobile/src/utils/chat/goToChatDetail.ts
@@ -1,0 +1,22 @@
+import {useNavigation} from '@react-navigation/native'
+import {type Chat} from '@vexl-next/domain/src/general/messaging'
+import {useCallback} from 'react'
+import {type RootStackParamsList} from '../../navigationTypes'
+
+export function chatDetailRouteParams(
+  chat: Chat
+): RootStackParamsList['ChatDetail'] {
+  return {
+    otherSideKey: chat.otherSide.publicKey,
+    inboxKey: chat.inbox.privateKey.publicKeyPemBase64,
+  }
+}
+
+export function useNavigateToChatDetail(chat: Chat | undefined): () => void {
+  const navigation = useNavigation()
+
+  return useCallback(() => {
+    if (!chat) return
+    navigation.navigate('ChatDetail', chatDetailRouteParams(chat))
+  }, [chat, navigation])
+}


### PR DESCRIPTION
Closes #2617

## Problem

Profiling the Marketplace tab switch on Android with 297 offers showed that FlashList's ~8 mounted offer cards still did avoidable state work when they mounted: `OffersListItem` and `OfferOnMarketplace` each independently subscribed to the chat atom for the same offer, `OfferOnMarketplace` computed owned-offer club names for every mounted card (including non-owned ones that can never display it), and club lookups scanned the full club collection per card.

## What this does

- `OffersListItem` now creates the chat atom once and passes it down to `OfferOnMarketplace` as a prop, so each mounted card has a single subscription instead of two.
- `OfferOnMarketplace` only evaluates owned-offer intended-club names and the smallest-club lookup for offers it actually owns.
- Extracted the repeated chat-atom assembly (`useChatWithMessagesForOfferAtom`) and the repeated ChatDetail navigation callback (`useNavigateToChatDetail` / `chatDetailRouteParams`) into shared helpers, replacing duplicated copies across `OffersListItem`, `OfferOnMarketplace`, `OfferDetailScreen`, `useNoteChatNavigation`, `ChatListItem`, and the chat search result items.
- The "Go to chat" action button (previously computed in `OffersListItem`) now lives inside `OfferOnMarketplace` itself, so it's also available on the map-view offer cards that render the same component.

## Design notes

- Club-name lookup (`clubNamesForIdsAtom`) still linearly scans the club collection rather than using an indexed map; left as-is since a user's club membership count is realistically capped around 10, so the scan is negligible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved navigation to chat details from search results, messages, notes, offers, and marketplace listings.
  * Marketplace offers now provide a consistent option to open the associated chat.
  * Improved handling of offer-related chats and club names across marketplace views.

* **Refactor**
  * Standardized chat navigation and offer-chat handling for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->