### PR TITLE
feat(mobile): #2550 refresh offer common friends when the social graph changes

### DIFF
--- a/apps/mobile/src/components/DebugScreen/index.tsx
+++ b/apps/mobile/src/components/DebugScreen/index.tsx
@@ -82,9 +82,7 @@ import {upsertInboxOnBeAndLocallyActionAtom} from '../../state/chat/hooks/useCre
 import {clubsToKeyHolderAtom} from '../../state/clubs/atom/clubsToKeyHolderV2Atom'
 import {clubsWithMembersAtom} from '../../state/clubs/atom/clubsWithMembersAtom'
 import {type ClubWithMembers} from '../../state/clubs/domain'
-import connectionStateAtom, {
-  syncConnectionsActionAtom,
-} from '../../state/connections/atom/connectionStateAtom'
+import connectionStateAtom from '../../state/connections/atom/connectionStateAtom'
 import offerToConnectionsAtom, {
   deleteOrphanRecordsActionAtom,
   updateAndReencryptAllOffersConnectionsActionAtom,
@@ -684,12 +682,14 @@ function DebugScreen(): React.ReactElement {
           <Button
             variant="primary"
             size="small"
-            text="Refresh connectionss"
+            text="Refresh offers and connections"
             onPress={() => {
               Effect.runFork(
                 Effect.gen(function* (_) {
-                  yield* store.set(syncConnectionsActionAtom)
-
+                  yield* store.set(
+                    updateAndReencryptAllOffersConnectionsActionAtom,
+                    {}
+                  )
                   const connectionState = store.get(connectionStateAtom)
                   console.log(connectionState)
                 })

--- a/apps/mobile/src/state/connections/atom/connectionStateAtom.test.ts
+++ b/apps/mobile/src/state/connections/atom/connectionStateAtom.test.ts
@@ -1,0 +1,115 @@
+import {generatePrivateKey} from '@vexl-next/cryptography/src/KeyHolder'
+import {ServerToClientHashedNumber} from '@vexl-next/domain/src/general/ServerToClientHashedNumber'
+import {Effect, HashMap, Option, Schema} from 'effect'
+import {createStore} from 'jotai'
+import {apiAtom} from '../../../api'
+import {ConnectionsState} from '../domain'
+import connectionStateAtom, {
+  fetchConnectionsActionAtom,
+} from './connectionStateAtom'
+
+jest.mock('../../../utils/atomUtils/atomWithParsedMmkvStorage', () => {
+  const {atom} = jest.requireActual('jotai')
+  return {
+    atomWithParsedMmkvStorage: (_key: string, initial: unknown) =>
+      Object.assign(atom(initial), {flushNow: jest.fn()}),
+  }
+})
+jest.mock('../../../api', () => {
+  const {atom} = jest.requireActual('jotai')
+  return {
+    apiAtom: atom({
+      contact: {
+        fetchMyContactsPaginated: jest.fn(),
+        fetchCommonConnectionsPaginated: jest.fn(),
+      },
+    }),
+  }
+})
+jest.mock('../../clubs/atom/clubsWithMembersAtom', () => {
+  const {atom} = jest.requireActual('jotai')
+  return {clubsWithMembersAtom: atom([])}
+})
+jest.mock('../../clubs/utils', () => ({getClubReach: jest.fn()}))
+jest.mock(
+  '../../contacts/atom/ensureAndGetAllImportedContactsHaveServerToClientHashActionAtom',
+  () => {
+    const {atom} = jest.requireActual('jotai')
+    const {Effect, HashMap} = jest.requireActual('effect')
+    return {
+      ensureAndGetAllImportedContactsHaveServerToClientHashActionAtom: atom(
+        null,
+        () =>
+          Effect.succeed(
+            HashMap.make(['ServerToClientHash:friend', 'new-friend'])
+          )
+      ),
+    }
+  }
+)
+jest.mock('../../../utils/notifications', () => {
+  const {Effect} = jest.requireActual('effect')
+  return {getNotificationTokenE: () => Effect.succeed(null)}
+})
+jest.mock(
+  '../../../utils/notifications/showDebugNotificationIfEnabled',
+  () => ({showDebugNotificationIfEnabled: jest.fn()})
+)
+jest.mock('../../../utils/reportError', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  reportErrorE: jest.fn(),
+}))
+jest.mock('../../ActionBenchmarks', () => ({
+  effectWithEnsuredBenchmark: () => (effect: unknown) => effect,
+}))
+
+it('fetches the latest graph without storing it', async () => {
+  const store = createStore()
+  const publicKey = generatePrivateKey().publicKeyPemBase64
+  store.set(
+    connectionStateAtom,
+    Schema.decodeUnknownSync(ConnectionsState)({
+      lastUpdate: 0,
+      firstLevel: [],
+      secondLevel: [publicKey],
+      commonFriends: [[publicKey, ['old-friend']]],
+      verifiedFriends: [],
+    })
+  )
+  const previous = store.get(connectionStateAtom)
+  const api = store.get(apiAtom).contact
+  jest.mocked(api.fetchMyContactsPaginated).mockImplementation(({level}) =>
+    Effect.succeed({
+      items: level === 'FIRST' ? [] : [publicKey],
+      nextPageToken: null,
+      hasNext: false,
+      limit: 500,
+    })
+  )
+  jest.mocked(api.fetchCommonConnectionsPaginated).mockReturnValue(
+    Effect.succeed({
+      items: [
+        {
+          publicKey,
+          common: {
+            hashes: [
+              Schema.decodeUnknownSync(ServerToClientHashedNumber)(
+                'ServerToClientHash:friend'
+              ),
+            ],
+            verifiedHashes: [],
+          },
+        },
+      ],
+      nextPageToken: null,
+      hasNext: false,
+      limit: 500,
+    })
+  )
+  const next = await Effect.runPromise(store.set(fetchConnectionsActionAtom))
+  expect(Option.getOrThrow(HashMap.get(next.commonFriends, publicKey))).toEqual(
+    ['new-friend']
+  )
+  expect(store.get(connectionStateAtom)).toBe(previous)
+})

--- a/apps/mobile/src/state/connections/atom/connectionStateAtom.ts
+++ b/apps/mobile/src/state/connections/atom/connectionStateAtom.ts
@@ -59,13 +59,9 @@ function fetchContacts(
   })
 }
 
-export const syncConnectionsActionAtom = atom(
+export const fetchConnectionsActionAtom = atom(
   null,
-  (
-    get,
-    set,
-    notificationTrackingId?: NotificationTrackingId
-  ): Effect.Effect<boolean> => {
+  (get, set, notificationTrackingId?: NotificationTrackingId) => {
     return Effect.gen(function* (_) {
       const api = get(apiAtom)
 
@@ -205,23 +201,23 @@ export const syncConnectionsActionAtom = atom(
 
       void showDebugNotificationIfEnabled({
         title: 'Connections synced',
-        subtitle: 'syncConnectionsActionAtom',
+        subtitle: 'fetchConnectionsActionAtom',
         body: `Finished syncing connections in ${unixMillisecondsNow() - updateStarted} ms`,
       })
 
-      set(connectionStateAtom, {
+      return {
         firstLevel,
         secondLevel,
         commonFriends,
         verifiedFriends,
         lastUpdate,
-      })
+      }
     }).pipe(
       Effect.tapError((e) =>
         Effect.sync(() => {
           void showDebugNotificationIfEnabled({
             title: 'Error while syncing connections',
-            subtitle: 'syncConnectionsActionAtom',
+            subtitle: 'fetchConnectionsActionAtom',
             body: e._tag,
           })
           reportError(
@@ -231,11 +227,6 @@ export const syncConnectionsActionAtom = atom(
           )
         })
       ),
-      Effect.mapBoth({
-        onFailure: () => false,
-        onSuccess: () => true,
-      }),
-      Effect.merge,
       effectWithEnsuredBenchmark('Sync connections')
     )
   }

--- a/apps/mobile/src/state/connections/atom/offerToConnectionsAtom.test.ts
+++ b/apps/mobile/src/state/connections/atom/offerToConnectionsAtom.test.ts
@@ -1,0 +1,318 @@
+import {generatePrivateKey} from '@vexl-next/cryptography/src/KeyHolder'
+import {
+  OfferId,
+  OfferInfo,
+  type OneOfferInState,
+} from '@vexl-next/domain/src/general/offers'
+import updateOffer from '@vexl-next/resources-utils/src/offers/updateOffer'
+import updatePrivateParts from '@vexl-next/resources-utils/src/offers/updatePrivateParts'
+import {Array, Deferred, Effect, Fiber, type Option, Schema} from 'effect'
+import {type atom, createStore} from 'jotai'
+import {type focusAtom} from 'jotai-optics'
+import {offersStateAtom} from '../../marketplace/atoms/offersState'
+import {updateOfferActionAtom} from '../../marketplace/atoms/updateOfferActionAtom'
+import {ConnectionsState, OfferToConnectionsItem} from '../domain'
+import connectionStateAtom from './connectionStateAtom'
+import offerToConnectionsAtom, {
+  updateAndReencryptAllOffersConnectionsActionAtom,
+} from './offerToConnectionsAtom'
+
+jest.mock('@vexl-next/resources-utils/src/offers/updatePrivateParts')
+jest.mock('@vexl-next/resources-utils/src/offers/updateOffer')
+jest.mock('../../session', () => {
+  const {atom} = jest.requireActual('jotai')
+  return {sessionDataOrDummyAtom: atom({privateKey: {}, keyPairV2: {}})}
+})
+jest.mock('../../marketplace/atoms/offersMissingOnServer', () => ({
+  reencryptSingleOfferMissingOnServerWhenEditingActionAtom: null,
+}))
+jest.mock('../../clubs/atom/refreshClubsActionAtom', () => {
+  const {atom} = jest.requireActual('jotai')
+  const {Effect} = jest.requireActual('effect')
+  return {
+    syncAllClubsHandleStateWhenNotFoundActionAtom: atom(
+      null,
+      () => Effect.void
+    ),
+  }
+})
+jest.mock('../../../utils/atomUtils/atomWithParsedMmkvStorage', () => {
+  const {atom} = jest.requireActual('jotai')
+  return {
+    atomWithParsedMmkvStorage: (_key: string, initial: unknown) =>
+      Object.assign(atom(initial), {flushNow: jest.fn()}),
+  }
+})
+jest.mock('../../../api', () => {
+  const {atom} = jest.requireActual('jotai')
+  return {apiAtom: atom({offer: {}})}
+})
+jest.mock('./connectionStateAtom', () => {
+  const {atom} = jest.requireActual('jotai')
+  const {HashMap} = jest.requireActual('effect')
+  return {
+    __esModule: true,
+    default: Object.assign(
+      atom({
+        lastUpdate: 0,
+        firstLevel: [],
+        secondLevel: [],
+        commonFriends: HashMap.empty(),
+        verifiedFriends: HashMap.empty(),
+      }),
+      {flushNow: jest.fn()}
+    ),
+    fetchConnectionsActionAtom: atom(null, () => mockFetchGraph()),
+  }
+})
+jest.mock('../../clubs/atom/clubsWithMembersAtom', () => {
+  const {atom} = jest.requireActual('jotai')
+  return {clubsWithMembersAtom: atom([])}
+})
+jest.mock('../../marketplace/atoms/offersState', () => {
+  const jotai = jest.requireActual<{atom: typeof atom}>('jotai')
+  const optics = jest.requireActual<{focusAtom: typeof focusAtom}>(
+    'jotai-optics'
+  )
+  const effect = jest.requireActual<{
+    Array: typeof Array
+    Option: typeof Option
+  }>('effect')
+  const offersStateAtom = Object.assign(
+    jotai.atom<{offers: OneOfferInState[]}>({offers: []}),
+    {flushNow: jest.fn()}
+  )
+  return {
+    offersStateAtom,
+    offersAtom: optics.focusAtom(offersStateAtom, (optic) =>
+      optic.prop('offers')
+    ),
+    singleOfferByAdminIdAtom: (adminId: string) =>
+      jotai.atom((get) =>
+        effect.Array.findFirst(
+          get(offersStateAtom).offers,
+          (offer) => offer.ownershipInfo?.adminId === adminId
+        ).pipe(effect.Option.getOrUndefined)
+      ),
+  }
+})
+jest.mock(
+  '../../../utils/notifications/showDebugNotificationIfEnabled',
+  () => ({showDebugNotificationIfEnabled: jest.fn()})
+)
+jest.mock('../../../utils/reportError', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+jest.mock('../../../utils/reportTime', () => ({startMeasure: () => () => 0}))
+jest.mock('../../ActionBenchmarks', () => ({
+  effectWithEnsuredBenchmark: () => (effect: unknown) => effect,
+}))
+
+const publicKey = generatePrivateKey().publicKeyPemBase64
+const otherKey = generatePrivateKey().publicKeyPemBase64
+const initial = Schema.decodeUnknownSync(OfferToConnectionsItem)({
+  adminId: 'admin-id',
+  symmetricKey: 'symmetric-key',
+  connections: {firstLevel: [publicKey, otherKey]},
+})
+const second = Schema.decodeUnknownSync(OfferToConnectionsItem)({
+  ...initial,
+  adminId: 'second-offer',
+})
+const offerInfo = Schema.decodeUnknownSync(OfferInfo)({
+  id: 1,
+  offerId: initial.adminId,
+  createdAt: '2026-09-11T00:00:00.000Z',
+  modifiedAt: '2026-09-11T00:00:00.000Z',
+  privatePart: {
+    symmetricKey: initial.symmetricKey,
+    commonFriends: [],
+    friendLevel: [],
+  },
+  publicPart: {
+    offerPublicKey: publicKey,
+    location: [],
+    offerDescription: 'offer',
+    amountBottomLimit: 1,
+    amountTopLimit: 2,
+    feeState: 'WITHOUT_FEE',
+    feeAmount: 0,
+    locationState: [],
+    paymentMethod: [],
+    btcNetwork: [],
+    currency: 'CZK',
+    spokenLanguages: [],
+    offerType: 'SELL',
+    activePriceState: 'NONE',
+    activePriceValue: 0,
+    activePriceCurrency: 'CZK',
+    active: true,
+    groupUuids: [],
+  },
+})
+const mockFetchGraph = jest.fn<Effect.Effect<ConnectionsState, unknown>, []>()
+function graph(friends: string[]): ConnectionsState {
+  return Schema.decodeUnknownSync(ConnectionsState)({
+    lastUpdate: 1,
+    firstLevel: [publicKey, otherKey],
+    secondLevel: [],
+    commonFriends: [[publicKey, friends]],
+    verifiedFriends: [],
+  })
+}
+function setupStore(
+  records: OfferToConnectionsItem[] = [initial]
+): ReturnType<typeof createStore> {
+  const store = createStore()
+  store.set(offerToConnectionsAtom, {offerToConnections: records})
+  store.set(offersStateAtom, (state) => ({
+    ...state,
+    offers: Array.map(
+      records,
+      (record): OneOfferInState => ({
+        offerInfo: {
+          ...offerInfo,
+          offerId: Schema.decodeSync(OfferId)(record.adminId),
+        },
+        ownershipInfo: {
+          adminId: record.adminId,
+          intendedConnectionLevel: 'ALL',
+          intendedClubs: [],
+        },
+        flags: {reported: false},
+      })
+    ),
+  }))
+  store.set(connectionStateAtom, graph(['old-friend']))
+  return store
+}
+function result(
+  updateSuccess = true
+): Effect.Effect.Success<ReturnType<typeof updatePrivateParts>> {
+  return {
+    updateSuccess,
+    encryptionErrors: [],
+    timeLimitReachedErrors: [],
+    removedConnections: [],
+    newConnections: {firstLevel: [], secondLevel: [], clubs: {}},
+  }
+}
+function refreshSets(): Array<readonly string[]> {
+  return Array.map(
+    jest.mocked(updatePrivateParts).mock.calls,
+    ([params]) => params.connectionsToRefresh ?? []
+  )
+}
+function run(
+  store: ReturnType<typeof createStore>,
+  isInBackground = false
+): Promise<ReadonlyArray<{adminId: string; success: boolean}>> {
+  return Effect.runPromise(
+    store.set(updateAndReencryptAllOffersConnectionsActionAtom, {
+      isInBackground,
+    })
+  )
+}
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockFetchGraph
+    .mockReset()
+    .mockReturnValue(Effect.succeed(graph(['new-friend'])))
+  jest
+    .mocked(updatePrivateParts)
+    .mockReset()
+    .mockReturnValue(Effect.succeed(result()))
+  jest
+    .mocked(updateOffer)
+    .mockReset()
+    .mockReturnValue(Effect.succeed(offerInfo))
+})
+
+it.each([false, true])(
+  'stores the graph after all uploads, then skips unchanged recipients (background: %s)',
+  async (isInBackground) => {
+    const store = setupStore()
+    jest.mocked(updatePrivateParts).mockImplementationOnce((params) =>
+      Effect.sync(() => {
+        expect(store.get(connectionStateAtom)).toEqual(graph(['old-friend']))
+        expect(params.connectionsToRefresh).toEqual([publicKey])
+        expect(params.commonFriends).toEqual(
+          graph(['new-friend']).commonFriends
+        )
+        return result()
+      })
+    )
+    await run(store, isInBackground)
+    expect(store.get(connectionStateAtom)).toEqual(graph(['new-friend']))
+    expect(connectionStateAtom.flushNow).toHaveBeenCalled()
+    await run(store, isInBackground)
+    expect(refreshSets()).toEqual([[publicKey], []])
+  }
+)
+
+it('keeps the old graph when any offer fails so the next round re-uploads the same diff', async () => {
+  const store = setupStore([initial, second])
+  jest
+    .mocked(updatePrivateParts)
+    .mockReturnValueOnce(Effect.succeed(result()))
+    .mockReturnValueOnce(Effect.succeed(result(false)))
+  await run(store)
+  expect(store.get(connectionStateAtom)).toEqual(graph(['old-friend']))
+  expect(connectionStateAtom.flushNow).not.toHaveBeenCalled()
+  await run(store)
+  expect(refreshSets()).toEqual([
+    [publicKey],
+    [publicKey],
+    [publicKey],
+    [publicKey],
+  ])
+  expect(store.get(connectionStateAtom)).toEqual(graph(['new-friend']))
+})
+
+it('keeps the old graph after interruption', async () => {
+  const store = setupStore()
+  const started = await Effect.runPromise(Deferred.make<undefined>())
+  jest
+    .mocked(updatePrivateParts)
+    .mockReturnValueOnce(
+      Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never))
+    )
+  const running = Effect.runFork(
+    store.set(updateAndReencryptAllOffersConnectionsActionAtom, {})
+  )
+  await Effect.runPromise(Deferred.await(started))
+  await Effect.runPromise(Fiber.interrupt(running))
+  expect(store.get(connectionStateAtom)).toEqual(graph(['old-friend']))
+})
+
+it('a manual edit uploads the fresh diff for its own offer without storing the graph', async () => {
+  const store = setupStore([initial, second])
+  await Effect.runPromise(
+    store.set(updateOfferActionAtom, {
+      adminId: initial.adminId,
+      symmetricKey: initial.symmetricKey,
+      payloadPublic: offerInfo.publicPart,
+      intendedConnectionLevel: 'ALL',
+      intendedClubs: [],
+      updatePrivateParts: true,
+    })
+  )
+  expect(refreshSets()).toEqual([[publicKey]])
+  expect(
+    jest.mocked(updatePrivateParts).mock.lastCall?.[0].commonFriends
+  ).toEqual(graph(['new-friend']).commonFriends)
+  expect(store.get(connectionStateAtom)).toEqual(graph(['old-friend']))
+})
+
+it('falls back to the stored graph with nothing to refresh when the fetch fails', async () => {
+  const store = setupStore()
+  mockFetchGraph.mockReturnValue(Effect.fail(new Error('offline')))
+  expect(await run(store)).toEqual([{adminId: initial.adminId, success: true}])
+  expect(refreshSets()).toEqual([[]])
+  expect(
+    jest.mocked(updatePrivateParts).mock.lastCall?.[0].commonFriends
+  ).toEqual(graph(['old-friend']).commonFriends)
+  expect(store.get(connectionStateAtom)).toEqual(graph(['old-friend']))
+  expect(connectionStateAtom.flushNow).not.toHaveBeenCalled()
+})

--- a/apps/mobile/src/state/connections/atom/offerToConnectionsAtom.ts
+++ b/apps/mobile/src/state/connections/atom/offerToConnectionsAtom.ts
@@ -29,8 +29,15 @@ import {
   offersStateAtom,
   singleOfferByAdminIdAtom,
 } from '../../marketplace/atoms/offersState'
-import {OfferToConnectionsItems, type OfferToConnectionsItem} from '../domain'
-import connectionStateAtom from './connectionStateAtom'
+import {
+  OfferToConnectionsItems,
+  type ConnectionsState,
+  type OfferToConnectionsItem,
+} from '../domain'
+import {getChangedConnectionPublicKeys} from '../utils/getChangedConnectionPublicKeys'
+import connectionStateAtom, {
+  fetchConnectionsActionAtom,
+} from './connectionStateAtom'
 
 const BACKGROUND_TIME_LIMIT_MS = 25_000
 
@@ -255,6 +262,26 @@ interface UpdateSingleOfferConnectionParams {
 }
 
 /**
+ * Fetches the current graph and diffs it against the stored one. The stored
+ * graph is left untouched so that a failed upload round re-uploads the same
+ * diff next time. Falls back to the stored graph when the fetch fails.
+ */
+const fetchConnectionsDiffActionAtom = atom(null, (get, set) =>
+  Effect.gen(function* (_) {
+    const previous = get(connectionStateAtom)
+    const fetched = yield* _(set(fetchConnectionsActionAtom), Effect.option)
+    return {
+      fetched,
+      connectionState: Option.getOrElse(fetched, () => previous),
+      connectionsToRefresh: Option.match(fetched, {
+        onNone: () => [],
+        onSome: (next) => getChangedConnectionPublicKeys(previous, next),
+      }),
+    }
+  })
+)
+
+/**
  * Uploads new/removed private parts for a single offer and returns an updater
  * that applies the resulting connection changes to the locally stored
  * `OfferToConnectionsItem`. Persisting the returned update is left to the
@@ -271,12 +298,16 @@ const computeSingleOfferConnectionUpdateActionAtom = atom(
       intendedConnectionLevel,
       stopProcessingAfter,
       onProgress,
-    }: UpdateSingleOfferConnectionParams
+      connectionState,
+      connectionsToRefresh,
+    }: UpdateSingleOfferConnectionParams & {
+      connectionState: ConnectionsState
+      connectionsToRefresh: ReadonlyArray<PublicKeyPemBase64 | PublicKeyV2>
+    }
   ) =>
     Effect.gen(function* (_) {
       const offerApi = get(apiAtom).offer
 
-      const connectionState = get(connectionStateAtom)
       const oneOfferConnectionsAtom =
         createSingleOfferToConnectionsAtom(adminId)
       const oneOfferConnections = yield* _(get(oneOfferConnectionsAtom))
@@ -314,6 +345,7 @@ const computeSingleOfferConnectionUpdateActionAtom = atom(
         'Update one offer connections'
       )
       const {
+        updateSuccess,
         encryptionErrors,
         newConnections,
         timeLimitReachedErrors,
@@ -321,6 +353,7 @@ const computeSingleOfferConnectionUpdateActionAtom = atom(
       } = yield* _(
         updatePrivateParts({
           currentConnections: oneOfferConnections.connections,
+          connectionsToRefresh,
           targetConnections: {
             firstLevel: connectionState.firstLevel,
             secondLevel:
@@ -363,44 +396,57 @@ const computeSingleOfferConnectionUpdateActionAtom = atom(
         )
       }
 
-      return (val: OfferToConnectionsItem): OfferToConnectionsItem => ({
-        ...val,
-        connections: {
-          firstLevel: subtractArrays(
-            [...val.connections.firstLevel, ...newConnections.firstLevel],
-            removedConnections
-          ),
-          secondLevel:
-            connectionLevel === 'ALL'
-              ? subtractArrays(
-                  [
-                    ...(val.connections.secondLevel ?? []),
-                    ...(newConnections.secondLevel ?? []),
-                  ],
-                  removedConnections
-                )
-              : [],
-          clubs: processClubConnections({
-            currentConnections: val.connections.clubs ?? {},
-            newConnections: newConnections.clubs ?? {},
-            removedConnections,
-          }),
-        },
-      })
+      return {
+        updateSuccess,
+        applyConnectionsUpdate: (
+          val: OfferToConnectionsItem
+        ): OfferToConnectionsItem => ({
+          ...val,
+          connections: {
+            firstLevel: subtractArrays(
+              [...val.connections.firstLevel, ...newConnections.firstLevel],
+              removedConnections
+            ),
+            secondLevel:
+              connectionLevel === 'ALL'
+                ? subtractArrays(
+                    [
+                      ...(val.connections.secondLevel ?? []),
+                      ...(newConnections.secondLevel ?? []),
+                    ],
+                    removedConnections
+                  )
+                : [],
+            clubs: processClubConnections({
+              currentConnections: val.connections.clubs ?? {},
+              newConnections: newConnections.clubs ?? {},
+              removedConnections,
+            }),
+          },
+        }),
+      }
     })
 )
 
 export const updateAndReencryptSingleOfferConnectionActionAtom = atom(
   null,
   (get, set, params: UpdateSingleOfferConnectionParams) =>
-    set(computeSingleOfferConnectionUpdateActionAtom, params).pipe(
-      Effect.map((applyConnectionsUpdate) => {
-        set(
-          createSingleOfferToConnectionsAtom(params.adminId),
-          applyConnectionsUpdate
-        )
-      })
-    )
+    Effect.gen(function* (_) {
+      const {connectionState, connectionsToRefresh} = yield* _(
+        set(fetchConnectionsDiffActionAtom)
+      )
+      const {applyConnectionsUpdate} = yield* _(
+        set(computeSingleOfferConnectionUpdateActionAtom, {
+          ...params,
+          connectionState,
+          connectionsToRefresh,
+        })
+      )
+      set(
+        createSingleOfferToConnectionsAtom(params.adminId),
+        applyConnectionsUpdate
+      )
+    })
 )
 
 export const updateAndReencryptAllOffersConnectionsActionAtom = atom(
@@ -426,6 +472,9 @@ export const updateAndReencryptAllOffersConnectionsActionAtom = atom(
     }>
   > =>
     Effect.gen(function* (_) {
+      const {fetched, connectionState, connectionsToRefresh} = yield* _(
+        set(fetchConnectionsDiffActionAtom)
+      )
       const stopProcessingAfter: UnixMilliseconds | undefined = isInBackground
         ? Schema.decodeSync(UnixMilliseconds)(
             unixMillisecondsNow() + BACKGROUND_TIME_LIMIT_MS
@@ -482,6 +531,8 @@ export const updateAndReencryptAllOffersConnectionsActionAtom = atom(
           const adminId = get(oneOfferAtom).adminId
           return set(computeSingleOfferConnectionUpdateActionAtom, {
             adminId,
+            connectionState,
+            connectionsToRefresh,
             onProgress: onProgres
               ? (progress) => {
                   onProgres({
@@ -493,14 +544,14 @@ export const updateAndReencryptAllOffersConnectionsActionAtom = atom(
               : undefined,
             stopProcessingAfter,
           }).pipe(
-            Effect.map((applyConnectionsUpdate) => {
+            Effect.map(({updateSuccess, applyConnectionsUpdate}) => {
               pendingConnectionUpdates.set(adminId, applyConnectionsUpdate)
               if (
                 pendingConnectionUpdates.size >=
                 PERSIST_CONNECTION_UPDATES_CHUNK_SIZE
               )
                 persistPendingConnectionUpdates()
-              return {adminId, success: true}
+              return {adminId, success: updateSuccess}
             }),
             Effect.catchAll((e) =>
               Effect.sync(() => {
@@ -539,6 +590,19 @@ export const updateAndReencryptAllOffersConnectionsActionAtom = atom(
             // (current === target, so nothing is deleted). Force one synchronous
             // durable write to bound that window to the sync loop itself.
             offerToConnectionsAtom.flushNow()
+          })
+        ),
+        // The fetched graph is stored only once every offer carries it, so a
+        // failed round re-uploads the same diff next time.
+        Effect.tap((res) =>
+          Effect.sync(() => {
+            if (
+              Option.isSome(fetched) &&
+              Array.every(res, (one) => one.success)
+            ) {
+              set(connectionStateAtom, fetched.value)
+              connectionStateAtom.flushNow()
+            }
           })
         ),
         Effect.tap((res) =>

--- a/apps/mobile/src/state/connections/syncConnectionsInAppLoadingTask.ts
+++ b/apps/mobile/src/state/connections/syncConnectionsInAppLoadingTask.ts
@@ -6,7 +6,6 @@ import {
 import {checkForClubsAdmissionActionAtom} from '../clubs/atom/checkForClubsAdmissionActionAtom'
 import {syncAllClubsHandleStateWhenNotFoundActionAtom} from '../clubs/atom/refreshClubsActionAtom'
 import {checkUserNeedsToImportContactsAndReencryptOffersActionAtom} from './atom/checkUserNeedsToImportAndReencryptOffersActionAtom'
-import {syncConnectionsActionAtom} from './atom/connectionStateAtom'
 import {updateAndReencryptAllNotesConnectionsActionAtom} from './atom/noteToConnectionsAtom'
 import {updateAndReencryptAllOffersConnectionsActionAtom} from './atom/offerToConnectionsAtom'
 
@@ -19,7 +18,6 @@ export const syncConnectionsInAppTaskId = registerInAppLoadingTask({
   },
   task: (store) =>
     Effect.gen(function* (_) {
-      const syncConnections = store.set(syncConnectionsActionAtom)
       const syncClubs = store.set(syncAllClubsHandleStateWhenNotFoundActionAtom)
       const updateOffers = store.set(
         updateAndReencryptAllOffersConnectionsActionAtom,
@@ -35,11 +33,10 @@ export const syncConnectionsInAppTaskId = registerInAppLoadingTask({
       )
 
       yield* _(
-        syncConnections,
-        Effect.andThen(checkUserNeedsToImportContactsAndReencryptOffers),
-        Effect.andThen(checkForClubAdmissions),
+        checkForClubAdmissions,
         Effect.andThen(syncClubs),
         Effect.andThen(updateOffers),
+        Effect.andThen(checkUserNeedsToImportContactsAndReencryptOffers),
         Effect.andThen(updateNotes)
       )
     }),

--- a/apps/mobile/src/state/connections/utils/getChangedConnectionPublicKeys.test.ts
+++ b/apps/mobile/src/state/connections/utils/getChangedConnectionPublicKeys.test.ts
@@ -1,0 +1,67 @@
+import {generatePrivateKey} from '@vexl-next/cryptography/src/KeyHolder'
+import {HashedPhoneNumber} from '@vexl-next/domain/src/general/HashedPhoneNumber.brand'
+import {Array, HashMap, Schema} from 'effect'
+import {getChangedConnectionPublicKeys} from './getChangedConnectionPublicKeys'
+
+const publicKey = generatePrivateKey().publicKeyPemBase64
+const otherPublicKey = generatePrivateKey().publicKeyPemBase64
+const friend = Schema.decodeSync(HashedPhoneNumber)('friend')
+const newFriend = Schema.decodeSync(HashedPhoneNumber)('new-friend')
+const graph = {
+  firstLevel: [],
+  secondLevel: [publicKey, otherPublicKey],
+  commonFriends: HashMap.make([publicKey, [friend, newFriend]]),
+  verifiedFriends: HashMap.empty(),
+}
+
+it('ignores reordered or duplicate common friends and equivalent empty entries', () => {
+  expect(
+    getChangedConnectionPublicKeys(graph, {
+      ...graph,
+      secondLevel: [otherPublicKey, publicKey, publicKey],
+      commonFriends: HashMap.make(
+        [publicKey, [newFriend, friend, friend]],
+        [otherPublicKey, []]
+      ),
+    })
+  ).toEqual([])
+})
+
+it.each(['common', 'verified', 'level'])(
+  'finds the recipient with a changed %s payload field',
+  (change) => {
+    expect(
+      getChangedConnectionPublicKeys(graph, {
+        ...graph,
+        ...(change === 'common' ? {commonFriends: HashMap.empty()} : {}),
+        ...(change === 'verified'
+          ? {verifiedFriends: HashMap.make([publicKey, [friend]])}
+          : {}),
+        ...(change === 'level'
+          ? {firstLevel: [publicKey], secondLevel: [otherPublicKey]}
+          : {}),
+      })
+    ).toEqual([publicKey])
+  }
+)
+
+it('compares a large graph once and identifies only the changed recipient', () => {
+  const keys = Array.makeBy(5000, () => generatePrivateKey().publicKeyPemBase64)
+  const previous = {...graph, secondLevel: [publicKey, ...keys]}
+  expect(
+    getChangedConnectionPublicKeys(previous, {
+      ...previous,
+      commonFriends: HashMap.make([publicKey, [newFriend]]),
+    })
+  ).toEqual([publicKey])
+})
+
+it('ignores redundant second-degree membership for first-degree recipients', () => {
+  const previous = {
+    ...graph,
+    firstLevel: [publicKey],
+    secondLevel: [otherPublicKey],
+  }
+  const current = {...previous, secondLevel: [publicKey, otherPublicKey]}
+  expect(getChangedConnectionPublicKeys(previous, current)).toEqual([])
+})

--- a/apps/mobile/src/state/connections/utils/getChangedConnectionPublicKeys.ts
+++ b/apps/mobile/src/state/connections/utils/getChangedConnectionPublicKeys.ts
@@ -1,0 +1,58 @@
+import {
+  type PublicKeyPemBase64,
+  type PublicKeyV2,
+} from '@vexl-next/cryptography/src/KeyHolder'
+import {Array, HashMap, Option} from 'effect'
+import {type ConnectionsState} from '../domain'
+
+type PublicKey = PublicKeyPemBase64 | PublicKeyV2
+type ConnectionSnapshot = Pick<
+  ConnectionsState,
+  'firstLevel' | 'secondLevel' | 'commonFriends' | 'verifiedFriends'
+>
+
+function sameMembers<T>(left: readonly T[], right: readonly T[]): boolean {
+  const leftSet = new Set(left)
+  const rightSet = new Set(right)
+  return (
+    leftSet.size === rightSet.size &&
+    Array.every(left, (value) => rightSet.has(value))
+  )
+}
+
+export function getChangedConnectionPublicKeys(
+  previous: ConnectionSnapshot,
+  next: ConnectionSnapshot
+): PublicKey[] {
+  const previousFirstLevelConnections = new Set(previous.firstLevel)
+  const previousSecondLevelConnections = new Set(previous.secondLevel)
+  const nextFirstLevelConnections = new Set(next.firstLevel)
+  const nextSecondLevelConnections = new Set(next.secondLevel)
+  const publicKeys = new Set([
+    ...previous.firstLevel,
+    ...previous.secondLevel,
+    ...next.firstLevel,
+    ...next.secondLevel,
+    ...HashMap.keys(previous.commonFriends),
+    ...HashMap.keys(next.commonFriends),
+    ...HashMap.keys(previous.verifiedFriends),
+    ...HashMap.keys(next.verifiedFriends),
+  ])
+  return Array.filter(
+    Array.fromIterable(publicKeys),
+    (key) =>
+      previousFirstLevelConnections.has(key) !==
+        nextFirstLevelConnections.has(key) ||
+      (!nextFirstLevelConnections.has(key) &&
+        previousSecondLevelConnections.has(key) !==
+          nextSecondLevelConnections.has(key)) ||
+      !sameMembers(
+        Option.getOrElse(HashMap.get(previous.commonFriends, key), () => []),
+        Option.getOrElse(HashMap.get(next.commonFriends, key), () => [])
+      ) ||
+      !sameMembers(
+        Option.getOrElse(HashMap.get(previous.verifiedFriends, key), () => []),
+        Option.getOrElse(HashMap.get(next.verifiedFriends, key), () => [])
+      )
+  )
+}

--- a/apps/mobile/src/state/contacts/atom/submitContactsActionAtom.ts
+++ b/apps/mobile/src/state/contacts/atom/submitContactsActionAtom.ts
@@ -19,7 +19,6 @@ import {formattingLocaleAtom} from '../../../utils/localization/formattingLocale
 import reportError from '../../../utils/reportError'
 import {waitForNextAnimationFrameEffect} from '../../../utils/runAfterAnimationFrames'
 import {toCommonErrorMessage} from '../../../utils/useCommonErrorMessages'
-import {syncConnectionsActionAtom} from '../../connections/atom/connectionStateAtom'
 import {
   noteRecordsToReencryptCountAtom,
   updateAndReencryptAllNotesConnectionsActionAtom,
@@ -615,35 +614,32 @@ const syncNetworkAfterContactsImportActionAtom = atom(
         })
 
         yield* _(
-          set(syncConnectionsActionAtom),
-          Effect.zip(
-            set(updateAndReencryptAllOffersConnectionsActionAtom, {
-              onProgres: ({offerI, totalOffers, progress}) => {
-                set(offerProgressModalActionAtoms.showStep, {
-                  aggregateProgress: {
-                    processingIndex: offerI,
-                    totalToProcess: totalOffers,
-                    span: offersProgressSpan,
-                  },
-                  progress,
-                  textData: {
-                    title: t('contacts.refreshingOffers.title'),
-                    belowProgressLeft: t(
-                      'contacts.refreshingOffers.belowProgressLeft',
-                      {
-                        i: offerI + 1,
-                        total: totalOffers,
-                      }
-                    ),
-                    bottomText: t(
-                      'offerForm.offerEncryption.dontCloseTheAppCanTakeAWhile'
-                    ),
-                  },
-                })
-              },
-              isInBackground: false,
-            })
-          ),
+          set(updateAndReencryptAllOffersConnectionsActionAtom, {
+            onProgres: ({offerI, totalOffers, progress}) => {
+              set(offerProgressModalActionAtoms.showStep, {
+                aggregateProgress: {
+                  processingIndex: offerI,
+                  totalToProcess: totalOffers,
+                  span: offersProgressSpan,
+                },
+                progress,
+                textData: {
+                  title: t('contacts.refreshingOffers.title'),
+                  belowProgressLeft: t(
+                    'contacts.refreshingOffers.belowProgressLeft',
+                    {
+                      i: offerI + 1,
+                      total: totalOffers,
+                    }
+                  ),
+                  bottomText: t(
+                    'offerForm.offerEncryption.dontCloseTheAppCanTakeAWhile'
+                  ),
+                },
+              })
+            },
+            isInBackground: false,
+          }),
           Effect.zipLeft(
             set(updateAndReencryptAllNotesConnectionsActionAtom, {
               onProgres: ({noteI, totalNotes, progress}) => {
@@ -718,7 +714,6 @@ const syncNetworkAfterContactsImportActionAtom = atom(
           enabled: showContactImportProgressDialog,
           title: t('contacts.importProgress.titleUpdatingNetwork'),
         })
-        yield* _(set(syncConnectionsActionAtom))
         yield* _(
           set(updateAndReencryptAllOffersConnectionsActionAtom, {
             isInBackground: false,

--- a/apps/mobile/src/state/marketplace/atoms/updateOfferActionAtom.ts
+++ b/apps/mobile/src/state/marketplace/atoms/updateOfferActionAtom.ts
@@ -22,7 +22,6 @@ import {Array, Effect, pipe, Schema} from 'effect'
 import {atom} from 'jotai'
 import {apiAtom} from '../../../api'
 import {syncAllClubsHandleStateWhenNotFoundActionAtom} from '../../clubs/atom/refreshClubsActionAtom'
-import {syncConnectionsActionAtom} from '../../connections/atom/connectionStateAtom'
 import {updateAndReencryptSingleOfferConnectionActionAtom} from '../../connections/atom/offerToConnectionsAtom'
 import {sessionDataOrDummyAtom} from '../../session'
 import {reencryptSingleOfferMissingOnServerWhenEditingActionAtom} from './offersMissingOnServer'
@@ -136,8 +135,6 @@ export const updateOfferActionAtom = atom<
 
     if (params.updatePrivateParts) {
       yield* _(set(syncAllClubsHandleStateWhenNotFoundActionAtom))
-      yield* _(set(syncConnectionsActionAtom))
-
       yield* _(
         set(updateAndReencryptSingleOfferConnectionActionAtom, {
           adminId,

--- a/apps/mobile/src/utils/notifications/notificationReceivedHandler/handlers/newSocialNetworkConnection.ts
+++ b/apps/mobile/src/utils/notifications/notificationReceivedHandler/handlers/newSocialNetworkConnection.ts
@@ -2,7 +2,6 @@ import {type NewSocialNetworkConnectionNotificationData} from '@vexl-next/domain
 import {Effect} from 'effect/index'
 import {getDefaultStore} from 'jotai'
 import {apiAtom} from '../../../../api'
-import {syncConnectionsActionAtom} from '../../../../state/connections/atom/connectionStateAtom'
 import {updateAndReencryptAllNotesConnectionsActionAtom} from '../../../../state/connections/atom/noteToConnectionsAtom'
 import {updateAndReencryptAllOffersConnectionsActionAtom} from '../../../../state/connections/atom/offerToConnectionsAtom'
 import {reportNewConnectionNotificationForked} from '../../../../state/notifications/reportNewConnectionNotification'
@@ -20,7 +19,6 @@ export function handleNewSocialNetworkConnectionNotification(
       store.get(apiAtom).metrics,
       notificationData.trackingId
     )
-    yield* store.set(syncConnectionsActionAtom)
     yield* store.set(updateAndReencryptAllOffersConnectionsActionAtom, {
       isInBackground: true,
     })

--- a/apps/mobile/src/utils/notifications/useConsumeNotificationStream.ts
+++ b/apps/mobile/src/utils/notifications/useConsumeNotificationStream.ts
@@ -46,7 +46,6 @@ import {
   createSingleRemovedClubAtom,
   markRemovedClubAsNotifiedActionAtom,
 } from '../../state/clubs/atom/removedClubsAtom'
-import {syncConnectionsActionAtom} from '../../state/connections/atom/connectionStateAtom'
 import {updateAndReencryptAllNotesConnectionsActionAtom} from '../../state/connections/atom/noteToConnectionsAtom'
 import {updateAndReencryptAllOffersConnectionsActionAtom} from '../../state/connections/atom/offerToConnectionsAtom'
 import {getKeyHolderForNotificationTokenOrCypherActionAtom} from '../../state/notifications/fcmCypherToKeyHolderAtom'
@@ -155,7 +154,6 @@ const processNewUserNotificationActionAtom = atom(
           Option.some(message.trackingId)
         )
       )
-      yield* _(set(syncConnectionsActionAtom))
       yield* _(
         set(updateAndReencryptAllOffersConnectionsActionAtom, {
           isInBackground: false,

--- a/packages/resources-utils/src/offers/updatePrivateParts.test.ts
+++ b/packages/resources-utils/src/offers/updatePrivateParts.test.ts
@@ -1,0 +1,288 @@
+import {generatePrivateKey} from '@vexl-next/cryptography/src/KeyHolder'
+import {PublicKeyPemBase64} from '@vexl-next/cryptography/src/KeyHolder/brands'
+import {ClubUuid} from '@vexl-next/domain/src/general/clubs'
+import {NotFoundError} from '@vexl-next/domain/src/general/commonErrors'
+import {HashedPhoneNumber} from '@vexl-next/domain/src/general/HashedPhoneNumber.brand'
+import {
+  generateAdminId,
+  OfferPrivatePart,
+  SymmetricKey,
+} from '@vexl-next/domain/src/general/offers'
+import {UnixMilliseconds} from '@vexl-next/domain/src/utility/UnixMilliseconds.brand'
+import {type OfferApi} from '@vexl-next/rest-api/src/services/offer'
+import {Array, Effect, HashMap, Option, Schema} from 'effect'
+import reportErrorFromResourcesUtils from '../reportErrorFromResourcesUtils'
+import {eciesDecryptE} from '../utils/crypto'
+import updatePrivateParts from './updatePrivateParts'
+
+jest.mock('../reportErrorFromResourcesUtils')
+
+beforeEach(() => jest.mocked(reportErrorFromResourcesUtils).mockClear())
+afterEach(() => jest.restoreAllMocks())
+
+const recipient = generatePrivateKey()
+const publicKey = recipient.publicKeyPemBase64
+const otherRecipient = generatePrivateKey()
+const friend = Schema.decodeSync(HashedPhoneNumber)('common-friend')
+const newFriend = Schema.decodeSync(HashedPhoneNumber)('new-common-friend')
+const connections = {firstLevel: [], secondLevel: [publicKey], clubs: {}}
+
+function setup(): {
+  params: Parameters<typeof updatePrivateParts>[0]
+  createPrivatePart: jest.MockedFunction<OfferApi['createPrivatePart']>
+  deletePrivatePart: jest.MockedFunction<OfferApi['deletePrivatePart']>
+  readUploadedPayload: () => Promise<OfferPrivatePart>
+} {
+  const createPrivatePart = jest.fn<
+    ReturnType<OfferApi['createPrivatePart']>,
+    Parameters<OfferApi['createPrivatePart']>
+  >(() => Effect.succeed({}))
+  const deletePrivatePart = jest.fn<
+    ReturnType<OfferApi['deletePrivatePart']>,
+    Parameters<OfferApi['deletePrivatePart']>
+  >(() => Effect.succeed({}))
+  const unusedApiCall = (): Effect.Effect<never> =>
+    Effect.die('Unexpected API call')
+  const params: Parameters<typeof updatePrivateParts>[0] = {
+    api: {
+      createPrivatePart,
+      deletePrivatePart,
+      getOffersForMeModifiedOrCreatedAfterPaginated: unusedApiCall,
+      getClubOffersForMeModifiedOrCreatedAfterPaginated: unusedApiCall,
+      createNewOffer: unusedApiCall,
+      refreshOffer: unusedApiCall,
+      deleteOffer: unusedApiCall,
+      updateOffer: unusedApiCall,
+      getRemovedOffers: unusedApiCall,
+      getRemovedClubOffers: unusedApiCall,
+      reportOffer: unusedApiCall,
+      reportClubOffer: unusedApiCall,
+      getNotesForMeModifiedOrCreatedAfterPaginated: unusedApiCall,
+      createNewNote: unusedApiCall,
+      deleteNote: unusedApiCall,
+      createNotePrivatePart: unusedApiCall,
+      deleteNotePrivatePart: unusedApiCall,
+      createRepostNotePrivatePart: unusedApiCall,
+      repostNote: unusedApiCall,
+      undoRepostNote: unusedApiCall,
+      getRemovedNotes: unusedApiCall,
+      reportNote: unusedApiCall,
+      createChallenge: unusedApiCall,
+    },
+    adminId: generateAdminId(),
+    symmetricKey: Schema.decodeSync(SymmetricKey)('symmetric-key'),
+    currentConnections: connections,
+    targetConnections: connections,
+    commonFriends: HashMap.make([publicKey, [friend]]),
+    verifiedFriends: HashMap.empty(),
+  }
+  const readUploadedPayload = async (): Promise<OfferPrivatePart> => {
+    const request = createPrivatePart.mock.lastCall?.[0]
+    const part = request?.offerPrivateList[0]
+    expect(part?.userPublicKey).toBe(publicKey)
+    if (!part) throw new Error('Expected an uploaded private part')
+    return await Effect.runPromise(
+      eciesDecryptE(recipient.privateKeyPemBase64)(
+        part.payloadPrivate.slice(1)
+      ).pipe(
+        Effect.flatMap(Schema.decodeUnknown(Schema.parseJson(OfferPrivatePart)))
+      )
+    )
+  }
+  return {params, createPrivatePart, deletePrivatePart, readUploadedPayload}
+}
+
+it.each([
+  {level: 'firstLevel', background: false},
+  {level: 'secondLevel', background: false},
+  {level: 'firstLevel', background: true},
+  {level: 'secondLevel', background: true},
+])(
+  'refreshes only changed existing $level recipients (background: $background)',
+  async ({level, background}) => {
+    const {params, createPrivatePart, readUploadedPayload} = setup()
+    const targetConnections = {
+      firstLevel: level === 'firstLevel' ? [publicKey] : [],
+      secondLevel: level === 'secondLevel' ? [publicKey] : [],
+      clubs: {},
+    }
+    const updatedParams = {
+      ...params,
+      currentConnections: targetConnections,
+      targetConnections,
+      commonFriends: HashMap.make([publicKey, [friend, newFriend]]),
+      stopProcessingAfter: background
+        ? Schema.decodeSync(UnixMilliseconds)(Date.now() + 25_000)
+        : undefined,
+    }
+    await Effect.runPromise(updatePrivateParts(updatedParams))
+    expect(createPrivatePart).not.toHaveBeenCalled()
+    const updated = await Effect.runPromise(
+      updatePrivateParts({...updatedParams, connectionsToRefresh: [publicKey]})
+    )
+    expect(updated.updateSuccess).toBe(true)
+    expect(updated.newConnections).toEqual({
+      firstLevel: [],
+      secondLevel: [],
+      clubs: {},
+    })
+    expect(await readUploadedPayload()).toMatchObject({
+      commonFriends: [friend, newFriend],
+      friendLevel: [level === 'firstLevel' ? 'FIRST_DEGREE' : 'SECOND_DEGREE'],
+    })
+  }
+)
+
+it('includes new recipients and deduplicates changed recipients using their current level', async () => {
+  const {params, createPrivatePart, readUploadedPayload} = setup()
+  const newPublicKey = otherRecipient.publicKeyPemBase64
+  const result = await Effect.runPromise(
+    updatePrivateParts({
+      ...params,
+      connectionsToRefresh: [publicKey, publicKey],
+      targetConnections: {
+        firstLevel: [publicKey],
+        secondLevel: [publicKey, newPublicKey],
+        clubs: {},
+      },
+      commonFriends: HashMap.empty(),
+      verifiedFriends: HashMap.make([publicKey, [friend]]),
+    })
+  )
+  expect(result.newConnections.secondLevel).toEqual([newPublicKey])
+  expect(createPrivatePart.mock.lastCall?.[0].offerPrivateList).toHaveLength(2)
+  expect(await readUploadedPayload()).toMatchObject({
+    friendLevel: ['FIRST_DEGREE'],
+    commonFriends: [],
+    verifiedCommonFriends: [friend],
+  })
+})
+
+it('adds club identities alongside changed social recipients and skips unchanged clubs', async () => {
+  const {params, createPrivatePart} = setup()
+  const clubUuid = Schema.decodeUnknownSync(ClubUuid)(
+    '00000000-0000-4000-8000-000000000001'
+  )
+  const clubPublicKey = otherRecipient.publicKeyPemBase64
+  const targetConnections = {
+    ...connections,
+    clubs: {[clubUuid]: [clubPublicKey]},
+  }
+  const updatedParams = {
+    ...params,
+    currentConnections: connections,
+    targetConnections,
+  }
+  await Effect.runPromise(
+    updatePrivateParts({
+      ...updatedParams,
+      connectionsToRefresh: [publicKey],
+      stopProcessingAfter: Schema.decodeSync(UnixMilliseconds)(
+        Date.now() + 25_000
+      ),
+    })
+  )
+  const part = Array.findFirst(
+    createPrivatePart.mock.lastCall?.[0].offerPrivateList ?? [],
+    (part) => part.userPublicKey === clubPublicKey
+  ).pipe(Option.getOrUndefined)
+  if (!part) throw new Error('Expected uploaded club payload')
+  const payload = await Effect.runPromise(
+    eciesDecryptE(otherRecipient.privateKeyPemBase64)(
+      part.payloadPrivate.slice(1)
+    ).pipe(
+      Effect.flatMap(Schema.decodeUnknown(Schema.parseJson(OfferPrivatePart)))
+    )
+  )
+  expect(payload).toMatchObject({
+    commonFriends: [],
+    verifiedCommonFriends: [],
+    friendLevel: ['CLUB'],
+    clubIds: [clubUuid],
+  })
+  await Effect.runPromise(
+    updatePrivateParts({
+      ...updatedParams,
+      currentConnections: targetConnections,
+    })
+  )
+  expect(createPrivatePart).toHaveBeenCalledTimes(1)
+})
+
+it('preserves separate social and club removal counts and does not recreate removed recipients', async () => {
+  const {params, createPrivatePart, deletePrivatePart} = setup()
+  const info = jest.spyOn(console, 'info').mockImplementation(() => undefined)
+  const clubUuid = Schema.decodeUnknownSync(ClubUuid)(
+    '00000000-0000-4000-8000-000000000001'
+  )
+  const clubPublicKey = otherRecipient.publicKeyPemBase64
+  await Effect.runPromise(
+    updatePrivateParts({
+      ...params,
+      currentConnections: {
+        ...connections,
+        clubs: {[clubUuid]: [clubPublicKey]},
+      },
+      connectionsToRefresh: [clubPublicKey],
+    })
+  )
+  expect(createPrivatePart).not.toHaveBeenCalled()
+  expect(deletePrivatePart).toHaveBeenCalledWith({
+    adminIds: [params.adminId],
+    publicKeys: [clubPublicKey],
+  })
+  expect(info).toHaveBeenLastCalledWith(
+    expect.stringContaining(
+      'Number of removedConnections: 0. Number of removed clubs connections: 1.'
+    )
+  )
+  expect(reportErrorFromResourcesUtils).not.toHaveBeenCalled()
+})
+
+it('still reports existing recipients skipped by the background deadline', async () => {
+  const {params, createPrivatePart} = setup()
+  const result = await Effect.runPromise(
+    updatePrivateParts({
+      ...params,
+      connectionsToRefresh: [publicKey],
+      stopProcessingAfter: Schema.decodeSync(UnixMilliseconds)(Date.now() - 1),
+    })
+  )
+  expect(result.updateSuccess).toBe(false)
+  expect(createPrivatePart).not.toHaveBeenCalled()
+  expect(
+    Array.map(result.timeLimitReachedErrors, (error) => error.toPublicKey)
+  ).toEqual([publicKey])
+})
+
+it('does not report a completed refresh when an existing recipient upload fails', async () => {
+  const {params, createPrivatePart} = setup()
+  createPrivatePart.mockReturnValue(Effect.fail(new NotFoundError()))
+  const result = await Effect.runPromise(
+    updatePrivateParts({...params, connectionsToRefresh: [publicKey]})
+  )
+  expect(result.updateSuccess).toBe(false)
+  expect(result.encryptionErrors).toEqual([])
+})
+
+it('reports a completed refresh when a recipient cannot be encrypted for', async () => {
+  const {params, createPrivatePart} = setup()
+  const brokenKey = Schema.decodeSync(PublicKeyPemBase64)('not-a-key')
+  const result = await Effect.runPromise(
+    updatePrivateParts({
+      ...params,
+      currentConnections: {firstLevel: [], secondLevel: [], clubs: {}},
+      targetConnections: {
+        firstLevel: [publicKey, brokenKey],
+        secondLevel: [],
+        clubs: {},
+      },
+    })
+  )
+  expect(result.updateSuccess).toBe(true)
+  expect(
+    Array.map(result.encryptionErrors, (error) => error.toPublicKey)
+  ).toEqual([brokenKey])
+  expect(result.newConnections.firstLevel).toEqual([publicKey])
+  expect(createPrivatePart).toHaveBeenCalledTimes(1)
+})

--- a/packages/resources-utils/src/offers/updatePrivateParts.ts
+++ b/packages/resources-utils/src/offers/updatePrivateParts.ts
@@ -187,6 +187,7 @@ function uploadPrivatePartsBatch({
 export default function updatePrivateParts({
   currentConnections,
   targetConnections,
+  connectionsToRefresh = [],
   commonFriends,
   verifiedFriends,
   adminId,
@@ -211,6 +212,7 @@ export default function updatePrivateParts({
       ReadonlyArray<PublicKeyPemBase64 | PublicKeyV2>
     >
   }
+  connectionsToRefresh?: ReadonlyArray<PublicKeyPemBase64 | PublicKeyV2>
   commonFriends: CommonConnectionsForUsers
   verifiedFriends: CommonConnectionsForUsers
   adminId: OfferAdminId
@@ -220,6 +222,7 @@ export default function updatePrivateParts({
   onProgress?: (status: OfferEncryptionProgress) => void
 }): Effect.Effect<
   {
+    updateSuccess: boolean
     encryptionErrors: PrivatePartEncryptionError[]
     timeLimitReachedErrors: TimeLimitReachedError[]
     removedConnections: Array<PublicKeyPemBase64 | PublicKeyV2>
@@ -310,14 +313,29 @@ export default function updatePrivateParts({
 
     if (onProgress) onProgress({type: 'CONSTRUCTING_PRIVATE_PAYLOADS'})
 
+    const publicKeysToUpdate = new Set([
+      ...newFirstLevelConnections,
+      ...(newSecondLevelConnections ?? []),
+      ...pipe(newClubsConnections, Record.values, Array.flatten),
+      ...connectionsToRefresh,
+    ])
     const privatePayloads = yield* _(
       constructPrivatePayloads({
         connectionsInfo: {
-          firstDegreeConnections: newFirstLevelConnections,
-          secondDegreeConnections: newSecondLevelConnections ?? [],
+          firstDegreeConnections: Array.filter(
+            targetConnections.firstLevel,
+            (key) => publicKeysToUpdate.has(key)
+          ),
+          secondDegreeConnections: Array.filter(
+            targetConnections.secondLevel,
+            (key) => publicKeysToUpdate.has(key)
+          ),
           commonFriends,
           verifiedFriends,
-          clubsConnections: newClubsConnections,
+          clubsConnections: Record.map(
+            targetConnections.clubs,
+            Array.filter((key) => publicKeysToUpdate.has(key))
+          ),
         },
         symmetricKey,
       })
@@ -404,6 +422,9 @@ export default function updatePrivateParts({
     ].map((one) => one.toPublicKey)
 
     return {
+      updateSuccess:
+        !Array.isNonEmptyArray(encryptionResult.timeLimitReachedErrors) &&
+        !Array.isNonEmptyArray(uploadErrors),
       encryptionErrors: encryptionResult.encryptionErrors,
       timeLimitReachedErrors: encryptionResult.timeLimitReachedErrors,
       removedConnections: deduplicate(removedConnections),


### PR DESCRIPTION
Closes #2550

## Problem

An offer's private part for a recipient is encrypted once, when that recipient first becomes a connection. It carries the common friends and connection level at that moment and is never touched again, so recipients see stale common friends as soon as either side's contacts change.

## What it does

The offer refresh now fetches the social graph itself, diffs it against the stored one, and re-uploads private parts for the recipients whose common friends, verified friends, or connection level changed. New and removed recipients are handled as before. The server replaces the old private parts, so recipients see the current common friends after the next refresh round.

`updatePrivateParts` gains a `connectionsToRefresh` input for those recipients and returns `updateSuccess`, which is false when the background deadline skipped recipients or an upload batch failed. Recipient keys that cannot be encrypted for are reported as before but do not count as a failed round.

## Design notes

- The fetched graph is stored only once every offer reports `updateSuccess`. A round cut short by the 25 second background budget keeps the old graph, so the next round computes the same diff and re-uploads it. This avoids any bookkeeping of what reached the server.
- Callers that previously ran the connections sync before the offer refresh drop that step. Storing the fresh graph first would make the diff empty and skip the re-encryption. The app-loading task runs the import-needed check after the refresh so it still sees the fresh graph.
- The manual offer edit fetches the graph for its own upload but does not store it, leaving the other offers' diff intact for the next round.
- If the fetch fails, the refresh falls back to the stored graph with nothing to re-encrypt, matching the previous behaviour when the sync failed.

## Risks

- After a partial round, if a recipient's data changes and then reverts before the next successful round, the offers uploaded in the partial round keep the intermediate common friends until that recipient changes again. Judged acceptable given the rarity and that the list was never refreshed before.
- Background rounds with very large networks may need several attempts before a diff-heavy round completes and the graph is stored. Each attempt re-uploads the same diff.
