### PR TITLE
fix(mobile): prevent freezing when publishing with zero reach

### DIFF
--- a/apps/mobile/src/components/CRUDOfferFlow/atoms/offerFormPublishAtoms.ts
+++ b/apps/mobile/src/components/CRUDOfferFlow/atoms/offerFormPublishAtoms.ts
@@ -28,7 +28,10 @@ import {
 import {showErrorAlert} from '../../ErrorAlert'
 import {askAreYouSureActionAtom, globalDialogAtom} from '../../GlobalDialog'
 import {loadingOverlayDisplayedAtom} from '../../LoadingOverlayProvider'
-import {offerProgressModalActionAtoms as progressModal} from '../../UploadingOfferProgressModal/atoms'
+import {
+  offerProgressModalActionAtoms as progressModal,
+  waitUntilProgressModalIsFullyHiddenActionAtom,
+} from '../../UploadingOfferProgressModal/atoms'
 import numberOfFriendsAtom, {
   numberOfFriendsLoadedEffect,
 } from './numberOfFriendsAtom'
@@ -258,9 +261,11 @@ export function createOfferFormPublishAtoms({
 
         return true
       }).pipe(
-        Effect.catchAll((e) => {
+        Effect.tapError(() => {
           set(progressModal.hide)
-
+          return set(waitUntilProgressModalIsFullyHiddenActionAtom)
+        }),
+        Effect.catchAll((e) => {
           if (e._tag === 'NotificationPrompted') return Effect.succeed(false)
 
           if (

--- a/packages/localization/locales/bg/offers.json
+++ b/packages/localization/locales/bg/offers.json
@@ -209,7 +209,7 @@
   "offerForm.friendLevel.reachPeople": "Достигаш до {{count}} души",
   "offerForm.friendLevel.reachPeopleFormatted": "Достигаш до {{localizedString}} души",
   "offerForm.errorCreatingOffer": "Грешка при създаване на оферта",
-  "offerForm.seemsYouHaveReachNoVexlers": "Изглежда все още няма никой, за когото да криптираш офертата си. Добави още контакти или се присъедини към Vexl клуб, за да увеличиш обхвата си.",
+  "offerForm.seemsYouHaveReachNoVexlers": "Все още не си импортирал никакви контакти. Офертата ти не може да бъде публикувана с нулев обхват, защото никой няма да я види. Импортирай контакти или се присъедини към Vexl клуб, за да достигнеш до някого.",
   "offerForm.errorSearchingForAvailableLocation": "Грешка при търсене на наличните местоположения",
   "offerForm.offerEncryption.encryptingYourOffer": "Вашата оферта се криптира ...",
   "offerForm.offerEncryption.dontShutDownTheApp": "Не затваряйте приложението докато тече криптирането. Може да отнеме няколко минути.",

--- a/packages/localization/locales/cs/offers.json
+++ b/packages/localization/locales/cs/offers.json
@@ -209,7 +209,7 @@
   "offerForm.friendLevel.reachPeople": "Oslovíš {{count}} lidí",
   "offerForm.friendLevel.reachPeopleFormatted": "Oslovíš {{localizedString}} lidí",
   "offerForm.errorCreatingOffer": "Chyba při vytváření nabídky",
-  "offerForm.seemsYouHaveReachNoVexlers": "Vypadá to, že zatím není nikdo, pro koho by šlo nabídku zašifrovat. Přidej další kontakty nebo se připoj k Vexl Clubu a rozšiř svůj dosah.",
+  "offerForm.seemsYouHaveReachNoVexlers": "Zatím nemáš importované žádné kontakty. Tvoji nabídku nejde zveřejnit s nulovým dosahem, protože by ji nikdo neviděl. Importuj kontakty nebo se přidej do Vexl Clubu, ať někoho oslovíš.",
   "offerForm.errorSearchingForAvailableLocation": "Chyba při vyhledávání dostupných lokalit",
   "offerForm.offerEncryption.encryptingYourOffer": "Šifrování tvé nabídky ...",
   "offerForm.offerEncryption.dontShutDownTheApp": "Nevypínej, prosím, aplikaci během šifrování nabídky. Může to trvat několik minut.",

--- a/packages/localization/locales/de/offers.json
+++ b/packages/localization/locales/de/offers.json
@@ -209,7 +209,7 @@
   "offerForm.friendLevel.reachPeople": "Du erreichst {{count}} Personen",
   "offerForm.friendLevel.reachPeopleFormatted": "Du erreichst {{localizedString}} Personen",
   "offerForm.errorCreatingOffer": "Fehler beim Erstellen des Angebots",
-  "offerForm.seemsYouHaveReachNoVexlers": "Es sieht so aus, als gäbe es noch niemanden, für den dein Angebot verschlüsselt werden kann. Füge mehr Kontakte hinzu oder tritt einem Vexl Club bei, um deine Reichweite zu vergrößern.",
+  "offerForm.seemsYouHaveReachNoVexlers": "Du hast noch keine Kontakte importiert. Dein Angebot kann mit einer Reichweite von null nicht veröffentlicht werden, weil es niemand sehen würde. Importiere Kontakte oder tritt einem Vexl Club bei, um jemanden zu erreichen.",
   "offerForm.errorSearchingForAvailableLocation": "Fehler bei der Suche nach verfügbaren Standorten",
   "offerForm.offerEncryption.encryptingYourOffer": "Verschlüssele dein Angebot ...",
   "offerForm.offerEncryption.dontShutDownTheApp": "Schalte die App während des Verschlüsselns nicht aus. Dies kann mehrere Minuten dauern.",

--- a/packages/localization/locales/en/offers.json
+++ b/packages/localization/locales/en/offers.json
@@ -209,7 +209,7 @@
   "offerForm.friendLevel.reachPeople": "You reach {{count}} people",
   "offerForm.friendLevel.reachPeopleFormatted": "You reach {{localizedString}} people",
   "offerForm.errorCreatingOffer": "Error while creating offer",
-  "offerForm.seemsYouHaveReachNoVexlers": "It looks like there's no one to encrypt your offer for yet. Add more contacts or join a Vexl Club to grow your reach.",
+  "offerForm.seemsYouHaveReachNoVexlers": "You haven't imported any contacts yet. Your offer can't be published with zero reach because no one would see it. Import contacts or join a Vexl Club to reach someone.",
   "offerForm.errorSearchingForAvailableLocation": "Error while searching for available locations",
   "offerForm.offerEncryption.encryptingYourOffer": "Encrypting your offer ...",
   "offerForm.offerEncryption.dontShutDownTheApp": "Don’t shut down the app while encrypting. It can take several minutes.",

--- a/packages/localization/locales/es/offers.json
+++ b/packages/localization/locales/es/offers.json
@@ -209,7 +209,7 @@
   "offerForm.friendLevel.reachPeople": "Llegas a {{count}} personas",
   "offerForm.friendLevel.reachPeopleFormatted": "Llegas a {{localizedString}} personas",
   "offerForm.errorCreatingOffer": "Error al crear oferta",
-  "offerForm.seemsYouHaveReachNoVexlers": "Parece que todavía no hay nadie para quien cifrar tu oferta. Añade más contactos o únete a un Vexl Club para aumentar tu alcance.",
+  "offerForm.seemsYouHaveReachNoVexlers": "Aún no has importado ningún contacto. Tu oferta no se puede publicar con un alcance de cero porque nadie la vería. Importa contactos o únete a un Vexl Club para llegar a alguien.",
   "offerForm.errorSearchingForAvailableLocation": "Error al buscar localidades disponibles",
   "offerForm.offerEncryption.encryptingYourOffer": "Cifrando tu oferta ...",
   "offerForm.offerEncryption.dontShutDownTheApp": "No cierres la aplicación mientras se encripta. Puede tardar varios minutos.",

--- a/packages/localization/locales/fr/offers.json
+++ b/packages/localization/locales/fr/offers.json
@@ -209,7 +209,7 @@
   "offerForm.friendLevel.reachPeople": "Tu touches {{count}} personnes",
   "offerForm.friendLevel.reachPeopleFormatted": "Tu touches {{localizedString}} personnes",
   "offerForm.errorCreatingOffer": "Erreur lors de la création de l'offre",
-  "offerForm.seemsYouHaveReachNoVexlers": "Il semble qu'il n'y ait encore personne pour qui chiffrer ton offre. Ajoute plus de contacts ou rejoins un Vexl Club pour étendre ta portée.",
+  "offerForm.seemsYouHaveReachNoVexlers": "Tu n’as encore importé aucun contact. Ton offre ne peut pas être publiée avec une portée nulle, car personne ne la verrait. Importe tes contacts ou rejoins un Vexl Club pour toucher quelqu’un.",
   "offerForm.errorSearchingForAvailableLocation": "Erreur lors de la recherche de lieux disponibles",
   "offerForm.offerEncryption.encryptingYourOffer": "Cryptage de votre offre ...",
   "offerForm.offerEncryption.dontShutDownTheApp": "Ne fermez pas l'application pendant le cryptage. Cela peut prendre plusieurs minutes.",

--- a/packages/localization/locales/it/offers.json
+++ b/packages/localization/locales/it/offers.json
@@ -209,7 +209,7 @@
   "offerForm.friendLevel.reachPeople": "Raggiungi {{count}} persone",
   "offerForm.friendLevel.reachPeopleFormatted": "Raggiungi {{localizedString}} persone",
   "offerForm.errorCreatingOffer": "Errore durante la creazione dell'offerta",
-  "offerForm.seemsYouHaveReachNoVexlers": "Sembra che al momento non ci sia nessuno per cui crittografare la tua offerta. Aggiungi altri contatti o unisciti a un Vexl Club per aumentare la tua portata.",
+  "offerForm.seemsYouHaveReachNoVexlers": "Non hai ancora importato nessun contatto. La tua offerta non può essere pubblicata con una portata pari a zero, perché nessuno la vedrebbe. Importa i contatti o unisciti a un Vexl Club per raggiungere qualcuno.",
   "offerForm.errorSearchingForAvailableLocation": "Errore durante la ricerca delle sedi disponibili",
   "offerForm.offerEncryption.encryptingYourOffer": "Crittografia dell'offerta ...",
   "offerForm.offerEncryption.dontShutDownTheApp": "Non spegnere l'app durante la crittografia. Può richiedere diversi minuti.",

--- a/packages/localization/locales/ja/offers.json
+++ b/packages/localization/locales/ja/offers.json
@@ -209,7 +209,7 @@
   "offerForm.friendLevel.reachPeople": "{{count}}人に届く",
   "offerForm.friendLevel.reachPeopleFormatted": "{{localizedString}}人に届く",
   "offerForm.errorCreatingOffer": "オファーの作成中にエラーが発生しました",
-  "offerForm.seemsYouHaveReachNoVexlers": "オファーを暗号化して届けられる相手がまだいないようです。連絡先を追加するか Vexl クラブに参加して、リーチを広げてください。",
+  "offerForm.seemsYouHaveReachNoVexlers": "まだ連絡先をインポートしていません。リーチがゼロだと誰にも見てもらえないため、オファーを公開できません。連絡先をインポートするか Vexl クラブに参加して、誰かに届けましょう。",
   "offerForm.errorSearchingForAvailableLocation": "利用可能な場所を検索中にエラーが発生しました",
   "offerForm.offerEncryption.encryptingYourOffer": "オファーを暗号化しています...",
   "offerForm.offerEncryption.dontShutDownTheApp": "暗号化中にアプリをシャットダウンしないでください。数分かかる場合があります。",

--- a/packages/localization/locales/nl/offers.json
+++ b/packages/localization/locales/nl/offers.json
@@ -209,7 +209,7 @@
   "offerForm.friendLevel.reachPeople": "Je bereikt {{count}} mensen",
   "offerForm.friendLevel.reachPeopleFormatted": "Je bereikt {{localizedString}} mensen",
   "offerForm.errorCreatingOffer": "Fout bij het aanmaken aanbieding",
-  "offerForm.seemsYouHaveReachNoVexlers": "Het lijkt erop dat er nog niemand is om je aanbod voor te versleutelen. Voeg meer contacten toe of word lid van een Vexl Club om je bereik te vergroten.",
+  "offerForm.seemsYouHaveReachNoVexlers": "Je hebt nog geen contacten geïmporteerd. Je aanbieding kan niet worden gepubliceerd met een bereik van nul, want niemand zou die zien. Importeer contacten of word lid van een Vexl Club om iemand te bereiken.",
   "offerForm.errorSearchingForAvailableLocation": "Fout bij het zoeken naar beschikbare locaties",
   "offerForm.offerEncryption.encryptingYourOffer": "Versleutelen van uw aanbieding ...",
   "offerForm.offerEncryption.dontShutDownTheApp": "Sluit de app niet af tijdens het coderen. Het kan enkele minuten duren.",

--- a/packages/localization/locales/pl/offers.json
+++ b/packages/localization/locales/pl/offers.json
@@ -209,7 +209,7 @@
   "offerForm.friendLevel.reachPeople": "Docierasz do {{count}} osób",
   "offerForm.friendLevel.reachPeopleFormatted": "Docierasz do {{localizedString}} osób",
   "offerForm.errorCreatingOffer": "Błąd podczas tworzenia oferty",
-  "offerForm.seemsYouHaveReachNoVexlers": "Wygląda na to, że nie ma jeszcze nikogo, dla kogo można by zaszyfrować twoją ofertę. Dodaj więcej kontaktów lub dołącz do klubu Vexl, aby zwiększyć swój zasięg.",
+  "offerForm.seemsYouHaveReachNoVexlers": "Nie masz jeszcze zaimportowanych kontaktów. Twojej oferty nie można opublikować z zerowym zasięgiem, bo nikt by jej nie zobaczył. Zaimportuj kontakty lub dołącz do klubu Vexl, aby do kogoś dotrzeć.",
   "offerForm.errorSearchingForAvailableLocation": "Błąd podczas wyszukiwania dostępnych miejsc",
   "offerForm.offerEncryption.encryptingYourOffer": "Szyfrowanie oferty...",
   "offerForm.offerEncryption.dontShutDownTheApp": "Nie wyłączaj aplikacji podczas szyfrowania. Może to potrwać kilka minut.",

--- a/packages/localization/locales/pt/offers.json
+++ b/packages/localization/locales/pt/offers.json
@@ -209,7 +209,7 @@
   "offerForm.friendLevel.reachPeople": "Alcanças {{count}} pessoas",
   "offerForm.friendLevel.reachPeopleFormatted": "Alcanças {{localizedString}} pessoas",
   "offerForm.errorCreatingOffer": "Erro ao criar a oferta",
-  "offerForm.seemsYouHaveReachNoVexlers": "Parece que ainda não há ninguém para quem encriptar a tua oferta. Adiciona mais contactos ou adere a um Vexl Club para aumentares o teu alcance.",
+  "offerForm.seemsYouHaveReachNoVexlers": "Ainda não importaste nenhum contacto. A tua oferta não pode ser publicada com alcance zero, porque ninguém a veria. Importa contactos ou adere a um Vexl Club para chegares a alguém.",
   "offerForm.errorSearchingForAvailableLocation": "Erro ao procurar locais disponíveis",
   "offerForm.offerEncryption.encryptingYourOffer": "Encriptar a sua oferta ...",
   "offerForm.offerEncryption.dontShutDownTheApp": "Não desligue a aplicação durante a encriptação. Pode demorar vários minutos.",

--- a/packages/localization/locales/sk/offers.json
+++ b/packages/localization/locales/sk/offers.json
@@ -209,7 +209,7 @@
   "offerForm.friendLevel.reachPeople": "Oslovíš {{count}} ľudí",
   "offerForm.friendLevel.reachPeopleFormatted": "Oslovíš {{localizedString}} ľudí",
   "offerForm.errorCreatingOffer": "Chyba pri vytváraní ponuky",
-  "offerForm.seemsYouHaveReachNoVexlers": "Zdá sa, že zatiaľ nie je nikto, pre koho by si mohol zašifrovať svoju ponuku. Pridaj viac kontaktov alebo sa pridaj do Vexl klubu a zvýš svoj dosah.",
+  "offerForm.seemsYouHaveReachNoVexlers": "Zatiaľ nemáš importované žiadne kontakty. Tvoju ponuku nemožno zverejniť s nulovým dosahom, pretože by ju nikto nevidel. Importuj kontakty alebo sa pridaj do Vexl Clubu, aby si niekoho oslovil.",
   "offerForm.errorSearchingForAvailableLocation": "Chyba pri vyhľadávaní dostupných lokalít",
   "offerForm.offerEncryption.encryptingYourOffer": "Šifrovanie tvojej ponuky ...",
   "offerForm.offerEncryption.dontShutDownTheApp": "Nevypínaj prosím aplikáciu počas šifrovania tvojej ponuky. Môže to trvať niekoľko minút.",

--- a/packages/localization/locales/sw/offers.json
+++ b/packages/localization/locales/sw/offers.json
@@ -209,7 +209,7 @@
   "offerForm.friendLevel.reachPeople": "Unafikia watu {{count}}",
   "offerForm.friendLevel.reachPeopleFormatted": "Unafikia watu {{localizedString}}",
   "offerForm.errorCreatingOffer": "Hitilafu wakati wa kuunda ofa",
-  "offerForm.seemsYouHaveReachNoVexlers": "Inaonekana bado hakuna mtu wa kufikiwa na ofa yako iliyosimbwa kwa njia fiche. Ongeza anwani zaidi au ujiunge na Klabu ya Vexl ili kuwafikia watu zaidi.",
+  "offerForm.seemsYouHaveReachNoVexlers": "Bado hujaingiza anwani zozote. Ofa yako haiwezi kuchapishwa ikiwa haimfikii mtu yeyote, kwa sababu hakuna atakayeiona. Ingiza anwani au ujiunge na Klabu ya Vexl ili kumfikia mtu.",
   "offerForm.errorSearchingForAvailableLocation": "Hitilafu wakati wa kutafuta maeneo yanayopatikana",
   "offerForm.offerEncryption.encryptingYourOffer": "Inasimba ofa yako...",
   "offerForm.offerEncryption.dontShutDownTheApp": "Usifunge programu wakati wa kusimba. Inaweza kuchukua dakika kadhaa.",

--- a/packages/localization/locales/zh/offers.json
+++ b/packages/localization/locales/zh/offers.json
@@ -209,7 +209,7 @@
   "offerForm.friendLevel.reachPeople": "你可以触达 {{count}} 人",
   "offerForm.friendLevel.reachPeopleFormatted": "你可以触达 {{localizedString}} 人",
   "offerForm.errorCreatingOffer": "创建报价时出错",
-  "offerForm.seemsYouHaveReachNoVexlers": "看来目前还没有可以为你加密出价的人。添加更多联系人或加入 Vexl 俱乐部以扩大触达范围。",
+  "offerForm.seemsYouHaveReachNoVexlers": "你还没有导入任何联系人。触达人数为零时无法发布出价，因为没有人能看到。导入联系人或加入 Vexl 俱乐部，触达其他人。",
   "offerForm.errorSearchingForAvailableLocation": "搜索可用地点时出错",
   "offerForm.offerEncryption.encryptingYourOffer": "正在加密您的报价……",
   "offerForm.offerEncryption.dontShutDownTheApp": "不要在加密时关闭此应用程序。它可能需要几分钟。",


### PR DESCRIPTION
Publishing an offer with zero reach could leave the iOS app stuck on the offer form. The zero-recipient error tried to open a dialog while the encryption progress modal was still dismissing, so UIKit rejected the dialog.

Wait for the progress modal to fully disappear before handling publish errors. The no-contact message now explains that no contacts have been imported and the offer cannot be published because nobody would see it. Updated all 14 shipped languages.

Validation:
- Reproduced on a native iPhone 17 Pro simulator build, iOS 26.5, against the local dev backend with a fresh account and contact import skipped. Confirmed UIKit's “already presenting” error.
- Verified the fixed dialog visually, closed it, retried publishing, and confirmed the form remained responsive with its contents intact. Confirmed My offers was still empty. No further modal-presentation errors.
- Mobile/localization typecheck, repository formatting and lint, and translation checks passed.

Maestro could not read the native error dialog through accessibility, so its text was checked in screenshots; Close/retry and the restored form were exercised with Maestro.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Offer creation errors now wait for the upload progress indicator to fully close before displaying the error, preventing overlapping or lingering UI states.

- **Localization**
  - Clarified the zero-reach publishing message across supported languages. The message now explains that contacts must be imported—or users should join a Vexl Club—before an offer can reach anyone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->