### PR TITLE
fix: show chat relationships in notifications

### DIFF
--- a/apps/mobile/src/utils/notifications/chatNotifications.test.ts
+++ b/apps/mobile/src/utils/notifications/chatNotifications.test.ts
@@ -1,0 +1,350 @@
+import {generatePrivateKey} from '@vexl-next/cryptography/src/KeyHolder'
+import {
+  generateChatMessageId,
+  type ChatOrigin,
+  type MessageType,
+} from '@vexl-next/domain/src/general/messaging'
+import {NoteId, OneNoteInState} from '@vexl-next/domain/src/general/notes'
+import {
+  FriendLevel,
+  OfferId,
+  OneOfferInState,
+} from '@vexl-next/domain/src/general/offers'
+import {UserName} from '@vexl-next/domain/src/general/UserName.brand'
+import {UnixMilliseconds} from '@vexl-next/domain/src/utility/UnixMilliseconds.brand'
+import {type en} from '@vexl-next/localization/src/translations'
+import {Schema} from 'effect'
+import {scheduleNotificationAsync} from 'expo-notifications'
+import {type createInstance} from 'i18next'
+import {getDefaultStore, type atom} from 'jotai'
+import {Platform} from 'react-native'
+import messagingStateAtom from '../../state/chat/atoms/messagingStateAtom'
+import {getOtherSideData} from '../../state/chat/atoms/selectOtherSideDataAtom'
+import {
+  dummyChatWithMessages,
+  type ChatMessageWithState,
+  type ChatWithMessages,
+  type ReceivedMessage,
+} from '../../state/chat/domain'
+import {offersAtom} from '../../state/marketplace/atoms/offersState'
+import {notesAtom} from '../../state/notes/atoms/notesState'
+import {showChatNotification} from './chatNotifications'
+import {getChatNotificationName} from './getChatNotificationName'
+import {scheduleTradeReminder} from './tradeReminderNotifications'
+
+jest.mock('react-native-mmkv')
+jest.mock('url-join', () => jest.fn((...parts: string[]) => parts.join('/')))
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {getItem: jest.fn(), setItem: jest.fn(), removeItem: jest.fn()},
+}))
+jest.mock('../reportError', () => ({__esModule: true, default: jest.fn()}))
+jest.mock('../useAppState', () => ({useAppState: jest.fn()}))
+jest.mock('../localization/I18nProvider', () => {
+  const jotai = jest.requireActual<{atom: typeof atom}>('jotai')
+  const i18next = jest.requireActual<{
+    createInstance: typeof createInstance
+  }>('i18next')
+  const translations = jest.requireActual<{en: typeof en}>(
+    '@vexl-next/localization/src/translations'
+  )
+  const i18n = i18next.createInstance({
+    lng: 'en',
+    resources: {en: {translation: translations.en}},
+    keySeparator: false,
+    interpolation: {escapeValue: false},
+  })
+  void i18n.init()
+  return {translationAtom: jotai.atom({t: i18n.t.bind(i18n)})}
+})
+jest.mock('../localization/formattingLocaleAtom', () => {
+  const jotai = jest.requireActual<{atom: typeof atom}>('jotai')
+  return {formattingLocaleAtom: jotai.atom('en-US')}
+})
+jest.mock('expo-notifications', () => ({
+  AndroidImportance: {DEFAULT: 3, HIGH: 4},
+  AndroidNotificationPriority: {HIGH: 'high'},
+  SchedulableTriggerInputTypes: {DATE: 'date'},
+  getPresentedNotificationsAsync: jest.fn(async () => []),
+  scheduleNotificationAsync: jest.fn(async () => 'notification-id'),
+  setNotificationChannelAsync: jest.fn(async () => null),
+  setNotificationHandler: jest.fn(),
+}))
+
+const store = getDefaultStore()
+const senderPublicKey = generatePrivateKey().publicKeyPemBase64
+const offerId = Schema.decodeSync(OfferId)('notification-test-offer')
+const noteId = Schema.decodeSync(NoteId)('00000000-0000-4000-8000-000000000001')
+
+function message(
+  messageType: MessageType,
+  friendLevel?: readonly FriendLevel[]
+): typeof ReceivedMessage.Type {
+  return {
+    state: 'received',
+    message: {
+      uuid: generateChatMessageId(),
+      time: Schema.decodeSync(UnixMilliseconds)(Date.now()),
+      senderPublicKey,
+      messageType,
+      text: messageType === 'MESSAGE' ? 'See you tomorrow' : '',
+      friendLevel,
+    },
+  }
+}
+
+function chat(
+  messages: ChatMessageWithState[],
+  origin: ChatOrigin = {type: 'myOffer', offerId}
+): ChatWithMessages {
+  return {
+    ...dummyChatWithMessages,
+    chat: {
+      ...dummyChatWithMessages.chat,
+      origin,
+      otherSide: {publicKey: senderPublicKey},
+    },
+    messages,
+  }
+}
+
+async function notify(
+  chatWithMessages: ChatWithMessages,
+  newMessage: ChatMessageWithState
+): Promise<void> {
+  await showChatNotification({
+    newMessage,
+    inbox: {inbox: chatWithMessages.chat.inbox, chats: [chatWithMessages]},
+  })
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.replaceProperty(Platform, 'OS', 'ios')
+  store.set(messagingStateAtom, [])
+  store.set(notesAtom, [])
+  store.set(offersAtom, [])
+})
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+it.each<{friendLevel: FriendLevel; name: string}>([
+  {friendLevel: 'FIRST_DEGREE', name: 'Direct friend'},
+  {friendLevel: 'SECOND_DEGREE', name: 'Friend of a friend'},
+  {friendLevel: 'CLUB', name: 'Club member'},
+])('uses $name in an iOS message notification', async ({friendLevel, name}) => {
+  const newMessage = message('MESSAGE')
+  await notify(
+    chat([message('REQUEST_MESSAGING', [friendLevel]), newMessage]),
+    newMessage
+  )
+  expect(scheduleNotificationAsync).toHaveBeenCalledWith(
+    expect.objectContaining({
+      content: expect.objectContaining({title: name, body: 'See you tomorrow'}),
+    })
+  )
+})
+
+it('uses the most recent received request, ignoring requests we sent', () => {
+  const chatWithMessages = chat([
+    message('REQUEST_MESSAGING', ['FIRST_DEGREE']),
+    message('REQUEST_MESSAGING', ['SECOND_DEGREE']),
+    {...message('REQUEST_MESSAGING', ['FIRST_DEGREE']), state: 'sent'},
+  ])
+  expect(getChatNotificationName(store.get, chatWithMessages)).toBe(
+    'Friend of a friend'
+  )
+})
+
+it('preserves a revealed name over the relationship label', async () => {
+  const newMessage = message('MESSAGE')
+  const initialChat = chat([
+    message('REQUEST_MESSAGING', ['FIRST_DEGREE']),
+    newMessage,
+  ])
+  const chatWithMessages: ChatWithMessages = {
+    ...initialChat,
+    chat: {
+      ...initialChat.chat,
+      otherSide: {
+        ...initialChat.chat.otherSide,
+        realLifeInfo: {
+          ...getOtherSideData(initialChat.chat),
+          userName: Schema.decodeSync(UserName)('Alice'),
+        },
+      },
+    },
+  }
+  await notify(chatWithMessages, newMessage)
+  expect(scheduleNotificationAsync).toHaveBeenCalledWith(
+    expect.objectContaining({
+      content: expect.objectContaining({title: 'Alice'}),
+    })
+  )
+})
+
+it('preserves the anonymous fallback when the relationship is unknown', () => {
+  const chatWithMessages = chat([
+    message('REQUEST_MESSAGING', ['NOT_SPECIFIED']),
+  ])
+  expect(getChatNotificationName(store.get, chatWithMessages)).toBe(
+    getOtherSideData(chatWithMessages.chat).userName
+  )
+})
+
+it('uses the note relationship for outgoing chats without a received request', () => {
+  const note = Schema.decodeUnknownSync(OneNoteInState)({
+    noteInfo: {
+      id: 1,
+      noteId,
+      privatePart: {
+        commonFriends: [],
+        friendLevel: ['SECOND_DEGREE'],
+        symmetricKey: 'test-key',
+      },
+      publicPart: {
+        notePublicKey: senderPublicKey,
+        text: 'Test',
+        allowRepost: true,
+      },
+      expiresAt: Date.now() + 100000,
+      createdAt: '2026-09-04T00:00:00.000Z',
+      modifiedAt: '2026-09-04T00:00:00.000Z',
+    },
+    flags: {},
+  })
+  store.set(notesAtom, [note])
+  expect(
+    getChatNotificationName(store.get, chat([], {type: 'theirNote', noteId}))
+  ).toBe('Friend of a friend')
+})
+
+it('uses the relationship in Android MessagingStyle sender data', async () => {
+  jest.replaceProperty(Platform, 'OS', 'android')
+  const newMessage = message('MESSAGE')
+  await notify(
+    chat([message('REQUEST_MESSAGING', ['FIRST_DEGREE']), newMessage]),
+    newMessage
+  )
+  expect(scheduleNotificationAsync).toHaveBeenCalledWith(
+    expect.objectContaining({
+      content: expect.objectContaining({
+        title: 'Direct friend',
+        data: expect.objectContaining({
+          androidConversation: expect.objectContaining({
+            senderName: 'Direct friend',
+          }),
+        }),
+      }),
+    })
+  )
+})
+
+it('preserves the generic messaging request copy', async () => {
+  const request = message('REQUEST_MESSAGING', ['SECOND_DEGREE'])
+  await notify(chat([request]), request)
+  expect(scheduleNotificationAsync).toHaveBeenCalledWith(
+    expect.objectContaining({
+      content: expect.objectContaining({
+        title: 'New response to your offer',
+        body: 'Someone wants to connect with you.',
+      }),
+    })
+  )
+})
+
+it('reads request history when scheduling a trade reminder from a Chat', async () => {
+  const chatWithMessages = chat([
+    message('REQUEST_MESSAGING', ['FIRST_DEGREE']),
+  ])
+  store.set(messagingStateAtom, [
+    {inbox: chatWithMessages.chat.inbox, chats: [chatWithMessages]},
+  ])
+  await scheduleTradeReminder({
+    chat: chatWithMessages.chat,
+    meetingTime: Schema.decodeSync(UnixMilliseconds)(Date.now() + 3600000),
+  })
+  expect(scheduleNotificationAsync).toHaveBeenCalledWith(
+    expect.objectContaining({
+      content: expect.objectContaining({
+        title: 'Meeting with Direct friend',
+      }),
+    })
+  )
+})
+
+it('uses the relationship in trade checklist notification copy', async () => {
+  const newMessage = message('TRADE_CHECKLIST_UPDATE')
+  await notify(
+    chat([message('REQUEST_MESSAGING', ['SECOND_DEGREE']), newMessage]),
+    newMessage
+  )
+  expect(scheduleNotificationAsync).toHaveBeenCalledWith(
+    expect.objectContaining({
+      content: expect.objectContaining({
+        title: 'Friend of a friend',
+        body: 'Friend of a friend updated the trade checklist.',
+      }),
+    })
+  )
+})
+
+it('uses the offer relationship for an outgoing chat and prefers its archived copy', () => {
+  const offer = Schema.decodeUnknownSync(OneOfferInState)({
+    offerInfo: {
+      id: 1,
+      offerId,
+      createdAt: '2026-09-04T00:00:00.000Z',
+      modifiedAt: '2026-09-04T00:00:00.000Z',
+      privatePart: {
+        commonFriends: [],
+        friendLevel: ['CLUB'],
+        symmetricKey: 'test-key',
+      },
+      publicPart: {
+        offerPublicKey: senderPublicKey,
+        location: [],
+        offerDescription: 'Test',
+        amountBottomLimit: 10,
+        amountTopLimit: 100,
+        feeState: 'WITHOUT_FEE',
+        feeAmount: 0,
+        locationState: [],
+        paymentMethod: [],
+        btcNetwork: [],
+        currency: 'USD',
+        spokenLanguages: [],
+        offerType: 'SELL',
+        activePriceState: 'NONE',
+        activePriceValue: 0,
+        activePriceCurrency: 'USD',
+        active: true,
+        groupUuids: [],
+      },
+    },
+    flags: {},
+  })
+  store.set(offersAtom, [offer])
+  expect(
+    getChatNotificationName(store.get, chat([], {type: 'theirOffer', offerId}))
+  ).toBe('Club member')
+  const archivedOffer = {
+    ...offer,
+    offerInfo: {
+      ...offer.offerInfo,
+      privatePart: {
+        ...offer.offerInfo.privatePart,
+        friendLevel: Schema.decodeSync(Schema.Array(FriendLevel))([
+          'FIRST_DEGREE',
+        ]),
+      },
+    },
+  }
+  expect(
+    getChatNotificationName(
+      store.get,
+      chat([], {type: 'theirOffer', offerId, offer: archivedOffer})
+    )
+  ).toBe('Direct friend')
+})

--- a/apps/mobile/src/utils/notifications/chatNotifications.ts
+++ b/apps/mobile/src/utils/notifications/chatNotifications.ts
@@ -29,6 +29,7 @@ import {translationAtom} from '../localization/I18nProvider'
 import {useAppState} from '../useAppState'
 import {conversationId, toAndroidAvatar} from './conversationShortcuts'
 import {displayLocalNotification} from './displayLocalNotification'
+import {getChatNotificationName} from './getChatNotificationName'
 import {getChannelForMessages} from './notificationChannels'
 import {SystemChatNotificationData} from './SystemNotificationData.brand'
 
@@ -168,12 +169,11 @@ export async function showChatNotification({
   const chat = inbox.chats.find(
     (one) => one.chat.otherSide.publicKey === newMessage.message.senderPublicKey
   )
-  // Same name and avatar the chat screen shows: revealed identity if there is
-  // one, otherwise the seeded anonymous ones.
   const otherSide = chat ? getOtherSideData(chat.chat) : undefined
-  const userName = otherSide?.userName
+  const store = getDefaultStore()
+  const userName = chat ? getChatNotificationName(store.get, chat) : undefined
 
-  const {t} = getDefaultStore().get(translationAtom)
+  const {t} = store.get(translationAtom)
   const chatData = SystemChatNotificationData.encode(
     new SystemChatNotificationData({
       inbox: inbox.inbox.privateKey.publicKeyPemBase64,

--- a/apps/mobile/src/utils/notifications/conversationShortcuts.ts
+++ b/apps/mobile/src/utils/notifications/conversationShortcuts.ts
@@ -22,6 +22,7 @@ import compareMessages from '../../state/chat/utils/compareMessages'
 import chatShouldBeVisible from '../../state/chat/utils/isChatActive'
 import {createOpenChatLink} from '../deepLinks/createLinks'
 import reportError from '../reportError'
+import {getChatNotificationName} from './getChatNotificationName'
 
 // Launchers show only the first few; the rest still back their notifications.
 const MAX_CONVERSATION_SHORTCUTS = 10
@@ -69,7 +70,7 @@ const conversationShortcutsAtom = selectAtom(
         }
         return {
           id: conversationId(keys),
-          name: otherSide.userName,
+          name: getChatNotificationName(get, chat),
           avatar: toAndroidAvatar(otherSide.image),
           url: createOpenChatLink(keys),
         }

--- a/apps/mobile/src/utils/notifications/getChatNotificationName.ts
+++ b/apps/mobile/src/utils/notifications/getChatNotificationName.ts
@@ -1,0 +1,34 @@
+import {type Chat} from '@vexl-next/domain/src/general/messaging'
+import {type Getter} from 'jotai'
+import focusChatWithMessagesAtom from '../../state/chat/atoms/focusChatWithMessagesAtom'
+import {getOtherSideData} from '../../state/chat/atoms/selectOtherSideDataAtom'
+import {type ChatWithMessages} from '../../state/chat/domain'
+import {offerForChatOriginAtom} from '../../state/marketplace/atoms/offersState'
+import {noteForChatOriginAtom} from '../../state/notes/atoms/notesState'
+import {getOtherSideRealNameOrFriendLevel} from '../chat/getOtherSideFriendLevel'
+import {translationAtom} from '../localization/I18nProvider'
+
+export function getChatNotificationName(
+  get: Getter,
+  chat: Chat | ChatWithMessages
+): string {
+  const chatInfo = 'chat' in chat ? chat.chat : chat
+  const chatWithMessages =
+    'messages' in chat
+      ? chat
+      : get(
+          focusChatWithMessagesAtom({
+            chatId: chatInfo.id,
+            inboxKey: chatInfo.inbox.privateKey.publicKeyPemBase64,
+          })
+        )
+
+  return (
+    getOtherSideRealNameOrFriendLevel({
+      chat: chatWithMessages ? {...chatWithMessages, chat: chatInfo} : chatInfo,
+      offerInfo: get(offerForChatOriginAtom(chatInfo.origin))?.offerInfo,
+      note: get(noteForChatOriginAtom(chatInfo.origin)),
+      t: get(translationAtom).t,
+    }) ?? getOtherSideData(chatInfo).userName
+  )
+}

--- a/apps/mobile/src/utils/notifications/tradeReminderNotifications.ts
+++ b/apps/mobile/src/utils/notifications/tradeReminderNotifications.ts
@@ -11,10 +11,10 @@ import {
 } from 'expo-notifications'
 import {getDefaultStore} from 'jotai'
 import {Platform} from 'react-native'
-import {getOtherSideData} from '../../state/chat/atoms/selectOtherSideDataAtom'
 import {translationAtom} from '../localization/I18nProvider'
 import {formatDateTime} from '../localization/formatting'
 import {formattingLocaleAtom} from '../localization/formattingLocaleAtom'
+import {getChatNotificationName} from './getChatNotificationName'
 import {getChannelForTradeReminders} from './notificationChannels'
 import {TradeReminderNotificationData} from './tradeReminderNotificationData'
 
@@ -49,8 +49,7 @@ export async function scheduleTradeReminder({
   const store = getDefaultStore()
   const {t} = store.get(translationAtom)
   const locale = store.get(formattingLocaleAtom)
-  const otherSideData = getOtherSideData(chat)
-  const userName = otherSideData.userName
+  const userName = getChatNotificationName(store.get, chat)
 
   // Format the meeting time using the user's locale
   const formattedTime = formatDateTime(meetingTime, locale)


### PR DESCRIPTION
Chat notifications used a generated name even when the chat screen showed the sender's relationship. They now use the same existing labels: Direct friend, Friend of a friend, or Club member. Revealed names take precedence, and chats without relationship information retain their existing fallback.

One shared resolver covers message notifications, trade reminders, and Android conversation shortcuts. It uses received request history and the originating offer or note, matching the chat UI. Existing translated strings and notification grouping are preserved.

Closes #2720.

Verification:
- Mobile typecheck; repository format and lint pass. Existing deprecation warnings remain.
- 24 tests across four relevant suites pass, including 12 new notification regression cases.
- Android API 37 emulator running a fresh local native build: actual notification APIs with synthetic local chat fixtures verify displayed titles and Android MessagingStyle sender names for direct friends, friends of friends, club members, revealed names, and unknown relationships. Scheduled trade-reminder title checked through the native scheduler and the reminder cancelled afterward.
- Independent review found no blocking issues. iOS payload behavior is covered by tests; no iOS device run was performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Chat notifications now use the most relevant available name, including revealed names, relationship details, and note or offer context.
  * Conversation shortcuts and trade reminder notifications now use the same improved chat naming.
  * Notifications continue to fall back to usernames when no other name or relationship information is available.
  * Android notifications include updated sender details, while request, trade reminder, checklist, and archived-offer notifications provide more consistent messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->