### PR TITLE
fix: require publishing environment approval for Zapstore

### DIFF
--- a/.github/workflows/release-zapstore.yaml
+++ b/.github/workflows/release-zapstore.yaml
@@ -15,6 +15,7 @@ jobs:
   publish:
     name: Publish latest production APK
     if: github.repository == 'vexl-it/vexl' && github.ref == 'refs/heads/main'
+    environment: zapstore-publishing
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
@@ -38,7 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           if [ -z "$SIGN_WITH" ]; then
-            echo '::error::The NSEC repository secret is required to sign Zapstore releases.'
+            echo '::error::The NSEC secret in the zapstore-publishing environment is required to sign Zapstore releases.'
             exit 1
           fi
           "$RUNNER_TEMP/zsp" publish --quiet zapstore.yaml

--- a/docs/zapstore.md
+++ b/docs/zapstore.md
@@ -6,10 +6,16 @@ branches or tags skip the publishing job. The publisher selects assets matching
 `vexl-production-*.apk` and uses the metadata in `apps/mobile/zapstore.yaml`.
 Drafts and prereleases are excluded.
 
-The workflow signs the Zapstore events with the Nostr private key in the `NSEC`
-repository secret. Use an `nsec1...` or 64-character hex private key belonging to
+The publishing job uses the `zapstore-publishing` environment and waits for its
+required approval before accessing the `NSEC` environment secret. Use an
+`nsec1...` or 64-character hex private key belonging to
 Vexl's Zapstore publisher identity. This signs the listing and release events;
 the APK keeps its existing Android signature.
+
+Configure the environment to allow only the `main` branch, require a publishing
+reviewer, prevent self-review, and disable administrator bypass. Store `NSEC`
+only in this environment; remove any repository-level copy so another workflow
+cannot access it without these protections.
 
 The workflow runs manually, serializes publishes, and requires only read access
 to GitHub contents. Uploads and signed events go to Zapstore's default CDN and


### PR DESCRIPTION
The Zapstore publishing job currently reads `NSEC` without referencing a protected environment. Bind it to `zapstore-publishing` so GitHub applies the environment's branch policy and approval rules before starting the job and exposing its secret.

Keep the existing main-only restriction. Update the missing-secret error and publishing documentation to name the environment and explain the required protection settings.

Validation: actionlint, Prettier, mobile typecheck, repository formatting, and repository lint passed. Lint reports existing deprecation warnings. Checked the environment binding, main/branch/tag/fork conditions, signing-secret reference, and missing-secret failure path. No live publication performed.

The environment exists with `NSEC`, a `main` branch policy, and required reviewers. An administrator still needs to delete the repository-level `NSEC`, enable Prevent self-review, and disable administrator bypass to complete the intended protection.
