### PR TITLE
perf: avoid building offer atoms just to display a count

### DIFF
--- a/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/MyOffersListHeader.tsx
+++ b/apps/mobile/src/components/InsideRouter/components/MarketplaceScreen/components/MyOffersListHeader.tsx
@@ -3,7 +3,7 @@ import {useAtom, useAtomValue} from 'jotai'
 import React, {useCallback} from 'react'
 import {Stack, useTheme, XStack} from 'tamagui'
 import {
-  myOffersSortedAtomsAtom,
+  myOffersCountAtom,
   selectedMyOffersSortingOptionAtom,
 } from '../../../../../state/marketplace/atoms/myOffers'
 import {useTranslation} from '../../../../../utils/localization/I18nProvider'
@@ -16,8 +16,7 @@ function MyOffersListHeader(): React.ReactElement | null {
   const {t} = useTranslation()
   const locale = useAtomValue(formattingLocaleAtom)
   const theme = useTheme()
-  const myOffersSortedAtoms = useAtomValue(myOffersSortedAtomsAtom)
-  const allOffersCount = myOffersSortedAtoms.length
+  const allOffersCount = useAtomValue(myOffersCountAtom)
   const [sortingOption, setSortingOption] = useAtom(
     selectedMyOffersSortingOptionAtom
   )
@@ -33,7 +32,7 @@ function MyOffersListHeader(): React.ReactElement | null {
       ? t('marketplace.sortByOldest')
       : t('marketplace.sortByNewest')
 
-  if (myOffersSortedAtoms.length === 0) {
+  if (allOffersCount === 0) {
     return null
   }
 

--- a/apps/mobile/src/state/marketplace/atoms/myOffers.ts
+++ b/apps/mobile/src/state/marketplace/atoms/myOffers.ts
@@ -28,6 +28,8 @@ export const myOffersAtom = focusAtom(offersAtom, (optic) =>
   )
 )
 
+export const myOffersCountAtom = atom((get) => get(myOffersAtom).length)
+
 export const areThereAnyMyOffersAtom = atom((get) => {
   const myOffers = get(myOffersAtom)
   return myOffers.length > 0
@@ -45,11 +47,6 @@ export const myOffersSortedAtom = atom((get) => {
       : undefined
   )
 })
-
-export const myOffersSortedAtomsAtom = splitAtom(
-  myOffersSortedAtom,
-  (offer) => offer.offerInfo.offerId
-)
 
 interface MyOffersListSection {
   readonly section: MyOffersSection


### PR DESCRIPTION
The My offers header subscribed to a separate per-offer atom list solely to display its length. It now reads a scalar count from the owned offers, allowing the redundant splitAtom cache to be removed. The existing list atoms, active/paused sections, and sorting remain unchanged.

Addresses item 2 of #2622. The other performance investigations remain open.

Verification:
- Mobile typecheck; repository format and lint pass. Existing deprecation warnings remain.
- Executed the actual offer atom and sorting modules with real Jotai, optics, and Effect: foreign offers are excluded; active and paused owned offers count; sorting and pausing do not notify count subscribers; list order and offer atom identity are preserved; deleting the last owned offer gives zero.
- Android API 37 emulator: rendered the production header with real offer state and local fixtures. UI assertions and screenshots verify three owned offers across sorting/pause, one owned offer, and zero owned offers hiding the header. Temporary test entry removed afterward.
