### PR TITLE
#2704 Preserve the progress dialog theme during account deletion

### DIFF
--- a/apps/mobile/src/components/UploadingOfferProgressModal/index.tsx
+++ b/apps/mobile/src/components/UploadingOfferProgressModal/index.tsx
@@ -1,6 +1,7 @@
 import {ProgressDialog} from '@vexl-next/ui'
 import {useAtomValue, useSetAtom} from 'jotai'
-import React, {useCallback, useEffect} from 'react'
+import React, {useCallback, useEffect, useState} from 'react'
+import {Theme, useThemeName} from 'tamagui'
 import {
   progressModalNativeModalUpAtom,
   uploadingProgressModalDataAtom,
@@ -10,6 +11,16 @@ function UploadingOfferProgressModal(): React.JSX.Element {
   const data = useAtomValue(uploadingProgressModalDataAtom)
   const setNativeModalUp = useSetAtom(progressModalNativeModalUpAtom)
   const shown = data.mode === 'shown'
+  const themeName = useThemeName()
+  const [appearance, setAppearance] = useState({shown, themeName})
+
+  // Clearing account preferences must not change a dialog already on screen.
+  if (appearance.shown !== shown) {
+    setAppearance({
+      shown,
+      themeName: shown ? themeName : appearance.themeName,
+    })
+  }
 
   useEffect(() => {
     if (shown) setNativeModalUp(true)
@@ -18,28 +29,20 @@ function UploadingOfferProgressModal(): React.JSX.Element {
   const handleHidden = useCallback(() => {
     setNativeModalUp(false)
   }, [setNativeModalUp])
-
-  if (data.mode === 'hidden') {
-    return (
-      <ProgressDialog
-        visible={false}
-        title=""
-        indicateProgress={{type: 'done'}}
-        onHidden={handleHidden}
-      />
-    )
-  }
+  const dialogData = data.mode === 'shown' ? data : undefined
 
   return (
-    <ProgressDialog
-      visible
-      title={data.title}
-      bottomText={data.bottomText}
-      belowProgressLeft={data.belowProgressLeft}
-      belowProgressRight={data.belowProgressRight}
-      indicateProgress={data.indicateProgress}
-      onHidden={handleHidden}
-    />
+    <Theme name={appearance.themeName}>
+      <ProgressDialog
+        title={dialogData?.title ?? ''}
+        bottomText={dialogData?.bottomText}
+        belowProgressLeft={dialogData?.belowProgressLeft}
+        belowProgressRight={dialogData?.belowProgressRight}
+        indicateProgress={dialogData?.indicateProgress ?? {type: 'done'}}
+        visible={shown}
+        onHidden={handleHidden}
+      />
+    </Theme>
   )
 }
 


### PR DESCRIPTION
Closes #2704

Keep the progress dialog's opening theme through dismissal so clearing account preferences does not change its appearance midway through deletion, as reported by leomira. Each new progress dialog captures the current theme; the app-wide theme provider and logout flow remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the uploading progress dialog’s theme handling so it remains visually consistent when account preferences change.
  - Streamlined dialog rendering while preserving expected behavior when optional progress details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->