### PR TITLE
fix: make premium or discount text clickable

### DIFF
--- a/apps/mobile/src/components/TradeCalculator/components/TradeCalculator/components/PremiumOrDiscount.tsx
+++ b/apps/mobile/src/components/TradeCalculator/components/TradeCalculator/components/PremiumOrDiscount.tsx
@@ -1,5 +1,5 @@
 import {ChevronRight, Switch, Typography} from '@vexl-next/ui'
-import {useAtomValue} from 'jotai'
+import {useAtomValue, useSetAtom} from 'jotai'
 import React from 'react'
 import {TouchableOpacity} from 'react-native'
 import {XStack, YStack, useTheme} from 'tamagui'
@@ -20,14 +20,27 @@ function PremiumOrDiscount({
   const {t} = useTranslation()
   const theme = useTheme()
   const premiumOrDiscountEnabled = useAtomValue(premiumOrDiscountEnabledAtom)
+  const setPremiumOrDiscountEnabled = useSetAtom(
+    premiumOrDiscountSwitchActionAtom
+  )
   const feeAmount = useAtomValue(feeAmountAtom)
 
   return (
     <YStack gap="$4">
       <XStack ai="center" jc="space-between">
-        <Typography variant="paragraphSmall" color="$foregroundPrimary">
-          {t('tradeChecklist.calculateAmount.premiumOrDiscount')}
-        </Typography>
+        <TouchableOpacity
+          style={{flex: 1}}
+          activeOpacity={0.7}
+          accessibilityRole="switch"
+          accessibilityState={{checked: premiumOrDiscountEnabled}}
+          onPress={() => {
+            setPremiumOrDiscountEnabled((value) => !value)
+          }}
+        >
+          <Typography variant="paragraphSmall" color="$foregroundPrimary">
+            {t('tradeChecklist.calculateAmount.premiumOrDiscount')}
+          </Typography>
+        </TouchableOpacity>
         <Switch valueAtom={premiumOrDiscountSwitchActionAtom} />
       </XStack>
       {!!premiumOrDiscountEnabled && (


### PR DESCRIPTION
Tapping the "Premium or discount" label now toggles the calculator option. The clickable area fills the space beside the switch and uses the same action, preserving the existing fee reset behavior.

Fixes #2714.

Validation: mobile typecheck, repository formatting, and repository lint passed. Exercised the component's label handler in both directions with mocked native components and hooks. Device UI was not tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * The premium/discount setting label is now tappable, making it easier to toggle the setting on mobile.
  * The control now exposes its switch role and current state to assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->