### PR TITLE
feat: publish releases to Zapstore using the Nostr key

### DIFF
--- a/.github/workflows/release-zapstore.yaml
+++ b/.github/workflows/release-zapstore.yaml
@@ -1,0 +1,44 @@
+name: "[Release] Zapstore"
+run-name: "Publish latest GitHub release to Zapstore"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-zapstore
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish latest production APK
+    if: github.repository == 'vexl-it/vexl'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Zapstore publisher
+        working-directory: ${{ runner.temp }}
+        run: |
+          curl --fail --location --silent --show-error --retry 3 \
+            https://github.com/zapstore/zsp/releases/download/v0.4.17/zsp-0.4.17-linux-amd64 \
+            --output zsp
+          echo '3f241da6a5dc7a85fe851d3b42b77790b651bd36c7029382a701262bda832d20  zsp' | sha256sum --check
+          chmod +x zsp
+
+      - name: Sign and publish to Zapstore
+        working-directory: apps/mobile
+        env:
+          SIGN_WITH: ${{ secrets.NSEC }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          if [ -z "$SIGN_WITH" ]; then
+            echo '::error::The NSEC repository secret is required to sign Zapstore releases.'
+            exit 1
+          fi
+          "$RUNNER_TEMP/zsp" publish --quiet zapstore.yaml

--- a/.github/workflows/release-zapstore.yaml
+++ b/.github/workflows/release-zapstore.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   publish:
     name: Publish latest production APK
-    if: github.repository == 'vexl-it/vexl'
+    if: github.repository == 'vexl-it/vexl' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:

--- a/apps/mobile/zapstore.yaml
+++ b/apps/mobile/zapstore.yaml
@@ -2,9 +2,11 @@ name: Vexl
 repository: https://github.com/vexl-it/vexl
 icon: assets/icon.png
 license: GPL-3.0
-remote_metadata:
+metadata_sources:
   - github
-tags: social_network
+match: '^vexl-production-.*\.apk$'
+tags:
+  - social_network
 summary: 'Vexl is a mobile app giving its users a simple, accessible and safe way to trade bitcoin as it was intended - peer-to-peer and without KYC.'
 description: |
   Vexl is a private, trust-based Bitcoin trading app that lets you buy and sell directly with people in your social network — no KYC, no middlemen, no public ratings. Built with end-to-end encryption and a privacy-first design, Vexl protects your data while empowering you to trade Bitcoin securely through real connections.

--- a/docs/zapstore.md
+++ b/docs/zapstore.md
@@ -1,7 +1,8 @@
 # Publishing to Zapstore
 
-Run **[Release] Zapstore** from GitHub Actions to publish the latest stable GitHub
-release containing a production APK. The publisher selects assets matching
+Run **[Release] Zapstore** from the `main` branch in GitHub Actions to publish the
+latest stable GitHub release containing a production APK. Dispatches from other
+branches or tags skip the publishing job. The publisher selects assets matching
 `vexl-production-*.apk` and uses the metadata in `apps/mobile/zapstore.yaml`.
 Drafts and prereleases are excluded.
 

--- a/docs/zapstore.md
+++ b/docs/zapstore.md
@@ -1,0 +1,22 @@
+# Publishing to Zapstore
+
+Run **[Release] Zapstore** from GitHub Actions to publish the latest stable GitHub
+release containing a production APK. The publisher selects assets matching
+`vexl-production-*.apk` and uses the metadata in `apps/mobile/zapstore.yaml`.
+Drafts and prereleases are excluded.
+
+The workflow signs the Zapstore events with the Nostr private key in the `NSEC`
+repository secret. Use an `nsec1...` or 64-character hex private key belonging to
+Vexl's Zapstore publisher identity. This signs the listing and release events;
+the APK keeps its existing Android signature.
+
+The workflow runs manually, serializes publishes, and requires only read access
+to GitHub contents. Uploads and signed events go to Zapstore's default CDN and
+relay. The pinned `zsp` binary is checked against its SHA-256 digest before use.
+
+To check release discovery and APK parsing locally without publishing, install
+[zsp](https://github.com/zapstore/zsp) and run:
+
+```sh
+zsp publish --check apps/mobile/zapstore.yaml
+```


### PR DESCRIPTION
Add a manually triggered `[Release] Zapstore` workflow so maintainers can publish the latest stable GitHub release with a production APK using the existing `NSEC` repository secret. The Nostr key signs the Zapstore events; the APK keeps its existing Android signature.

The workflow uses a pinned, SHA-256-verified `zsp` binary, read-only GitHub permissions, and serialized publishing. Update the existing Zapstore config to the current publisher format and select only `vexl-production-*.apk` assets. Usage is documented in `docs/zapstore.md`.

Validation:
- `pnpm turbo:typecheck --filter=@vexl-next/mobile-app`
- `pnpm turbo:format`
- `pnpm turbo:lint` passed with existing deprecation warnings in unchanged code.
- Actionlint and Prettier on the changed workflow, config, and documentation.
- `zsp publish --check` downloaded the current production release and confirmed `it.vexl.next`.
- Offline signing of that APK with a temporary key produced application, release, and asset events. All event hashes and BIP-340 signatures verified.
- Verified the publisher binary checksum and the missing-secret failure path.

No live Zapstore publication was performed. After merging, run `[Release] Zapstore` from GitHub Actions to publish using `NSEC`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a manually triggered workflow to publish the latest production Android APK to Zapstore.
  - APK releases now use GitHub-based metadata and consistently match production APK assets.
  - Added checks to verify publishing tools and require signing credentials before publishing.

- **Documentation**
  - Added guidance for publishing releases to Zapstore, including release selection, metadata usage, signing requirements, and local validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->