### PR TITLE
feat(tooling): track legacy Expo notification sends

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2308,6 +2308,40 @@ importers:
         specifier: ~6.0.3
         version: 6.0.3
 
+  tooling/expo-token-notifier:
+    dependencies:
+      csv-parse:
+        specifier: ^6.1.0
+        version: 6.2.1
+      effect:
+        specifier: ^3.20.0
+        version: 3.21.4
+      expo-server-sdk:
+        specifier: ^5.0.0
+        version: 5.0.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.20.1
+      '@vexl-next/eslint-config':
+        specifier: 0.0.0
+        version: link:../eslint
+      '@vexl-next/prettier-config':
+        specifier: 0.0.0
+        version: link:../prettier
+      eslint:
+        specifier: ^9.20.0
+        version: 9.39.4(jiti@2.7.0)
+      prettier:
+        specifier: ^3.3.2
+        version: 3.8.4
+      typescript:
+        specifier: ~6.0.3
+        version: 6.0.3
+      undici:
+        specifier: ^7.29.1
+        version: 7.29.1
+
   tooling/generate-api-call-limits:
     dependencies:
       '@effect/platform':
@@ -7337,6 +7371,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  csv-parse@6.2.1:
+    resolution: {integrity: sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==}
+
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
     engines: {node: '>=12'}
@@ -11701,6 +11738,10 @@ packages:
 
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.29.1:
+    resolution: {integrity: sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -19497,6 +19538,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  csv-parse@6.2.1: {}
+
   d3-array@3.2.4:
     dependencies:
       internmap: 2.0.3
@@ -25159,6 +25202,8 @@ snapshots:
   undici@6.28.0: {}
 
   undici@7.28.0: {}
+
+  undici@7.29.1: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/tooling/expo-token-notifier/.gitignore
+++ b/tooling/expo-token-notifier/.gitignore
@@ -1,0 +1,12 @@
+# Track only package source and configuration. Runtime data stays local.
+*
+!/.gitignore
+!/.prettierignore
+!/README.md
+!/package.json
+!/tsconfig.json
+!/eslint.config.mjs
+!/src/
+!/src/*.ts
+!/test/
+!/test/*.ts

--- a/tooling/expo-token-notifier/.prettierignore
+++ b/tooling/expo-token-notifier/.prettierignore
@@ -1,0 +1,9 @@
+*
+!README.md
+!package.json
+!tsconfig.json
+!eslint.config.mjs
+!src/
+!src/*.ts
+!test/
+!test/*.ts

--- a/tooling/expo-token-notifier/README.md
+++ b/tooling/expo-token-notifier/README.md
@@ -1,0 +1,182 @@
+# Expo token notifier
+
+Send a one-time notification to an exported set of legacy Expo tokens, with local
+SQLite bookkeeping. This package is part of the pnpm workspace under `tooling/`.
+Only source, tests, and configuration are tracked; runtime files are ignored by
+default. The package archive includes only runtime source and package metadata.
+
+## Setup
+
+Use Node 24, matching the repository, or Node 22.18+. SQLite is built into Node;
+there is no database server or native dependency to install. Node may print an
+experimental SQLite warning.
+
+```sh
+pnpm install --frozen-lockfile
+cd tooling/expo-token-notifier
+pnpm notify --help
+```
+
+Existing databases in `local/expo-token-notifier/` can stay there. From this package,
+use `--db ../../local/expo-token-notifier/notifications.sqlite` to continue with the
+same attempt history. Do not reimport the export into a fresh database to resume
+an existing run: that would make all recipients eligible again.
+
+All commands default to `notifications.sqlite` in the current directory. Pass
+`--db /absolute/path/notifications.sqlite` to use another location. Its parent
+directory must exist. Use the same database for every send and receipt lookup.
+
+## Import once
+
+Export only the `id` and `expo_token` columns from your chosen recipient set, with
+headers. IDs are stored as text so large numeric IDs retain their exact value.
+These example tokens are synthetic:
+
+```csv
+id,expo_token
+123,ExponentPushToken[example-one]
+456,ExpoPushToken[example-two]
+```
+
+```sh
+pnpm notify import --csv /path/to/users.csv
+pnpm notify status
+```
+
+Header order does not matter. Quoted fields, UTF-8 BOM, and CRLF are supported.
+Additional columns, duplicate IDs or tokens, empty values, malformed tokens, and
+invalid CSV fail the entire import. The transaction rolls back all rows on failure.
+An empty or header-only file also fails. Import fails if the recipients table
+already contains any rows; reimport never overwrites attempt history.
+
+## Preview and send
+
+```sh
+pnpm notify send \
+  --title 'Update Vexl' \
+  --body 'Please update Vexl to keep receiving notifications.' \
+  --chunk-size 100 \
+  --dry-run
+```
+
+The dry run prints the message and pending/selected counts without modifying the
+database or contacting Expo. It needs no access token.
+
+Set `EXPO_ACCESS_TOKEN` in your environment. For an interactive zsh or bash session,
+this reads it without echoing it or putting its value in shell history:
+
+```sh
+printf 'Expo access token: '
+read -rs EXPO_ACCESS_TOKEN
+printf '\n'
+export EXPO_ACCESS_TOKEN
+
+pnpm notify send \
+  --title 'Update Vexl' \
+  --body 'Please update Vexl to keep receiving notifications.' \
+  --chunk-size 100
+```
+
+Each invocation attempts **at most `chunk-size` pending recipients**, then exits.
+Run it again to process the next set. Title and body may differ between runs; each
+attempt stores its own copy. Notifications use a normal visible title/body payload,
+default sound, and high priority. There is no URL or custom navigation data; tapping
+opens Vexl through the operating system's normal notification behavior.
+
+The script sends sequential SDK batches of at most 100 tokens, with a one-second
+pause between batches. The SDK retains its own HTTP 429 retries inside each call.
+There are no application-level send retries.
+
+Before calling Expo, the script commits an attempt marker for just that API batch.
+Later runs select only `WHERE attempted_at IS NULL`. Per-recipient errors are saved
+and processing continues. A request-level error stops the command, saves the
+attempted batch's outcome, and leaves subsequent batches pending.
+
+Ctrl+C, process termination, a network failure, or an ambiguous response can leave
+the attempted batch `unknown`. Those rows stay excluded, even if Expo never
+received the request. Successful sends can also remain `unknown` if the process
+dies before saving their result. This is the agreed tradeoff to avoid script-level
+resends. Expo itself does not guarantee exactly-once delivery.
+
+Import, send, and receipts commands acquire an exclusive lock using a separate
+`*.lock.sqlite` file. The OS releases the lock when the process exits, including
+after a crash. A concurrent command fails immediately. `status` and dry runs can
+read while another command is running. Keep these files on a local filesystem and
+do not remove or replace the database or lock file during a run.
+
+## Fetch receipts
+
+```sh
+pnpm notify receipts
+pnpm notify status
+```
+
+`receipts` makes one pass through unresolved receipt IDs and exits. It preserves
+the original send response and stores receipt status, raw response, and check time
+separately. Missing receipts and lookup failures remain eligible for another pass.
+Completed `ok` and `error` receipts are skipped. Request-level or malformed receipt
+responses fail the command after saving the available failure information.
+
+Expo recommends checking around 15 minutes after sending and clears receipts after
+24 hours. `status` reports unresolved receipts older than 24 hours; their delivery
+outcome may no longer be recoverable. Receipt `ok` means APNs or FCM accepted the
+notification, not that a device displayed it or a user read it.
+
+See [Expo receipt documentation](https://docs.expo.dev/push-notifications/sending-notifications/#check-push-receipts-for-errors)
+and [delivery guarantees](https://docs.expo.dev/push-notifications/faq/#delivery-guarantees).
+
+## Inspect or export the results
+
+The `recipients` table contains:
+
+| Columns                                       | Meaning                                                               |
+| --------------------------------------------- | --------------------------------------------------------------------- |
+| `user_id`, `expo_token`, `imported_at`        | Imported recipient and import time                                    |
+| `attempted_at`, `title`, `body`               | Persisted before the SDK send call                                    |
+| `send_status`                                 | `pending`, `accepted`, `error`, or `unknown`                          |
+| `send_response_json`                          | Original ticket, request failure, or initial uncertainty marker       |
+| `receipt_id`                                  | Successful Expo ticket ID used for receipt lookups                    |
+| `receipt_status`                              | NULL before lookup, then `missing`, `lookup_failed`, `ok`, or `error` |
+| `receipt_response_json`, `receipt_checked_at` | Latest receipt response and lookup time                               |
+
+`accepted` means Expo returned a successful ticket. `error` means a recipient error
+or an explicit HTTP 4xx rejection. Network failures, HTTP 5xx responses, malformed
+responses, and interrupted attempts are `unknown`. Both `error` and `unknown` stay
+excluded from future sends. All timestamps are UTC ISO strings.
+
+Inspect the table with a SQLite browser, or export it using the `sqlite3` CLI:
+
+```sh
+sqlite3 -header -csv notifications.sqlite 'SELECT * FROM recipients ORDER BY user_id' > results.csv
+```
+
+The CSV, database, and SQLite sidecar files contain recipient data. Files created
+by the CLI are restricted to the current OS user. Console output contains counts
+and operational errors rather than IDs, tokens, or raw Expo errors. The access
+token is never stored; it is redacted from persisted Expo responses. User IDs are
+never included in the notification payload. This tool neither connects to Postgres
+nor drops the original tokens.
+
+Exit code `1` indicates invalid input, an import/locking/storage failure, or a
+request-level failure. Recipient-level send and receipt errors appear in counts
+and SQLite; they do not fail the entire command.
+
+## Verification
+
+```sh
+pnpm typecheck
+pnpm format
+pnpm lint
+pnpm test
+```
+
+From the repository root, run all three checks with
+`pnpm exec turbo typecheck format lint --filter=@vexl-next/expo-token-notifier`.
+Integration tests run the real CLI, SQLite, and Expo SDK
+with an Undici mock transport that disables real network access. They cover import
+rollback, chunk limits, response persistence, retry behavior, process termination,
+concurrent commands, and receipt lookups. They do not send real notifications.
+
+Actual display and tap behavior on the targeted old iOS and Android builds still
+needs a device check. Use a separate CSV and database containing your own test
+device tokens for that check before processing the real export.

--- a/tooling/expo-token-notifier/eslint.config.mjs
+++ b/tooling/expo-token-notifier/eslint.config.mjs
@@ -1,0 +1,3 @@
+import baseConfig from '@vexl-next/eslint-config/index.mjs'
+
+export default [...baseConfig]

--- a/tooling/expo-token-notifier/package.json
+++ b/tooling/expo-token-notifier/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@vexl-next/expo-token-notifier",
+  "version": "0.0.0",
+  "type": "module",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "files": [
+    "src/*.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "notify": "node src/cli.ts",
+    "test": "node --test test/*.test.ts",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --check \"**/*.{js,mjs,cjs,ts,md,json}\"",
+    "format:fix": "prettier --write \"**/*.{js,mjs,cjs,ts,md,json}\"",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "csv-parse": "^6.1.0",
+    "effect": "^3.20.0",
+    "expo-server-sdk": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "@vexl-next/eslint-config": "0.0.0",
+    "@vexl-next/prettier-config": "0.0.0",
+    "eslint": "^9.20.0",
+    "prettier": "^3.3.2",
+    "typescript": "~6.0.3",
+    "undici": "^7.29.1"
+  },
+  "prettier": "@vexl-next/prettier-config"
+}

--- a/tooling/expo-token-notifier/src/cli.ts
+++ b/tooling/expo-token-notifier/src/cli.ts
@@ -1,0 +1,105 @@
+import {Expo} from 'expo-server-sdk'
+import {parseArgs} from 'node:util'
+import {status, withDatabase} from './database.ts'
+import {CliError, fail} from './errors.ts'
+import {importCsv} from './import.ts'
+import {preview, receipts, send, validateSend} from './notifications.ts'
+
+const help = `Usage: pnpm notify <command> [options]
+
+  import   --csv users.csv [--db notifications.sqlite]
+  send     --title "Title" --body "Body" --chunk-size 100 [--dry-run] [--db ...]
+  receipts [--db ...]
+  status   [--db ...]
+
+Set EXPO_ACCESS_TOKEN for send and receipts. Dry runs need no token.
+Import requires CSV headers id,expo_token and an empty recipients table.
+All attempted records, including unknown outcomes and errors, stay excluded.
+Receipt lookups make one pass; run again later for missing receipts.
+`
+
+async function main(): Promise<void> {
+  process.umask(0o077)
+  const {values, positionals} = parseArgs({
+    allowPositionals: true,
+    strict: true,
+    options: {
+      db: {type: 'string', default: 'notifications.sqlite'},
+      csv: {type: 'string'},
+      title: {type: 'string'},
+      body: {type: 'string'},
+      'chunk-size': {type: 'string'},
+      'dry-run': {type: 'boolean'},
+      help: {type: 'boolean', short: 'h'},
+    },
+  })
+  if (values.help || positionals.length === 0) {
+    console.log(help)
+    return
+  }
+  if (positionals.length !== 1) fail('Specify exactly one command. Use --help.')
+  const command = positionals[0]
+  if (values['dry-run'] && command !== 'send')
+    fail('--dry-run is only supported for send.')
+  if (command === 'import') {
+    if (!values.csv) fail('Import requires --csv.')
+    const filename = values.csv
+    const imported = await withDatabase(
+      values.db,
+      'import',
+      async (db) => await importCsv(db, filename)
+    )
+    console.log(JSON.stringify({imported}, null, 2))
+  } else if (command === 'status') {
+    console.log(
+      JSON.stringify(await withDatabase(values.db, 'read', status), null, 2)
+    )
+  } else if (command === 'send' || command === 'receipts') {
+    const options = {
+      title: values.title ?? '',
+      body: values.body ?? '',
+      chunkSize: Number(values['chunk-size']),
+    }
+    if (command === 'send') validateSend(options)
+    if (values['dry-run']) {
+      console.log(
+        JSON.stringify(
+          await withDatabase(values.db, 'read', (db) => preview(db, options)),
+          null,
+          2
+        )
+      )
+      return
+    }
+    const accessToken = process.env.EXPO_ACCESS_TOKEN?.trim()
+    if (!accessToken)
+      fail('Set EXPO_ACCESS_TOKEN before sending or fetching receipts.')
+    const expo = new Expo({accessToken, maxConcurrentRequests: 1})
+    const result =
+      command === 'send'
+        ? await withDatabase(
+            values.db,
+            'write',
+            async (db) => await send(db, expo, accessToken, options)
+          )
+        : await withDatabase(
+            values.db,
+            'write',
+            async (db) => await receipts(db, expo, accessToken)
+          )
+    console.log(JSON.stringify(result, null, 2))
+  } else {
+    fail('Unknown command. Use --help.')
+  }
+}
+
+try {
+  await main()
+} catch (error) {
+  console.error(
+    error instanceof CliError
+      ? error.message
+      : 'Command failed. Check arguments, database access, and schema. No recipient data is printed. Use --help for usage.'
+  )
+  process.exitCode = 1
+}

--- a/tooling/expo-token-notifier/src/database.ts
+++ b/tooling/expo-token-notifier/src/database.ts
@@ -1,0 +1,120 @@
+import {Schema} from 'effect'
+import {existsSync, realpathSync} from 'node:fs'
+import {basename, dirname, resolve} from 'node:path'
+import {DatabaseSync, type SQLOutputValue} from 'node:sqlite'
+import {fail} from './errors.ts'
+
+const schema = `
+  CREATE TABLE IF NOT EXISTS recipients (
+    user_id TEXT PRIMARY KEY NOT NULL,
+    expo_token TEXT UNIQUE NOT NULL,
+    imported_at TEXT NOT NULL,
+    attempted_at TEXT,
+    title TEXT,
+    body TEXT,
+    send_status TEXT NOT NULL DEFAULT 'pending'
+      CHECK (send_status IN ('pending', 'unknown', 'accepted', 'error')),
+    send_response_json TEXT,
+    receipt_id TEXT,
+    receipt_status TEXT CHECK (receipt_status IN ('missing', 'ok', 'error', 'lookup_failed')),
+    receipt_response_json TEXT,
+    receipt_checked_at TEXT,
+    CHECK ((attempted_at IS NULL AND send_status = 'pending')
+      OR (attempted_at IS NOT NULL AND send_status <> 'pending'))
+  ) STRICT;
+  CREATE INDEX IF NOT EXISTS recipients_pending ON recipients(user_id)
+    WHERE attempted_at IS NULL;
+  CREATE INDEX IF NOT EXISTS recipients_receipts ON recipients(user_id)
+    WHERE receipt_id IS NOT NULL AND (receipt_status IS NULL OR receipt_status NOT IN ('ok', 'error'));
+`
+
+export function transaction<T>(db: DatabaseSync, operation: () => T): T {
+  db.exec('BEGIN IMMEDIATE')
+  try {
+    const result = operation()
+    db.exec('COMMIT')
+    return result
+  } catch (error) {
+    db.exec('ROLLBACK')
+    throw error
+  }
+}
+
+export async function withDatabase<T>(
+  filename: string,
+  mode: 'import' | 'write' | 'read',
+  operation: (db: DatabaseSync) => T | Promise<T>
+): Promise<T> {
+  const absolute = resolve(filename)
+  if (mode !== 'import' && !existsSync(absolute)) {
+    fail('Database does not exist. Import the CSV first or check --db.')
+  }
+  const path = existsSync(absolute)
+    ? realpathSync(absolute)
+    : resolve(realpathSync(dirname(absolute)), basename(absolute))
+  let lock: DatabaseSync | undefined
+  let db: DatabaseSync | undefined
+  try {
+    if (mode !== 'read') {
+      // The OS releases this separate database lock even when the process is killed.
+      lock = new DatabaseSync(`${path}.lock.sqlite`)
+      try {
+        lock.exec('PRAGMA busy_timeout = 0; BEGIN EXCLUSIVE')
+      } catch {
+        fail('Another command is using this database. Wait for it to finish.')
+      }
+    }
+    db = new DatabaseSync(path, {readOnly: mode === 'read'})
+    if (mode !== 'read') {
+      db.exec('PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL')
+      if (mode === 'import') db.exec(schema)
+    }
+    return await operation(db)
+  } finally {
+    try {
+      db?.close()
+    } finally {
+      lock?.close()
+    }
+  }
+}
+
+const Count = Schema.Struct({count: Schema.Number})
+
+export function countRecipients(db: DatabaseSync, pending = false): number {
+  return Schema.decodeUnknownSync(Count)(
+    db
+      .prepare(
+        `SELECT COUNT(*) AS count FROM recipients ${pending ? 'WHERE attempted_at IS NULL' : ''}`
+      )
+      .get()
+  ).count
+}
+
+export function status(
+  db: DatabaseSync
+): Record<string, number | Array<Record<string, SQLOutputValue>>> {
+  return {
+    total: countRecipients(db),
+    sends: db
+      .prepare(
+        'SELECT send_status, COUNT(*) AS count FROM recipients GROUP BY send_status'
+      )
+      .all(),
+    receipts: db
+      .prepare(
+        `SELECT COALESCE(receipt_status, 'pending') AS receipt_status,
+        COUNT(*) AS count FROM recipients WHERE receipt_id IS NOT NULL GROUP BY receipt_status`
+      )
+      .all(),
+    unresolvedReceiptsOlderThan24Hours: Schema.decodeUnknownSync(Count)(
+      db
+        .prepare(
+          `SELECT COUNT(*) AS count FROM recipients WHERE receipt_id IS NOT NULL
+          AND (receipt_status IS NULL OR receipt_status NOT IN ('ok', 'error'))
+          AND attempted_at < ?`
+        )
+        .get(new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString())
+    ).count,
+  }
+}

--- a/tooling/expo-token-notifier/src/errors.ts
+++ b/tooling/expo-token-notifier/src/errors.ts
@@ -1,0 +1,32 @@
+import {Option, Schema} from 'effect'
+
+export class CliError extends Schema.TaggedError<CliError>()('CliError', {
+  message: Schema.String,
+}) {}
+
+export function fail(message: string): never {
+  throw new CliError({message})
+}
+
+const SdkError = Schema.Struct({
+  name: Schema.optional(Schema.String),
+  message: Schema.optional(Schema.String),
+  statusCode: Schema.optional(Schema.Number),
+  code: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Unknown),
+  others: Schema.optional(Schema.Unknown),
+  errorText: Schema.optional(Schema.Unknown),
+  errorData: Schema.optional(Schema.Unknown),
+  data: Schema.optional(Schema.Unknown),
+})
+
+export function describeError(error: unknown): typeof SdkError.Type {
+  return Option.getOrElse(Schema.decodeUnknownOption(SdkError)(error), () => ({
+    message: 'Unrecognized request failure',
+  }))
+}
+
+export function jsonResponse(value: unknown, accessToken: string): string {
+  const json = JSON.stringify(value) ?? 'null'
+  return accessToken ? json.replaceAll(accessToken, '[REDACTED]') : json
+}

--- a/tooling/expo-token-notifier/src/import.ts
+++ b/tooling/expo-token-notifier/src/import.ts
@@ -1,0 +1,77 @@
+import {parse} from 'csv-parse'
+import {Either, Schema} from 'effect'
+import {Expo} from 'expo-server-sdk'
+import {createReadStream} from 'node:fs'
+import {type DatabaseSync} from 'node:sqlite'
+import {pipeline} from 'node:stream'
+import {countRecipients} from './database.ts'
+import {CliError, fail} from './errors.ts'
+
+const CsvRow = Schema.Struct({
+  id: Schema.NonEmptyTrimmedString,
+  expo_token: Schema.NonEmptyTrimmedString.pipe(
+    Schema.filter(
+      (token) => Expo.isExpoPushToken(token) && !/\s|\[\]/.test(token)
+    )
+  ),
+})
+
+export async function importCsv(
+  db: DatabaseSync,
+  filename: string
+): Promise<number> {
+  if (countRecipients(db) !== 0)
+    fail('Import requires an empty recipients table.')
+  const parser = parse({
+    bom: true,
+    columns: (headers: string[]) => {
+      if (
+        headers.length !== 2 ||
+        !headers.includes('id') ||
+        !headers.includes('expo_token')
+      ) {
+        fail('CSV headers must be exactly id and expo_token.')
+      }
+      return headers
+    },
+    skip_empty_lines: true,
+    trim: true,
+    max_record_size: 1024 * 1024,
+  })
+  let count = 0
+  const importedAt = new Date().toISOString()
+  const conflict = db.prepare(
+    'SELECT 1 FROM recipients WHERE user_id = ? OR expo_token = ?'
+  )
+  const insert = db.prepare(
+    'INSERT INTO recipients (user_id, expo_token, imported_at) VALUES (?, ?, ?)'
+  )
+  db.exec('BEGIN IMMEDIATE')
+  try {
+    pipeline(createReadStream(filename), parser, () => {})
+    for await (const raw of parser) {
+      const decoded = Schema.decodeUnknownEither(CsvRow)(raw)
+      if (Either.isLeft(decoded))
+        fail(`Invalid ID or Expo token at CSV record ${count + 1}.`)
+      const row = decoded.right
+      if (conflict.get(row.id, row.expo_token)) {
+        fail(
+          `Duplicate ID or Expo token at CSV record ${count + 1}. Import rolled back.`
+        )
+      }
+      insert.run(row.id, row.expo_token, importedAt)
+      count++
+    }
+    if (count === 0) fail('CSV contains no recipients.')
+    db.exec('COMMIT')
+    return count
+  } catch (error) {
+    db.exec('ROLLBACK')
+    if (error instanceof CliError) throw error
+    fail(
+      `Could not import CSV near record ${count + 1}. Check file access and CSV syntax. Import rolled back.`
+    )
+  } finally {
+    parser.destroy()
+  }
+}

--- a/tooling/expo-token-notifier/src/notifications.ts
+++ b/tooling/expo-token-notifier/src/notifications.ts
@@ -1,0 +1,258 @@
+import {Array, Option, Schema, pipe} from 'effect'
+import {Expo, type ExpoPushMessage} from 'expo-server-sdk'
+import {type DatabaseSync} from 'node:sqlite'
+import {setTimeout} from 'node:timers/promises'
+import {countRecipients, transaction} from './database.ts'
+import {describeError, fail, jsonResponse} from './errors.ts'
+
+const Recipient = Schema.Struct({
+  user_id: Schema.String,
+  expo_token: Schema.String,
+})
+const ErrorResult = Schema.Struct({
+  status: Schema.Literal('error'),
+  message: Schema.String,
+})
+const Ticket = Schema.Union(
+  Schema.Struct({status: Schema.Literal('ok'), id: Schema.NonEmptyString}),
+  ErrorResult
+)
+const Receipt = Schema.Union(
+  Schema.Struct({status: Schema.Literal('ok')}),
+  ErrorResult
+)
+const ReceiptTarget = Schema.Struct({
+  user_id: Schema.String,
+  receipt_id: Schema.String,
+})
+
+export interface SendOptions {
+  title: string
+  body: string
+  chunkSize: number
+}
+
+export function validateSend(options: SendOptions): void {
+  if (!options.title.trim() || !options.body.trim())
+    fail('Title and body must not be empty.')
+  if (!Number.isSafeInteger(options.chunkSize) || options.chunkSize <= 0) {
+    fail('Chunk size must be a positive safe integer.')
+  }
+}
+
+export function preview(
+  db: DatabaseSync,
+  options: SendOptions
+): {pending: number; selected: number; title: string; body: string} {
+  validateSend(options)
+  const pending = countRecipients(db, true)
+  return {
+    pending,
+    selected: Math.min(pending, options.chunkSize),
+    title: options.title,
+    body: options.body,
+  }
+}
+
+export async function send(
+  db: DatabaseSync,
+  expo: Expo,
+  accessToken: string,
+  options: SendOptions,
+  report: (message: string) => void = console.log
+): Promise<{attempted: number; accepted: number; error: number}> {
+  validateSend(options)
+  const totals = {attempted: 0, accepted: 0, error: 0}
+  const select = db.prepare(
+    'SELECT user_id, expo_token FROM recipients WHERE attempted_at IS NULL ORDER BY user_id LIMIT ?'
+  )
+  const claim =
+    db.prepare(`UPDATE recipients SET attempted_at = ?, title = ?, body = ?,
+    send_status = 'unknown', send_response_json = ? WHERE user_id = ? AND attempted_at IS NULL`)
+  const save = db.prepare(
+    'UPDATE recipients SET send_status = ?, send_response_json = ?, receipt_id = ? WHERE user_id = ?'
+  )
+  while (totals.attempted < options.chunkSize) {
+    const rows = Schema.decodeUnknownSync(Schema.Array(Recipient))(
+      select.all(
+        Math.min(
+          Expo.pushNotificationChunkSizeLimit,
+          options.chunkSize - totals.attempted
+        )
+      )
+    )
+    if (!Array.isNonEmptyReadonlyArray(rows)) break
+    const messages: ExpoPushMessage[] = pipe(
+      rows,
+      Array.map((row) => ({
+        to: row.expo_token,
+        title: options.title,
+        body: options.body,
+        sound: 'default',
+        priority: 'high',
+      }))
+    )
+    const attemptedAt = new Date().toISOString()
+    transaction(db, () => {
+      for (const row of rows) {
+        claim.run(
+          attemptedAt,
+          options.title,
+          options.body,
+          JSON.stringify({
+            kind: 'unknown',
+            message: 'Attempt started; no final Expo response was saved.',
+          }),
+          row.user_id
+        )
+      }
+    })
+    totals.attempted += rows.length
+    let raw: unknown
+    let tickets: Array<typeof Ticket.Type>
+    try {
+      raw = await expo.sendPushNotificationsAsync(messages)
+      tickets = Schema.decodeUnknownSync(Schema.mutable(Schema.Array(Ticket)))(
+        raw
+      )
+      if (tickets.length !== rows.length)
+        fail('Expo returned an unexpected number of tickets.')
+    } catch (error) {
+      const details = describeError(error)
+      const rejected =
+        details.statusCode !== undefined &&
+        details.statusCode >= 400 &&
+        details.statusCode < 500
+      const sendStatus = rejected ? 'error' : 'unknown'
+      const response = jsonResponse(
+        {kind: 'request_error', ...details, response: raw},
+        accessToken
+      )
+      transaction(db, () => {
+        for (const row of rows)
+          save.run(sendStatus, response, null, row.user_id)
+      })
+      fail(
+        `Expo request failed; ${rows.length} records saved as ${sendStatus}. Stopped after ${totals.attempted} attempts; later batches remain pending. Inspect send_response_json in SQLite.`
+      )
+    }
+    const rawTickets = Schema.decodeUnknownSync(Schema.Array(Schema.Unknown))(
+      raw
+    )
+    transaction(db, () => {
+      for (const [index, row] of rows.entries()) {
+        const ticket = tickets[index]
+        if (!ticket) fail('Missing Expo ticket.')
+        save.run(
+          ticket.status === 'ok' ? 'accepted' : 'error',
+          jsonResponse(rawTickets[index], accessToken),
+          ticket.status === 'ok' ? ticket.id : null,
+          row.user_id
+        )
+        if (ticket.status === 'ok') totals.accepted++
+        else totals.error++
+      }
+    })
+    report(
+      `Attempted ${totals.attempted}; accepted ${totals.accepted}; recipient errors ${totals.error}.`
+    )
+    if (totals.attempted < options.chunkSize && countRecipients(db, true) > 0)
+      await setTimeout(1000)
+  }
+  return totals
+}
+
+export async function receipts(
+  db: DatabaseSync,
+  expo: Expo,
+  accessToken: string,
+  report: (message: string) => void = console.log
+): Promise<{
+  checked: number
+  ok: number
+  error: number
+  missing: number
+  lookupFailed: number
+}> {
+  const totals = {checked: 0, ok: 0, error: 0, missing: 0, lookupFailed: 0}
+  let afterUserId = ''
+  const select =
+    db.prepare(`SELECT user_id, receipt_id FROM recipients WHERE receipt_id IS NOT NULL
+    AND (receipt_status IS NULL OR receipt_status NOT IN ('ok', 'error'))
+    AND user_id > ? ORDER BY user_id LIMIT ?`)
+  const save = db.prepare(
+    'UPDATE recipients SET receipt_status = ?, receipt_response_json = ?, receipt_checked_at = ? WHERE user_id = ?'
+  )
+  while (true) {
+    const rows = Schema.decodeUnknownSync(Schema.Array(ReceiptTarget))(
+      select.all(afterUserId, Expo.pushNotificationReceiptChunkSizeLimit)
+    )
+    if (!Array.isNonEmptyReadonlyArray(rows)) break
+    afterUserId = rows[rows.length - 1]?.user_id ?? afterUserId
+    let response: Record<string, unknown>
+    try {
+      response = Schema.decodeUnknownSync(
+        Schema.Record({key: Schema.String, value: Schema.Unknown})
+      )(
+        await expo.getPushNotificationReceiptsAsync(
+          pipe(
+            rows,
+            Array.map((row) => row.receipt_id)
+          )
+        )
+      )
+    } catch (error) {
+      transaction(db, () => {
+        for (const row of rows)
+          save.run(
+            'lookup_failed',
+            jsonResponse(describeError(error), accessToken),
+            new Date().toISOString(),
+            row.user_id
+          )
+      })
+      fail(
+        'Receipt lookup failed. Saved lookup errors; unresolved receipts can be checked again.'
+      )
+    }
+    const checkedAt = new Date().toISOString()
+    transaction(db, () => {
+      for (const row of rows) {
+        const raw = response[row.receipt_id]
+        if (raw === undefined) {
+          save.run('missing', null, checkedAt, row.user_id)
+          totals.missing++
+        } else {
+          const decoded = Schema.decodeUnknownOption(Receipt)(raw)
+          if (Option.isNone(decoded)) {
+            save.run(
+              'lookup_failed',
+              jsonResponse(raw, accessToken),
+              checkedAt,
+              row.user_id
+            )
+            totals.lookupFailed++
+          } else {
+            save.run(
+              decoded.value.status,
+              jsonResponse(raw, accessToken),
+              checkedAt,
+              row.user_id
+            )
+            if (decoded.value.status === 'ok') totals.ok++
+            else totals.error++
+          }
+        }
+        totals.checked++
+      }
+    })
+    report(
+      `Receipts checked ${totals.checked}; ok ${totals.ok}; errors ${totals.error}; missing ${totals.missing}.`
+    )
+    if (totals.lookupFailed > 0)
+      fail(
+        'Expo returned malformed receipts. Saved responses; unresolved receipts can be checked again.'
+      )
+  }
+  return totals
+}

--- a/tooling/expo-token-notifier/test/cli.test.ts
+++ b/tooling/expo-token-notifier/test/cli.test.ts
@@ -1,0 +1,393 @@
+import {Array, Schema, pipe} from 'effect'
+import assert from 'node:assert/strict'
+import {execFile, spawn} from 'node:child_process'
+import {once} from 'node:events'
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {DatabaseSync} from 'node:sqlite'
+import {test, type TestContext} from 'node:test'
+import {setTimeout} from 'node:timers/promises'
+import {fileURLToPath} from 'node:url'
+import {promisify} from 'node:util'
+
+const exec = promisify(execFile)
+const root = fileURLToPath(new URL('../', import.meta.url))
+const secret = 'synthetic-access-token'
+const Row = Schema.Struct({
+  user_id: Schema.String,
+  expo_token: Schema.String,
+  attempted_at: Schema.NullOr(Schema.String),
+  send_status: Schema.String,
+  send_response_json: Schema.NullOr(Schema.String),
+  receipt_id: Schema.NullOr(Schema.String),
+  receipt_status: Schema.NullOr(Schema.String),
+  receipt_response_json: Schema.NullOr(Schema.String),
+})
+
+interface Fixture {
+  folder: string
+  db: string
+  csv: string
+  log: string
+  run: (
+    command: string[],
+    scenario?: string
+  ) => Promise<{stdout: string; stderr: string}>
+  rows: () => ReadonlyArray<typeof Row.Type>
+  writeCsv: (count: number) => void
+  requests: () => string[]
+  args: (command: string[]) => string[]
+  environment: (scenario?: string) => NodeJS.ProcessEnv
+}
+
+function fixture(t: TestContext): Fixture {
+  const folder = mkdtempSync(join(tmpdir(), 'expo-notifier-test-'))
+  t.after(() => {
+    rmSync(folder, {recursive: true, force: true})
+  })
+  const db = join(folder, 'state.sqlite')
+  const csv = join(folder, 'users.csv')
+  const log = join(folder, 'requests.jsonl')
+  const environment: Fixture['environment'] = (scenario = 'success') => ({
+    ...process.env,
+    EXPO_ACCESS_TOKEN: secret,
+    MOCK_EXPO_SCENARIO: scenario,
+    MOCK_EXPO_LOG: log,
+  })
+  const args: Fixture['args'] = (command) => [
+    '--import',
+    './test/mock-expo.ts',
+    './src/cli.ts',
+    ...command,
+    '--db',
+    db,
+  ]
+  const run: Fixture['run'] = async (command, scenario) =>
+    await exec(process.execPath, args(command), {
+      cwd: root,
+      env: environment(scenario),
+      timeout: 20_000,
+    })
+  function rows(): ReadonlyArray<typeof Row.Type> {
+    const connection = new DatabaseSync(db, {readOnly: true})
+    try {
+      return Schema.decodeUnknownSync(Schema.Array(Row))(
+        connection.prepare('SELECT * FROM recipients ORDER BY user_id').all()
+      )
+    } finally {
+      connection.close()
+    }
+  }
+  function writeCsv(count: number): void {
+    writeFileSync(
+      csv,
+      'id,expo_token\n' +
+        pipe(
+          Array.range(1, count),
+          Array.map((id) => `${id},ExpoPushToken[test-${id}]`)
+        ).join('\n') +
+        '\n'
+    )
+  }
+  const requests: Fixture['requests'] = () =>
+    existsSync(log) ? readFileSync(log, 'utf8').trim().split('\n') : []
+  return {
+    folder,
+    db,
+    csv,
+    log,
+    run,
+    rows,
+    writeCsv,
+    requests,
+    args,
+    environment,
+  }
+}
+
+const sendArgs = (limit: number): string[] => [
+  'send',
+  '--title',
+  'Update Vexl',
+  '--body',
+  'Please update.\nDíky!',
+  '--chunk-size',
+  String(limit),
+]
+
+await test('CSV validation is atomic; quoted BOM CSV preserves large IDs; populated database rejects import', async (t) => {
+  const f = fixture(t)
+  for (const input of [
+    'id,expo_token\n1,ExpoPushToken[a]\n2,ExpoPushToken[a]\n',
+    'id,expo_token\n1,ExpoPushToken[a]\n1,ExpoPushToken[b]\n',
+    'id,expo_token\n1,ExpoPushToken[a]\n2,invalid\n',
+    'id,expo_token\n1,ExpoPushToken[a]\n2,"unfinished\n',
+    'id,expo_token\n1,ExpoPushToken[a]\n2,ExpoPushToken[]\n',
+    'id,expo_token,hash\n1,ExpoPushToken[a],private\n',
+    'id,expo_token\n',
+  ]) {
+    writeFileSync(f.csv, input)
+    await assert.rejects(f.run(['import', '--csv', f.csv]))
+    assert.equal(f.rows().length, 0)
+  }
+  writeFileSync(
+    f.csv,
+    '\uFEFF"expo_token","id"\r\n"ExponentPushToken[abc]","9007199254740993"\r\n'
+  )
+  await f.run(['import', '--csv', f.csv])
+  assert.equal(f.rows()[0]?.user_id, '9007199254740993')
+  await assert.rejects(
+    f.run(['import', '--csv', f.csv]),
+    /empty recipients table/
+  )
+  assert.equal(f.rows().length, 1)
+  assert.equal(statSync(f.db).mode & 0o077, 0)
+})
+
+await test('dry run does not mutate state; chunk limit, ticket errors, and repeated sends preserve attempts', async (t) => {
+  const f = fixture(t)
+  f.writeCsv(3)
+  await f.run(['import', '--csv', f.csv])
+  const before = f.rows()
+  const preview = await f.run([...sendArgs(2), '--dry-run'])
+  assert.match(preview.stdout, /"selected": 2/)
+  assert.deepEqual(f.rows(), before)
+  assert.equal(f.requests().length, 0)
+  await assert.rejects(f.run(sendArgs(0)), /positive safe integer/)
+  await f.run(sendArgs(2), 'mixed')
+  let rows = f.rows()
+  assert.equal(rows[0]?.send_status, 'error')
+  assert.match(rows[0]?.send_response_json ?? '', /DeviceNotRegistered/)
+  assert.equal(rows[1]?.send_status, 'accepted')
+  assert.equal(rows[1]?.receipt_id, 'receipt:ExpoPushToken[test-2]')
+  assert.equal(rows[2]?.send_status, 'pending')
+  const sentRows = pipe(rows, Array.take(2))
+  await f.run(sendArgs(100))
+  await f.run(sendArgs(100))
+  rows = f.rows()
+  assert.deepEqual(pipe(rows, Array.take(2)), sentRows)
+  assert.equal(rows[2]?.send_status, 'accepted')
+  assert.equal(f.requests().length, 2)
+  assert.doesNotMatch(
+    f.requests().join('\n'),
+    /user_id|_contentAvailable|mutableContent|"data"/
+  )
+  await assert.rejects(f.run(['import', '--csv', f.csv]))
+  assert.deepEqual(f.rows(), rows)
+})
+
+await test('invocation chunk size is independent of Expo batch size', async (t) => {
+  const f = fixture(t)
+  f.writeCsv(205)
+  await f.run(['import', '--csv', f.csv])
+  await f.run(sendArgs(150))
+  assert.equal(
+    pipe(
+      f.rows(),
+      Array.filter((row) => row.attempted_at !== null)
+    ).length,
+    150
+  )
+  const sizes = pipe(
+    f.requests(),
+    Array.map(
+      (line) =>
+        Schema.decodeUnknownSync(
+          Schema.Struct({body: Schema.Array(Schema.Unknown)})
+        )(JSON.parse(line)).body.length
+    )
+  )
+  assert.deepEqual(sizes, [100, 50])
+})
+
+await test('request rejection is persisted and halts before later batches; access token is redacted', async (t) => {
+  const f = fixture(t)
+  f.writeCsv(120)
+  await f.run(['import', '--csv', f.csv])
+  await assert.rejects(
+    f.run(sendArgs(120), 'reject'),
+    /100 records saved as error/
+  )
+  const rows = f.rows()
+  assert.equal(
+    pipe(
+      rows,
+      Array.filter((row) => row.send_status === 'error')
+    ).length,
+    100
+  )
+  assert.equal(
+    pipe(
+      rows,
+      Array.filter((row) => row.send_status === 'pending')
+    ).length,
+    20
+  )
+  assert.doesNotMatch(JSON.stringify(rows), new RegExp(secret))
+  assert.match(JSON.stringify(rows), /REDACTED/)
+  await f.run(sendArgs(120))
+  assert.equal(f.requests().length, 2)
+})
+
+await test('outage after a successful batch preserves successes and leaves later batches pending', async (t) => {
+  const f = fixture(t)
+  f.writeCsv(250)
+  await f.run(['import', '--csv', f.csv])
+  await assert.rejects(
+    f.run(sendArgs(250), 'outage'),
+    /100 records saved as unknown/
+  )
+  const states = (state: string): number =>
+    pipe(
+      f.rows(),
+      Array.filter((row) => row.send_status === state)
+    ).length
+  assert.equal(states('accepted'), 100)
+  assert.equal(states('unknown'), 100)
+  assert.equal(states('pending'), 50)
+  assert.equal(f.requests().length, 2)
+})
+
+await test('network and malformed response outcomes are unknown and never retried by later commands', async (t) => {
+  for (const scenario of ['network', 'malformed']) {
+    await t.test(scenario, async (t) => {
+      const f = fixture(t)
+      f.writeCsv(1)
+      await f.run(['import', '--csv', f.csv])
+      await assert.rejects(f.run(sendArgs(1), scenario), /saved as unknown/)
+      const before = f.rows()
+      await f.run(sendArgs(1))
+      assert.deepEqual(f.rows(), before)
+      assert.equal(before[0]?.send_status, 'unknown')
+    })
+  }
+})
+
+await test('SDK handles HTTP 429 retry inside a single saved attempt', async (t) => {
+  const f = fixture(t)
+  f.writeCsv(1)
+  await f.run(['import', '--csv', f.csv])
+  await f.run(sendArgs(1), 'rate-limit')
+  assert.equal(f.requests().length, 2)
+  assert.equal(f.rows()[0]?.send_status, 'accepted')
+})
+
+await test('SIGKILL leaves unknown attempts, blocks concurrent writers, and automatically releases the lock', async (t) => {
+  const f = fixture(t)
+  f.writeCsv(120)
+  await f.run(['import', '--csv', f.csv])
+  const child = spawn(process.execPath, f.args(sendArgs(120)), {
+    cwd: root,
+    env: f.environment('crash'),
+    stdio: 'ignore',
+  })
+  t.after(() => {
+    child.kill('SIGKILL')
+  })
+  const exited = once(child, 'exit')
+  const deadline = Date.now() + 10_000
+  while (!existsSync(f.log) && Date.now() < deadline && child.exitCode === null)
+    await setTimeout(50)
+  assert.ok(existsSync(f.log), 'child reached the mocked Expo request')
+  await assert.rejects(f.run(sendArgs(120)), /Another command/)
+  await assert.rejects(f.run(['receipts']), /Another command/)
+  const during = await f.run(['status'])
+  assert.match(during.stdout, /unknown/)
+  child.kill('SIGKILL')
+  await exited
+  assert.equal(
+    pipe(
+      f.rows(),
+      Array.filter((row) => row.send_status === 'unknown')
+    ).length,
+    100
+  )
+  await f.run(sendArgs(120))
+  assert.equal(
+    pipe(
+      f.rows(),
+      Array.filter((row) => row.send_status === 'accepted')
+    ).length,
+    20
+  )
+  assert.equal(f.requests().length, 2)
+})
+
+await test('receipt pass saves raw responses, revisits missing results, and skips completed results', async (t) => {
+  const f = fixture(t)
+  f.writeCsv(3)
+  await f.run(['import', '--csv', f.csv])
+  await f.run(sendArgs(3))
+  const sends = pipe(
+    f.rows(),
+    Array.map((row) => row.send_response_json)
+  )
+  await f.run(['receipts'], 'missing-receipts')
+  assert.deepEqual(
+    pipe(
+      f.rows(),
+      Array.map((row) => row.receipt_status)
+    ),
+    ['ok', 'missing', 'missing']
+  )
+  assert.equal(f.requests().length, 2)
+  await f.run(['receipts'], 'receipt-error')
+  assert.deepEqual(
+    pipe(
+      f.rows(),
+      Array.map((row) => row.receipt_status)
+    ),
+    ['ok', 'error', 'ok']
+  )
+  assert.match(f.rows()[1]?.receipt_response_json ?? '', /InvalidCredentials/)
+  await f.run(['receipts'])
+  assert.equal(f.requests().length, 3)
+  assert.deepEqual(
+    pipe(
+      f.rows(),
+      Array.map((row) => row.send_response_json)
+    ),
+    sends
+  )
+})
+
+await test('receipt failures remain checkable, malformed results fail visibly, and overdue missing receipts appear in status', async (t) => {
+  const f = fixture(t)
+  f.writeCsv(1)
+  await f.run(['import', '--csv', f.csv])
+  await f.run(sendArgs(1))
+  await assert.rejects(
+    f.run(['receipts'], 'receipt-failure'),
+    /Receipt lookup failed/
+  )
+  assert.equal(f.rows()[0]?.receipt_status, 'lookup_failed')
+  await assert.rejects(
+    f.run(['receipts'], 'malformed-receipts'),
+    /malformed receipts/
+  )
+  const connection = new DatabaseSync(f.db)
+  connection
+    .prepare('UPDATE recipients SET attempted_at = ?')
+    .run(new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString())
+  connection.close()
+  assert.match(
+    (await f.run(['status'])).stdout,
+    /"unresolvedReceiptsOlderThan24Hours": 1/
+  )
+  await f.run(['receipts'])
+  assert.equal(f.rows()[0]?.receipt_status, 'ok')
+})
+
+await test('send never creates a database for a mistyped path', async (t) => {
+  const f = fixture(t)
+  await assert.rejects(f.run(sendArgs(1)), /Database does not exist/)
+  assert.equal(existsSync(f.db), false)
+})

--- a/tooling/expo-token-notifier/test/mock-expo.ts
+++ b/tooling/expo-token-notifier/test/mock-expo.ts
@@ -1,0 +1,126 @@
+import {Array, Schema, pipe} from 'effect'
+import {appendFileSync} from 'node:fs'
+import {gunzipSync} from 'node:zlib'
+import {MockAgent, setGlobalDispatcher} from 'undici'
+import {CliError, fail} from '../src/errors.ts'
+
+const mock = new MockAgent()
+mock.disableNetConnect()
+setGlobalDispatcher(mock)
+const pool = mock.get('https://exp.host')
+const scenario = process.env.MOCK_EXPO_SCENARIO ?? 'success'
+const log = process.env.MOCK_EXPO_LOG
+let sendCalls = 0
+
+function readBody(body: unknown): unknown {
+  const buffer =
+    typeof body === 'string'
+      ? Buffer.from(body)
+      : body instanceof Uint8Array
+        ? Buffer.from(body)
+        : fail('Unexpected mock request body.')
+  return JSON.parse(
+    (buffer[0] === 0x1f && buffer[1] === 0x8b
+      ? gunzipSync(buffer)
+      : buffer
+    ).toString('utf8')
+  )
+}
+
+function record(value: unknown): void {
+  if (log) appendFileSync(log, JSON.stringify(value) + '\n')
+}
+
+const sendInterceptor = pool.intercept({
+  path: '/--/api/v2/push/send',
+  method: 'POST',
+})
+if (scenario === 'network') {
+  sendInterceptor
+    .replyWithError(new CliError({message: 'Synthetic connection reset'}))
+    .persist()
+} else {
+  const scope = sendInterceptor.reply<Record<string, unknown>>(({body}) => {
+    const messages = Schema.decodeUnknownSync(
+      Schema.Array(Schema.Struct({to: Schema.String}))
+    )(readBody(body))
+    record({kind: 'send', body: readBody(body)})
+    sendCalls++
+    if (
+      scenario === 'reject' ||
+      (scenario === 'rate-limit' && sendCalls === 1)
+    ) {
+      return {
+        statusCode: scenario === 'reject' ? 401 : 429,
+        data: {
+          errors: [
+            {
+              code: 'SYNTHETIC_FAILURE',
+              message: `Synthetic rejection ${process.env.EXPO_ACCESS_TOKEN}`,
+            },
+          ],
+        },
+      }
+    }
+    if (scenario === 'outage' && sendCalls === 2) {
+      return {
+        statusCode: 503,
+        data: {errors: [{code: 'UNAVAILABLE', message: 'Synthetic outage'}]},
+      }
+    }
+    if (scenario === 'malformed')
+      return {statusCode: 200, data: {data: [{status: 'unexpected'}]}}
+    return {
+      statusCode: 200,
+      data: {
+        data: pipe(
+          messages,
+          Array.map((message, index) =>
+            scenario === 'mixed' && index === 0
+              ? {
+                  status: 'error',
+                  message: 'Synthetic unregistered device',
+                  details: {error: 'DeviceNotRegistered'},
+                }
+              : {status: 'ok', id: `receipt:${message.to}`}
+          )
+        ),
+      },
+    }
+  })
+  if (scenario === 'crash') scope.delay(60_000)
+  scope.persist()
+}
+
+pool
+  .intercept({path: '/--/api/v2/push/getReceipts', method: 'POST'})
+  .reply<Record<string, unknown>>(({body}) => {
+    const {ids} = Schema.decodeUnknownSync(
+      Schema.Struct({ids: Schema.Array(Schema.String)})
+    )(readBody(body))
+    record({kind: 'receipts', ids})
+    if (scenario === 'receipt-failure') {
+      return {
+        statusCode: 503,
+        data: {
+          errors: [{code: 'UNAVAILABLE', message: 'Synthetic receipt outage'}],
+        },
+      }
+    }
+    const data: Record<string, unknown> = {}
+    for (const [index, id] of ids.entries()) {
+      if (scenario === 'missing-receipts' && index > 0) continue
+      data[id] =
+        scenario === 'receipt-error' && index === 0
+          ? {
+              status: 'error',
+              message: 'Synthetic credential failure',
+              details: {error: 'InvalidCredentials'},
+            }
+          : scenario === 'malformed-receipts'
+            ? {unexpected: true}
+            : {status: 'ok', details: {provider: 'mock'}}
+    }
+    return {statusCode: 200, data: {data}}
+  })
+  .persist()

--- a/tooling/expo-token-notifier/tsconfig.json
+++ b/tooling/expo-token-notifier/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
Users with legacy Expo tokens need a notification before those tokens are retired. Add `@vexl-next/expo-token-notifier` under `tooling/` to import a recipient CSV, send bounded batches, and fetch receipts with persistent SQLite attempt tracking.

Every attempt is saved before calling Expo, so later runs skip accepted, failed, and uncertain sends. Imports require an empty table and roll back on duplicate IDs/tokens or invalid rows. The CLI includes status, dry runs, and a process lock that releases after a crash.

The package uses the workspace's shared lint/format configuration and public package metadata. Git tracks only source, tests, and configuration; the package archive includes only runtime source, README, and its manifest. Existing local databases and sidecars remain outside the change. Credentials come from the environment, responses redact the access token, and logs omit recipient data.

Validation:

- Package typecheck and full workspace format/lint passed. Workspace lint retains existing deprecation warnings outside this package.
- All 13 integration tests passed on Node 22 and Node 24, using the real CLI, SQLite, and Expo SDK with network-disabled mock transport.
- Checked Git exclusions for CSV, SQLite/sidecars, environment files, exports, and arbitrary backups; audited all 14 staged files.
- `npm pack --dry-run` contains exactly the five runtime source files, README, and package manifest.

No live notifications were sent during validation. Device display and tap behavior still require checking on the old app versions being targeted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line tool for importing Expo tokens from CSV files, viewing notification status, sending notifications, and checking delivery receipts.
  - Supports dry runs, batching, validation, retry handling, and detailed delivery outcomes.
  - Includes local SQLite tracking with safe recovery from interrupted operations.
  - Added setup, usage, workflow, and troubleshooting documentation.

- **Tests**
  - Added comprehensive coverage for imports, sending, receipts, failures, retries, locking, and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->