### PR TITLE
fix(mobile): keep chats, offers and contacts out of iCloud backups

### DIFF
--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -8,6 +8,8 @@ import './src/utils/notifications/displayLocalNotification'
 import './src/utils/setupCrypto'
 
 import './src/utils/setupSentry'
+// Order matters: runs before MMKV creates its directory on first use.
+import './src/utils/setupBackupExclusion'
 // INITIAL SETUP - KEEP THIS AT THE TOP
 import '@vexl-next/ui/src/config/tamagui.config'
 import 'intl-pluralrules'

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -40,6 +40,7 @@
     "@vexl-next/domain": "0.0.0",
     "@vexl-next/expo-android-notification-presentation": "0.0.0",
     "@vexl-next/expo-background-notification-socket": "0.0.0",
+    "@vexl-next/expo-ios-backup-exclusion": "0.0.0",
     "@vexl-next/fix-brorand-for-expo": "0.0.0",
     "@vexl-next/generic-utils": "0.0.0",
     "@vexl-next/localization": "0.0.0",

--- a/apps/mobile/src/utils/setupBackupExclusion.ts
+++ b/apps/mobile/src/utils/setupBackupExclusion.ts
@@ -1,0 +1,25 @@
+import {excludeDirectoryFromBackup} from '@vexl-next/expo-ios-backup-exclusion'
+import {Directory, Paths} from 'expo-file-system'
+import {IMAGES_DIRECTORY, PROFILE_PICTURE_DIRECTORY} from './fsDirectories'
+import reportError from './reportError'
+
+// MMKV (chats, offers, contacts, clubs, ...) and chat images are device-local.
+// A backup restored to another device could not use them anyway: the session
+// secret is THIS_DEVICE_ONLY, so the user lands logged out. Keeping them out
+// of backups means they never leave the device in plaintext.
+const DEVICE_LOCAL_DIRECTORIES = [
+  'mmkv',
+  IMAGES_DIRECTORY,
+  PROFILE_PICTURE_DIRECTORY,
+]
+
+for (const directory of DEVICE_LOCAL_DIRECTORIES) {
+  try {
+    excludeDirectoryFromBackup(new Directory(Paths.document, directory).uri)
+  } catch (e) {
+    reportError(
+      'error',
+      new Error(`Could not exclude ${directory} from backup`, {cause: e})
+    )
+  }
+}

--- a/docs/mobile_local_data_backups.md
+++ b/docs/mobile_local_data_backups.md
@@ -1,0 +1,53 @@
+# Device-local data and OS backups
+
+Chats, offers, contacts, club keys and chat images exist only on the device.
+The session secret that would make them usable lives in the keychain /
+keystore as `THIS_DEVICE_ONLY`, so a backup restored to another device lands
+the user logged out with data it cannot use. Backing that data up therefore
+only creates plaintext copies outside the device. The app keeps it out of
+backups on both platforms.
+
+## Android
+
+Expo's config plugin for `expo-secure-store` sets the app's Auto Backup rules
+(`fullBackupContent` for API 30 and lower, `dataExtractionRules` for API 31
+and higher, both cloud backup and device transfer). Those rules include only
+the `sharedpref` domain and exclude SecureStore's own preferences. Files and
+databases are never backed up, which covers MMKV (`files/mmkv`), chat images
+and AsyncStorage.
+
+This holds as long as no other plugin sets its own backup rules; the
+expo-secure-store plugin warns at prebuild if one does. If custom rules are
+ever added they must keep the `file` and `database` domains excluded.
+
+## iOS
+
+The Documents directory is included in iCloud and Finder backups by default,
+and the exclusion is a per-directory file attribute, not a plist setting.
+`apps/mobile/src/utils/setupBackupExclusion.ts` runs at app start (all entry
+points go through `index.js`) and marks these Documents subdirectories with
+`NSURLIsExcludedFromBackupKey` through the local
+`@vexl-next/expo-ios-backup-exclusion` module:
+
+| Directory        | Content                                       |
+| ---------------- | --------------------------------------------- |
+| `mmkv`           | all MMKV instances (chats, offers, contacts…) |
+| `chat-images`    | images exchanged in chats                     |
+| `profilePicture` | the user's own avatar                         |
+
+The directories are created if missing so the attribute has something to
+stick to; MMKV keeps using the directory afterwards. The attribute persists
+across launches, but it is re-applied on every launch because a reinstall or
+an interrupted migration can recreate a directory without it.
+
+AsyncStorage holds the AES-encrypted session blob and small diagnostics. It
+stays in backups: without the keychain secret the blob is unreadable, and
+excluding `Library/Application Support` wholesale would also drop
+unrelated framework state.
+
+## What this does not cover
+
+Data Protection already encrypts the app container on a locked device until
+first unlock on both platforms, which is the same window in which the session
+secret is available. Excluding backups does not protect against an attacker
+with access to a running, unlocked or rooted device.

--- a/packages/expo-ios-backup-exclusion/README.md
+++ b/packages/expo-ios-backup-exclusion/README.md
@@ -1,0 +1,7 @@
+# expo-ios-backup-exclusion
+
+One function, `excludeDirectoryFromBackup(uri)`, that marks a directory with
+`NSURLIsExcludedFromBackupKey` on iOS. Android is a no-op because the app's
+backup rules (from expo-secure-store) already include only shared preferences.
+
+Why the app uses it: see `docs/mobile_local_data_backups.md`.

--- a/packages/expo-ios-backup-exclusion/eslint.config.mjs
+++ b/packages/expo-ios-backup-exclusion/eslint.config.mjs
@@ -1,0 +1,3 @@
+import eslintConfig from '@vexl-next/eslint-config/index.mjs'
+
+export default [...eslintConfig]

--- a/packages/expo-ios-backup-exclusion/expo-module.config.json
+++ b/packages/expo-ios-backup-exclusion/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["ExpoIosBackupExclusionModule"]
+  }
+}

--- a/packages/expo-ios-backup-exclusion/ios/ExpoIosBackupExclusion.podspec
+++ b/packages/expo-ios-backup-exclusion/ios/ExpoIosBackupExclusion.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name = 'ExpoIosBackupExclusion'
+  s.version = package['version']
+  s.summary = package['description']
+  s.description = package['description']
+  s.license = 'MIT'
+  s.author = 'Vexl'
+  s.homepage = 'https://vexl.it'
+  s.platforms = { :ios => '16.4' }
+  s.swift_version = '5.9'
+  s.source = { git: 'https://github.com/vexl-it/vexl.git' }
+  s.static_framework = true
+  s.dependency 'ExpoModulesCore'
+  s.source_files = '**/*.swift'
+end

--- a/packages/expo-ios-backup-exclusion/ios/ExpoIosBackupExclusionModule.swift
+++ b/packages/expo-ios-backup-exclusion/ios/ExpoIosBackupExclusionModule.swift
@@ -1,0 +1,18 @@
+import ExpoModulesCore
+
+public class ExpoIosBackupExclusionModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("ExpoIosBackupExclusion")
+
+    // The flag lives on the directory, so it must exist before it can be set.
+    Function("excludeDirectoryFromBackup") { (uri: String) in
+      guard var url = URL(string: uri), url.isFileURL else {
+        throw Exception(name: "InvalidUri", description: "Expected a file:// URI, got \(uri)")
+      }
+      try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+      var values = URLResourceValues()
+      values.isExcludedFromBackup = true
+      try url.setResourceValues(values)
+    }
+  }
+}

--- a/packages/expo-ios-backup-exclusion/package.json
+++ b/packages/expo-ios-backup-exclusion/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@vexl-next/expo-ios-backup-exclusion",
+  "version": "0.0.0",
+  "description": "Keeps device-local directories out of iCloud and Finder backups on iOS",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint .",
+    "format": "prettier --check \"**/*.{js,mjs,cjs,ts,json,md}\"",
+    "format:fix": "prettier --write \"**/*.{js,mjs,cjs,ts,json,md}\"",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@vexl-next/eslint-config": "0.0.0",
+    "@vexl-next/prettier-config": "0.0.0",
+    "@vexl-next/tsconfig": "0.0.0",
+    "eslint": "^9.20.0",
+    "expo": "~57.0.15",
+    "prettier": "^3.3.2",
+    "react-native": "0.86.2",
+    "typescript": "~6.0.3"
+  },
+  "peerDependencies": {
+    "expo": "*",
+    "react-native": "*"
+  },
+  "prettier": "@vexl-next/prettier-config",
+  "private": true
+}

--- a/packages/expo-ios-backup-exclusion/src/index.ts
+++ b/packages/expo-ios-backup-exclusion/src/index.ts
@@ -1,0 +1,22 @@
+import {requireNativeModule} from 'expo-modules-core'
+import {Platform} from 'react-native'
+
+interface IosBackupExclusionNativeModule {
+  readonly excludeDirectoryFromBackup: (uri: string) => void
+}
+
+/**
+ * Sets `NSURLIsExcludedFromBackupKey` on the directory (creating it if
+ * needed) so iCloud and Finder backups skip it and everything inside. The flag
+ * is stored on the directory itself, so call this on every launch in case the
+ * directory was recreated.
+ *
+ * No-op on Android: the app's Auto Backup rules include only shared
+ * preferences, so files are never backed up there.
+ */
+export function excludeDirectoryFromBackup(uri: string): void {
+  if (Platform.OS !== 'ios') return
+  requireNativeModule<IosBackupExclusionNativeModule>(
+    'ExpoIosBackupExclusion'
+  ).excludeDirectoryFromBackup(uri)
+}

--- a/packages/expo-ios-backup-exclusion/tsconfig.json
+++ b/packages/expo-ios-backup-exclusion/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@vexl-next/tsconfig/base.json",
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "moduleResolution": "node",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -850,6 +850,9 @@ importers:
       '@vexl-next/expo-background-notification-socket':
         specifier: 0.0.0
         version: link:../../packages/expo-background-notification-socket
+      '@vexl-next/expo-ios-backup-exclusion':
+        specifier: 0.0.0
+        version: link:../../packages/expo-ios-backup-exclusion
       '@vexl-next/fix-brorand-for-expo':
         specifier: 0.0.0
         version: link:../../packages/fix-brorand-for-expo
@@ -1774,6 +1777,33 @@ importers:
       effect:
         specifier: ^3.20.0
         version: 3.21.4
+    devDependencies:
+      '@vexl-next/eslint-config':
+        specifier: 0.0.0
+        version: link:../../tooling/eslint
+      '@vexl-next/prettier-config':
+        specifier: 0.0.0
+        version: link:../../tooling/prettier
+      '@vexl-next/tsconfig':
+        specifier: 0.0.0
+        version: link:../../tooling/tsconfig
+      eslint:
+        specifier: ^9.20.0
+        version: 9.39.4(jiti@2.7.0)
+      expo:
+        specifier: ~57.0.15
+        version: 57.0.15(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      prettier:
+        specifier: ^3.3.2
+        version: 3.8.4
+      react-native:
+        specifier: 0.86.2
+        version: 0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+      typescript:
+        specifier: ~6.0.3
+        version: 6.0.3
+
+  packages/expo-ios-backup-exclusion:
     devDependencies:
       '@vexl-next/eslint-config':
         specifier: 0.0.0


### PR DESCRIPTION
Relates to #2604. Alternative to #2718.

## Problem

Chats, offers, contacts, club keys and chat images live only on the device. The session secret that makes them usable is stored `THIS_DEVICE_ONLY`, so a backup restored to another phone lands the user logged out with data it cannot use. On iOS that data was still copied in plaintext into iCloud and Finder backups, which is the one realistic way it leaves the device. On a locked device the OS already encrypts the app container in the same window in which the session secret is available, so encrypting MMKV ourselves adds little there. #2604 asked for MMKV encryption; this PR closes the backup exposure directly without a key, a migration, or any change to startup and headless behaviour.

## What changes

- New local Expo module `@vexl-next/expo-ios-backup-exclusion` (Apple only) with one function that sets `NSURLIsExcludedFromBackupKey` on a directory, creating it if missing. Same layout as the existing local modules.
- `apps/mobile/src/utils/setupBackupExclusion.ts` runs from `index.js` at every app start, before MMKV is first used, and marks `Documents/mmkv`, `Documents/chat-images` and `Documents/profilePicture`. Failures are reported to Sentry.
- `docs/mobile_local_data_backups.md` records the policy for both platforms.

Android needs no change: the generated manifest already uses expo-secure-store's Auto Backup and data-extraction rules, which include only the shared-preferences domain, so MMKV files, chat images and AsyncStorage are never backed up or transferred. The doc notes the constraint that any future custom backup rules must keep it that way.

AsyncStorage (the AES-encrypted session blob) stays in iOS backups; it is unreadable without the keychain secret.

## Verification

- Typecheck, lint and format pass for the mobile app and the new package.
- Expo autolinking resolves the module for Apple.
- iOS simulator build (Debug, local flavour) succeeds after `pod install`; `ExpoIosBackupExclusionModule.swift` compiles for arm64 and x86_64.
- Not verified on a device: that a fresh iCloud backup omits the directories. Checking with a Finder backup of a device running this build would confirm it.

This requires a new native iOS build; a JS-only preview on an existing binary will report the module missing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added protection to keep device-local mobile data, including chats, offers, contacts, keys, and images, out of iOS and Android backups.
  - Added automatic setup during app startup for relevant local storage directories.
  - Added a reusable iOS backup-exclusion capability for app directories.

- **Documentation**
  - Added documentation describing backup behavior, platform differences, and remaining device encryption protections.
  - Added usage documentation for the backup-exclusion capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
