### PR TITLE
Fix onboarding screen order after contact import

### DIFF
--- a/apps/mobile/src/components/PostLoginFlow/index.tsx
+++ b/apps/mobile/src/components/PostLoginFlow/index.tsx
@@ -6,7 +6,6 @@ import {
   type PostLoginFlowStackParamsList,
   type PostLoginFlowStackScreenProps,
 } from '../../navigationTypes'
-import {importedContactsCountAtom} from '../../state/contacts/atom/contactsStore'
 import {checkAreNotificationsEnabledAtom} from '../../state/notifications/areNotificationsEnabledAtom'
 import {
   postLoginFlowCompletedScreensAtom,
@@ -37,43 +36,35 @@ export default function PostLoginFlow(): React.ReactElement {
     postLoginFlowEffectiveCompletedScreensAtom
   )
   const storedCompletedScreens = useAtomValue(postLoginFlowCompletedScreensAtom)
-  const importedContactsCount = useAtomValue(importedContactsCountAtom)
   const checkAreNotificationsEnabled = useSetAtom(
     checkAreNotificationsEnabledAtom
   )
-  const [hasCheckedNotifications, setHasCheckedNotifications] = useState(false)
-  const [isCheckingNotifications, setIsCheckingNotifications] = useState(false)
-  const contactsImportCompleted =
-    importedContactsCount > 0 ||
-    Array.contains(storedCompletedScreens, 'contactsImport')
-  const notificationSetupCompleted = Array.contains(
-    storedCompletedScreens,
-    'notificationSetup'
+  // Only check when resuming past contacts import. Starting a check during an
+  // active import would unmount the navigator before its goNext callback runs.
+  // Use stored notification completion so cached permission state is rechecked.
+  const [isCheckingNotifications, setIsCheckingNotifications] = useState(
+    () =>
+      Array.contains(completedScreens, 'contactsImport') &&
+      !Array.contains(storedCompletedScreens, 'notificationSetup')
   )
-  const shouldCheckNotifications =
-    contactsImportCompleted &&
-    !notificationSetupCompleted &&
-    !hasCheckedNotifications
 
   useEffect(() => {
-    if (!shouldCheckNotifications) return
+    if (!isCheckingNotifications) return
 
     let shouldUpdateState = true
 
-    setIsCheckingNotifications(true)
     void Effect.runPromise(checkAreNotificationsEnabled()).finally(() => {
       if (!shouldUpdateState) return
 
-      setHasCheckedNotifications(true)
       setIsCheckingNotifications(false)
     })
 
     return () => {
       shouldUpdateState = false
     }
-  }, [checkAreNotificationsEnabled, shouldCheckNotifications])
+  }, [checkAreNotificationsEnabled, isCheckingNotifications])
 
-  if (shouldCheckNotifications || isCheckingNotifications) {
+  if (isCheckingNotifications) {
     return <></>
   }
 


### PR DESCRIPTION
## Problem

After confirming contact import, onboarding could briefly show UsageInfo before NotificationSetup. The imported-contact count triggered a notification permission check that unmounted the navigator while the import was still finishing, allowing it to restart on UsageInfo.

## What this does

- Decide whether to check notification permissions when entering the flow, keeping the navigator mounted throughout contact import.
- Preserve the sequence: ContactsImport → NotificationSetup → UsageInfo.
- Reuse the shared contact-completion state and retain the permission recheck when resuming unfinished notification setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Simplified notification setup checks during post-login onboarding.
  - Improved handling of the notification-checking state to prevent unnecessary checks and ensure the flow proceeds after completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->